### PR TITLE
ci: have electron-builder include node modules, but remove dev deps before packaging

### DIFF
--- a/ci-jobs/package.yml
+++ b/ci-jobs/package.yml
@@ -15,7 +15,7 @@ jobs:
     pool:
       vmImage: 'windows-2019'
     name: 'windows_package'
-    buildScript: 'npx electron-builder build -w --ia32 --x64 --publish always'
+    buildScript: 'electron-builder build -w --ia32 --x64 --publish always'
 - template: templates/package.yml
   parameters:
     pool:

--- a/ci-jobs/templates/package.yml
+++ b/ci-jobs/templates/package.yml
@@ -7,7 +7,7 @@ parameters:
   pool: ''
   xvfb: false
   target: ''
-  buildScript: 'npx electron-builder build --publish always'
+  buildScript: 'electron-builder build --publish always'
 jobs:
   - job: ${{parameters.name}}
     pool: ${{parameters.pool}}
@@ -25,14 +25,18 @@ jobs:
     - task: NodeTool@0
       inputs:
         versionSpec: '14.x'
-    - script: npm ci
+    - script: npm install
       displayName: Install dependencies
+    - script: npm install -g electron-builder@22.13.0
+      displayName: Install electron builder globally
     - script: |
         git clone https://github.com/appium/appium-desktop.git
         npm run copy-en-i18n ./appium-desktop
       displayName: Copy EN translations from server
     - script: npm run build
       displayName: Build
+    - script: npm install --production
+      displayName: Remove dev dependencies
     - script: ${{ parameters.buildScript }}
       displayName: Bundle
       env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "appium-inspector",
-  "version": "2021.8.1",
+  "version": "2021.8.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2021.8.1",
+      "version": "2021.8.4",
       "license": "Apache-2.0",
       "dependencies": {
         "antd": "^4.16.7",
@@ -66,7 +66,7 @@
         "cross-env": "^7.0.0",
         "devtron": "^1.4.0",
         "electron": "^13.1.8",
-        "electron-builder": "^22.11.11",
+        "electron-builder": "^22.13.0",
         "electron-devtools-installer": "^3.0.0",
         "eslint-config-appium": "^4.5.0",
         "eslint-plugin-import": "^2.24.2",
@@ -3328,9 +3328,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.17.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.11.tgz",
-      "integrity": "sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w=="
+      "version": "14.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
+      "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -3554,9 +3554,9 @@
       }
     },
     "node_modules/@wdio/protocols": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.10.1.tgz",
-      "integrity": "sha512-qfa1IfHWnUZt51km9jj2Ckg/GJQanJft/YnEg56LfpaQEXmcr6QE4pGp4MhFYspRqoIkQVhOhIYsgsJXqReN7g==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.11.0.tgz",
+      "integrity": "sha512-yWKmCUmbHB1AH0U3lebXRh/G3+JtsD9Tx9fevgP9qA7Hq+rHj7KqUf15k1lPPodhOms8ncPj0J6ET1E13wh2qg==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3846,9 +3846,9 @@
       }
     },
     "node_modules/@wdio/utils": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.10.1.tgz",
-      "integrity": "sha512-Pou5CX/uw8VbXU0HP4InS3Aquy5KI6xi3RKW7JLlPuorjrfmKy0QtBBMpRPZyjt6YqL9F8TgDzYW5QzaQo6yyw==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.11.0.tgz",
+      "integrity": "sha512-0n5mZha2QktV0181nMhw+IQ8MgYrqyvVDjP20P7JEnl6hehSkyXTAYQcYuKaw5AAVqipV3Eh96JBi5CnhpsoKQ==",
       "dependencies": {
         "@wdio/logger": "7.7.0",
         "@wdio/types": "7.10.1",
@@ -4174,9 +4174,9 @@
       "dev": true
     },
     "node_modules/app-builder-lib": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.12.1.tgz",
-      "integrity": "sha512-lE//wq64cp8zA/oDQKsmgtoJOmjNMebPeUBYai7yGAqwhR7P9ggYDwWCUd2sL+T6f1YJFCQ2GrLwf1qkm7xHMQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.13.0.tgz",
+      "integrity": "sha512-7W0EuvVx8r0ZNJTtBnnYELPFFBElBIp6bRFn43wN/OCZPJ/T/hDbYo7WoMSAX+oAr9AAprU+v5OeuhD+xR6pdA==",
       "dev": true,
       "dependencies": {
         "@develar/schema-utils": "~2.6.5",
@@ -4185,13 +4185,13 @@
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
         "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.12.1",
+        "electron-publish": "22.13.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
         "is-ci": "^3.0.0",
@@ -4900,9 +4900,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axe-core": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.2.tgz",
-      "integrity": "sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
+      "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -5837,9 +5837,9 @@
       "dev": true
     },
     "node_modules/builder-util": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.12.1.tgz",
