### PR TITLE
feat: enable state init and auto-start-session via the query string

### DIFF
--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -21,7 +21,7 @@ export default class Session extends Component {
 
   componentDidMount () {
     const {setLocalServerParams, getSavedSessions, setSavedServerParams, setVisibleProviders,
-           getRunningSessions, bindWindowClose} = this.props;
+           getRunningSessions, bindWindowClose, initFromQueryString} = this.props;
     (async () => {
       try {
         bindWindowClose();
@@ -30,6 +30,7 @@ export default class Session extends Component {
         await setLocalServerParams();
         await setVisibleProviders();
         getRunningSessions();
+        await initFromQueryString();
       } catch (e) {
         console.error(e); // eslint-disable-line no-console
       }

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -10,7 +10,7 @@ import { NEW_SESSION_REQUESTED, NEW_SESSION_BEGAN, NEW_SESSION_DONE,
          CHANGE_SERVER_TYPE, SET_SERVER_PARAM, SET_SERVER, SET_ATTACH_SESS_ID,
          GET_SESSIONS_REQUESTED, GET_SESSIONS_DONE,
          ENABLE_DESIRED_CAPS_EDITOR, ABORT_DESIRED_CAPS_EDITOR, SAVE_RAW_DESIRED_CAPS, SET_RAW_DESIRED_CAPS, SHOW_DESIRED_CAPS_JSON_ERROR,
-         IS_ADDING_CLOUD_PROVIDER, SET_PROVIDERS, SET_ADD_VENDOR_PREFIXES,
+         IS_ADDING_CLOUD_PROVIDER, SET_PROVIDERS, SET_ADD_VENDOR_PREFIXES, SET_STATE_FROM_URL,
          ServerTypes } from '../actions/Session';
 
 const visibleProviders = []; // Pull this from "electron-settings"
@@ -326,6 +326,16 @@ export default function session (state = INITIAL_STATE, action) {
       return {
         ...state,
         addVendorPrefixes: action.addVendorPrefixes,
+      };
+
+    case SET_STATE_FROM_URL:
+      return {
+        ...state,
+        server: {
+          ...state.server,
+          ...(action.state.server || {})
+        },
+        ...omit(action.state, ['server']),
       };
 
     default:

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -50,7 +50,7 @@ describe('inspector window', function () {
   });
 
   beforeEach(async function () {
-    await client.waitForExist(inspector.inspectorToolbar);
+    await client.waitForExist(inspector.inspectorToolbar, {timeout: 7000});
   });
 
   it('shows content in "Selected Element" pane when clicking on an item in the Source inspector', async function () {


### PR DESCRIPTION
This will enable us to automatically set state for ADI via a deep link or a regular URL (in browser mode)