-      "integrity": "sha512-w0XF84saZZ8GLXy75tL1UzKEVCRHTIi/0NYV5WDqAUXLQWYWZr1m0TfsMXwD2+3TfzCAcavctzcpprm8Iw3gcQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.13.0.tgz",
+      "integrity": "sha512-yT2seIwK+pgKslgsMcZWLYuV6I1FAdMiSR4KPvaBPX+ZqkWEMIeHHjVx8TYwNCvTGhZQ59XIwTneuZyJA0PFow==",
       "dev": true,
       "dependencies": {
         "@types/debug": "^4.1.6",
@@ -5847,7 +5847,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "3.7.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.7.10",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
@@ -5860,9 +5860,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.7.10",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.10.tgz",
-      "integrity": "sha512-zelTRebsOsj33pF+Jf/qwpvx9W6CeMQshqaRa70Ii6+NQGsspMXqlKDQb+1lvTv9aWARxa3+jy/syzm8jTE8Kw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.0.tgz",
+      "integrity": "sha512-XMxCbIOuqZTalJ8Og0HzD6FpQ+MzmDnjM4yS5pVBGXCan0lMHdN84NThMErf4YBh1UknIVf7IYW2mZJVQfxYOQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.3.2",
@@ -6177,9 +6177,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -7168,12 +7168,12 @@
       "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
-      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.3.tgz",
+      "integrity": "sha512-A/OtSfSJQKLAFRVd4V0m6Sep9lPdjD8bpN8v3tCCGwE0Tmh0hOiVDm9tw6mXmWOKOSZIyr3EkywPo84cJjGvIQ==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.16.7",
+        "browserslist": "^4.16.8",
         "semver": "7.0.0"
       },
       "funding": {
@@ -7191,9 +7191,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
-      "integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.3.tgz",
+      "integrity": "sha512-6In+2RwN0FT5yK0ZnhDP5rco/NnuuFZhHauQizZiHo5lDnqAvq8Phxcpy3f+prJOqtKodt/cftBl/GTOW0kiqQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -7933,9 +7933,9 @@
       "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "node_modules/deasync": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.22.tgz",
-      "integrity": "sha512-o21R8Vhv3wX0E19jpATUJIAinQ1I2rHIlAnzRRsMynWlIrvU0HbCwjpquPIYR544Tvg9z/L+NZQev5cjVD1/nQ==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.23.tgz",
+      "integrity": "sha512-CGZSokFwidI50GOAmkz/7z3QdMzTQqAiUOzt95PuhKgi6VVztn9D03ZCzzi93uUWlp/v6A9osvNWpIvqHvKjTA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -8412,14 +8412,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.12.1.tgz",
-      "integrity": "sha512-keh9hGtqZ6weOyFg7wd8VYS7U5oYKFzeOEDoEc5ciiaLHfYKqFbJskvCOM2+aA7One92hZMwaIhMNoEug+jsbw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.13.0.tgz",
+      "integrity": "sha512-SqvXs10EsthwoqQEr0ae8fbvTywc0GNScY5XL2Nw1eHLLvjy8qaM4aC5ekOj422rqiBBGSrg1YgyUEmHzX6xqg==",
       "dev": true,
       "dependencies": {
-        "app-builder-lib": "22.12.1",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "app-builder-lib": "22.13.0",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
@@ -8730,17 +8730,17 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.12.1.tgz",
-      "integrity": "sha512-WttcOgfO5uy9OgKAWE3Yy2oiz39bTNXaKC3dKrwtKq0MaZL8DDvNGRNkFiZutOIF4wAUfwyG7Pm0KbI8Hl44Gw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.13.0.tgz",
+      "integrity": "sha512-OCk7ZIk/nmxWe58F3hD49BW7V4T3l98IvDsLIWBYEmlT/HYAoxI69rv0M+7EXIKwe064ZAN5Z96e7wqMJECwmg==",
       "dev": true,
       "dependencies": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.12.1",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "app-builder-lib": "22.13.0",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.12.1",
+        "dmg-builder": "22.13.0",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -9059,14 +9059,14 @@
       "dev": true
     },
     "node_modules/electron-publish": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.12.1.tgz",
-      "integrity": "sha512-863+dgShqdmfelCfteR2xkkHch9bPtmIdD1IDLPzL3+43HdEz0oGvRnRJTBKzLrI94D3CNOM4OoPUj3L2JMLqw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.13.0.tgz",
+      "integrity": "sha512-ekBCgbzwKweQxFyvQqxNGZH2va1ZPNeCJRQowt7KV0McR161C+8XRa654DARIpjJ9jE+v+Ne1ImKzND1XCZ2PA==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -9195,9 +9195,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.815",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.815.tgz",
-      "integrity": "sha512-2QaE8L5l3BDf82ZXcm0TpWOPoCVUwrp3lKiYzgUbdhRAO2sW60ZdKS5T8yq4r7y1ZeiKJXnf5u8n9u3ldnj5Bw==",
+      "version": "1.3.819",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.819.tgz",
+      "integrity": "sha512-vH3jJLd+tMwrQcYlZJUSjUMlq2JacHuIKl4rT0ZEAdY1Lxk95dBg+rc69ahIPGdKPPWgaN4wjt2f0BopFF3wjQ==",
       "dev": true
     },
     "node_modules/electron-updater": {
@@ -11605,9 +11605,9 @@
       }
     },
     "node_modules/global-agent/node_modules/core-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-      "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+      "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
       "hasInstallScript": true,
       "optional": true,
       "funding": {
@@ -12223,9 +12223,9 @@
       }
     },
     "node_modules/htmlnano/node_modules/terser": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-      "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
+      "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
       "dev": true,
       "dependencies": {
         "commander": "^2.20.0",
@@ -15259,9 +15259,9 @@
       }
     },
     "node_modules/needle": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
-      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.0.tgz",
+      "integrity": "sha512-UBLC4P8w9to3rAhWOQYXIXzTUio9yVnDzIeKxfGbF+Hngy+2bXTqqFK+6nF42EAQKfJdezXK6vzMsefUa1Y3ag==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -23039,16 +23039,16 @@
       }
     },
     "node_modules/webdriver": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.10.1.tgz",
-      "integrity": "sha512-vDDTGrigGh4oMPMH3ERGP8G941K142K+sAgzKIx6Hc2u7PuTjToD/3W0jjH6DQ8B1wgKoQkFk/sf6XQ3TBd09A==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.11.0.tgz",
+      "integrity": "sha512-Sd4n3Hxz/6WDa4Ay8cJj/ICDbf2ndlAzd7NMj+dmhfDsDF7L77eCZYB8zrrxs2hoK63E54eyKzyycK3BB3WoYQ==",
       "dependencies": {
         "@types/node": "^15.12.5",
         "@wdio/config": "7.10.1",
         "@wdio/logger": "7.7.0",
-        "@wdio/protocols": "7.10.1",
+        "@wdio/protocols": "7.11.0",
         "@wdio/types": "7.10.1",
-        "@wdio/utils": "7.10.1",
+        "@wdio/utils": "7.11.0",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
@@ -26555,9 +26555,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.11.tgz",
-      "integrity": "sha512-n2OQ+0Bz6WEsUjrvcHD1xZ8K+Kgo4cn9/w94s1bJS690QMUWfJPW/m7CCb7gPkA1fcYwL2UpjXP/rq/Eo41m6w=="
+      "version": "14.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
+      "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -26756,9 +26756,9 @@
       }
     },
     "@wdio/protocols": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.10.1.tgz",
-      "integrity": "sha512-qfa1IfHWnUZt51km9jj2Ckg/GJQanJft/YnEg56LfpaQEXmcr6QE4pGp4MhFYspRqoIkQVhOhIYsgsJXqReN7g=="
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/protocols/-/protocols-7.11.0.tgz",
+      "integrity": "sha512-yWKmCUmbHB1AH0U3lebXRh/G3+JtsD9Tx9fevgP9qA7Hq+rHj7KqUf15k1lPPodhOms8ncPj0J6ET1E13wh2qg=="
     },
     "@wdio/repl": {
       "version": "6.11.0",
@@ -26965,9 +26965,9 @@
       }
     },
     "@wdio/utils": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.10.1.tgz",
-      "integrity": "sha512-Pou5CX/uw8VbXU0HP4InS3Aquy5KI6xi3RKW7JLlPuorjrfmKy0QtBBMpRPZyjt6YqL9F8TgDzYW5QzaQo6yyw==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/@wdio/utils/-/utils-7.11.0.tgz",
+      "integrity": "sha512-0n5mZha2QktV0181nMhw+IQ8MgYrqyvVDjP20P7JEnl6hehSkyXTAYQcYuKaw5AAVqipV3Eh96JBi5CnhpsoKQ==",
       "requires": {
         "@wdio/logger": "7.7.0",
         "@wdio/types": "7.10.1",
@@ -27227,9 +27227,9 @@
       "dev": true
     },
     "app-builder-lib": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.12.1.tgz",
-      "integrity": "sha512-lE//wq64cp8zA/oDQKsmgtoJOmjNMebPeUBYai7yGAqwhR7P9ggYDwWCUd2sL+T6f1YJFCQ2GrLwf1qkm7xHMQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-22.13.0.tgz",
+      "integrity": "sha512-7W0EuvVx8r0ZNJTtBnnYELPFFBElBIp6bRFn43wN/OCZPJ/T/hDbYo7WoMSAX+oAr9AAprU+v5OeuhD+xR6pdA==",
       "dev": true,
       "requires": {
         "@develar/schema-utils": "~2.6.5",
@@ -27238,13 +27238,13 @@
         "7zip-bin": "~5.1.1",
         "async-exit-hook": "^2.0.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chromium-pickle-js": "^0.2.0",
         "debug": "^4.3.2",
         "ejs": "^3.1.6",
         "electron-osx-sign": "^0.5.0",
-        "electron-publish": "22.12.1",
+        "electron-publish": "22.13.0",
         "fs-extra": "^10.0.0",
         "hosted-git-info": "^4.0.2",
         "is-ci": "^3.0.0",
@@ -27846,9 +27846,9 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axe-core": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.2.tgz",
-      "integrity": "sha512-5LMaDRWm8ZFPAEdzTYmgjjEdj1YnQcpfrVajO/sn/LhbpGp0Y0H64c2hLZI1gRMxfA+w1S71Uc/nHaOXgcCvGg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.3.3.tgz",
+      "integrity": "sha512-/lqqLAmuIPi79WYfRpy2i8z+x+vxU3zX2uAm0gs1q52qTuKwolOj1P8XbufpXcsydrpKx2yGn2wzAnxCMV86QA==",
       "dev": true
     },
     "axios": {
@@ -28629,9 +28629,9 @@
       "dev": true
     },
     "builder-util": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.12.1.tgz",
-      "integrity": "sha512-w0XF84saZZ8GLXy75tL1UzKEVCRHTIi/0NYV5WDqAUXLQWYWZr1m0TfsMXwD2+3TfzCAcavctzcpprm8Iw3gcQ==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-22.13.0.tgz",
+      "integrity": "sha512-yT2seIwK+pgKslgsMcZWLYuV6I1FAdMiSR4KPvaBPX+ZqkWEMIeHHjVx8TYwNCvTGhZQ59XIwTneuZyJA0PFow==",
       "dev": true,
       "requires": {
         "@types/debug": "^4.1.6",
@@ -28639,7 +28639,7 @@
         "7zip-bin": "~5.1.1",
         "app-builder-bin": "3.7.1",
         "bluebird-lst": "^1.0.9",
-        "builder-util-runtime": "8.7.10",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.2",
@@ -28756,9 +28756,9 @@
       }
     },
     "builder-util-runtime": {
-      "version": "8.7.10",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.10.tgz",
-      "integrity": "sha512-zelTRebsOsj33pF+Jf/qwpvx9W6CeMQshqaRa70Ii6+NQGsspMXqlKDQb+1lvTv9aWARxa3+jy/syzm8jTE8Kw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.0.tgz",
+      "integrity": "sha512-XMxCbIOuqZTalJ8Og0HzD6FpQ+MzmDnjM4yS5pVBGXCan0lMHdN84NThMErf4YBh1UknIVf7IYW2mZJVQfxYOQ==",
       "dev": true,
       "requires": {
         "debug": "^4.3.2",
@@ -28895,9 +28895,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001252",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001252.tgz",
+      "integrity": "sha512-I56jhWDGMtdILQORdusxBOH+Nl/KgQSdDmpJezYddnAkVOmnoU8zwjTV9xAjMIYxr0iPreEAVylCGcmHCjfaOw==",
       "dev": true
     },
     "capitalize": {
@@ -29715,12 +29715,12 @@
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.2.tgz",
-      "integrity": "sha512-4lUshXtBXsdmp8cDWh6KKiHUg40AjiuPD3bOWkNVsr1xkAhpUqCjaZ8lB1bKx9Gb5fXcbRbFJ4f4qpRIRTuJqQ==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.16.3.tgz",
+      "integrity": "sha512-A/OtSfSJQKLAFRVd4V0m6Sep9lPdjD8bpN8v3tCCGwE0Tmh0hOiVDm9tw6mXmWOKOSZIyr3EkywPo84cJjGvIQ==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.7",
+        "browserslist": "^4.16.8",
         "semver": "7.0.0"
       },
       "dependencies": {
@@ -29733,9 +29733,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.2.tgz",
-      "integrity": "sha512-oxKe64UH049mJqrKkynWp6Vu0Rlm/BTXO/bJZuN2mmR3RtOFNepLlSWDd1eo16PzHpQAoNG97rLU1V/YxesJjw==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.16.3.tgz",
+      "integrity": "sha512-6In+2RwN0FT5yK0ZnhDP5rco/NnuuFZhHauQizZiHo5lDnqAvq8Phxcpy3f+prJOqtKodt/cftBl/GTOW0kiqQ==",
       "dev": true
     },
     "core-util-is": {
@@ -30337,9 +30337,9 @@
       "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "deasync": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.22.tgz",
-      "integrity": "sha512-o21R8Vhv3wX0E19jpATUJIAinQ1I2rHIlAnzRRsMynWlIrvU0HbCwjpquPIYR544Tvg9z/L+NZQev5cjVD1/nQ==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.23.tgz",
+      "integrity": "sha512-CGZSokFwidI50GOAmkz/7z3QdMzTQqAiUOzt95PuhKgi6VVztn9D03ZCzzi93uUWlp/v6A9osvNWpIvqHvKjTA==",
       "dev": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -30715,14 +30715,14 @@
       }
     },
     "dmg-builder": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.12.1.tgz",
-      "integrity": "sha512-keh9hGtqZ6weOyFg7wd8VYS7U5oYKFzeOEDoEc5ciiaLHfYKqFbJskvCOM2+aA7One92hZMwaIhMNoEug+jsbw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-22.13.0.tgz",
+      "integrity": "sha512-SqvXs10EsthwoqQEr0ae8fbvTywc0GNScY5XL2Nw1eHLLvjy8qaM4aC5ekOj422rqiBBGSrg1YgyUEmHzX6xqg==",
       "dev": true,
       "requires": {
-        "app-builder-lib": "22.12.1",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "app-builder-lib": "22.13.0",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "dmg-license": "^1.0.9",
         "fs-extra": "^10.0.0",
         "iconv-lite": "^0.6.2",
@@ -30971,17 +30971,17 @@
       }
     },
     "electron-builder": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.12.1.tgz",
-      "integrity": "sha512-WttcOgfO5uy9OgKAWE3Yy2oiz39bTNXaKC3dKrwtKq0MaZL8DDvNGRNkFiZutOIF4wAUfwyG7Pm0KbI8Hl44Gw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-22.13.0.tgz",
+      "integrity": "sha512-OCk7ZIk/nmxWe58F3hD49BW7V4T3l98IvDsLIWBYEmlT/HYAoxI69rv0M+7EXIKwe064ZAN5Z96e7wqMJECwmg==",
       "dev": true,
       "requires": {
         "@types/yargs": "^17.0.1",
-        "app-builder-lib": "22.12.1",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "app-builder-lib": "22.13.0",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
-        "dmg-builder": "22.12.1",
+        "dmg-builder": "22.13.0",
         "fs-extra": "^10.0.0",
         "is-ci": "^3.0.0",
         "lazy-val": "^1.0.5",
@@ -31227,14 +31227,14 @@
       }
     },
     "electron-publish": {
-      "version": "22.12.1",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.12.1.tgz",
-      "integrity": "sha512-863+dgShqdmfelCfteR2xkkHch9bPtmIdD1IDLPzL3+43HdEz0oGvRnRJTBKzLrI94D3CNOM4OoPUj3L2JMLqw==",
+      "version": "22.13.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-22.13.0.tgz",
+      "integrity": "sha512-ekBCgbzwKweQxFyvQqxNGZH2va1ZPNeCJRQowt7KV0McR161C+8XRa654DARIpjJ9jE+v+Ne1ImKzND1XCZ2PA==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "22.12.1",
-        "builder-util-runtime": "8.7.10",
+        "builder-util": "22.13.0",
+        "builder-util-runtime": "8.8.0",
         "chalk": "^4.1.1",
         "fs-extra": "^10.0.0",
         "lazy-val": "^1.0.5",
@@ -31333,9 +31333,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.815",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.815.tgz",
-      "integrity": "sha512-2QaE8L5l3BDf82ZXcm0TpWOPoCVUwrp3lKiYzgUbdhRAO2sW60ZdKS5T8yq4r7y1ZeiKJXnf5u8n9u3ldnj5Bw==",
+      "version": "1.3.819",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.819.tgz",
+      "integrity": "sha512-vH3jJLd+tMwrQcYlZJUSjUMlq2JacHuIKl4rT0ZEAdY1Lxk95dBg+rc69ahIPGdKPPWgaN4wjt2f0BopFF3wjQ==",
       "dev": true
     },
     "electron-updater": {
@@ -33254,9 +33254,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.16.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.2.tgz",
-          "integrity": "sha512-P0KPukO6OjMpjBtHSceAZEWlDD1M2Cpzpg6dBbrjFqFhBHe/BwhxaP820xKOjRn/lZRQirrCusIpLS/n2sgXLQ==",
+          "version": "3.16.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+          "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
           "optional": true
         }
       }
@@ -33741,9 +33741,9 @@
           "dev": true
         },
         "terser": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.1.tgz",
-          "integrity": "sha512-b3e+d5JbHAe/JSjwsC3Zn55wsBIM7AsHLjKxT31kGCldgbpFePaFo+PiddtO6uwRZWRw7sPXmAN8dTW61xmnSg==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-5.7.2.tgz",
+          "integrity": "sha512-0Omye+RD4X7X69O0eql3lC4Heh/5iLj3ggxR/B5ketZLOtLiOqukUgjw3q4PDnNQbsrkKr3UMypqStQG3XKRvw==",
           "dev": true,
           "requires": {
             "commander": "^2.20.0",
@@ -36155,9 +36155,9 @@
       "dev": true
     },
     "needle": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.8.0.tgz",
-      "integrity": "sha512-ZTq6WYkN/3782H1393me3utVYdq2XyqNUFBsprEE3VMAT0+hP/cItpnITpqsY6ep2yeFE4Tqtqwc74VqUlUYtw==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.0.tgz",
+      "integrity": "sha512-UBLC4P8w9to3rAhWOQYXIXzTUio9yVnDzIeKxfGbF+Hngy+2bXTqqFK+6nF42EAQKfJdezXK6vzMsefUa1Y3ag==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -42418,16 +42418,16 @@
       }
     },
     "webdriver": {
-      "version": "7.10.1",
-      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.10.1.tgz",
-      "integrity": "sha512-vDDTGrigGh4oMPMH3ERGP8G941K142K+sAgzKIx6Hc2u7PuTjToD/3W0jjH6DQ8B1wgKoQkFk/sf6XQ3TBd09A==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/webdriver/-/webdriver-7.11.0.tgz",
+      "integrity": "sha512-Sd4n3Hxz/6WDa4Ay8cJj/ICDbf2ndlAzd7NMj+dmhfDsDF7L77eCZYB8zrrxs2hoK63E54eyKzyycK3BB3WoYQ==",
       "requires": {
         "@types/node": "^15.12.5",
         "@wdio/config": "7.10.1",
         "@wdio/logger": "7.7.0",
-        "@wdio/protocols": "7.10.1",
+        "@wdio/protocols": "7.11.0",
         "@wdio/types": "7.10.1",
-        "@wdio/utils": "7.10.1",
+        "@wdio/utils": "7.11.0",
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   },
   "build": {
     "productName": "Appium Inspector",
+    "includeSubNodeModules": true,
     "appId": "io.appium.inspector",
     "asar": true,
     "directories": {
@@ -178,7 +179,7 @@
     "cross-env": "^7.0.0",
     "devtron": "^1.4.0",
     "electron": "^13.1.8",
-    "electron-builder": "^22.11.11",
+    "electron-builder": "^22.13.0",
     "electron-devtools-installer": "^3.0.0",
     "eslint-config-appium": "^4.5.0",
     "eslint-plugin-import": "^2.24.2",


### PR DESCRIPTION
this is a workaround for https://github.com/electron-userland/electron-builder/issues/6145.

won't really know if it works until we merge and attempt a publish.