### PR TITLE
Use bstack:options for setting the 'source' capability for BrowserStack to comply with W3C

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -290,7 +290,8 @@ export function newSession (caps, attachSessId = null) {
         port = session.server.browserstack.port = process.env.BROWSERSTACK_PORT || 443;
         path = session.server.browserstack.path = '/wd/hub';
         username = session.server.browserstack.username || process.env.BROWSERSTACK_USERNAME;
-        desiredCapabilities['browserstack.source'] = 'appiumdesktop';
+        desiredCapabilities['bstack:options'] = {};
+        desiredCapabilities['bstack:options'].source = 'appiumdesktop';
         accessKey = session.server.browserstack.accessKey || process.env.BROWSERSTACK_ACCESS_KEY;
         if (!username || !accessKey) {
           notification.error({


### PR DESCRIPTION
**Issue**
Currently, on using the appium-inspector we get the following error.

![image](https://user-images.githubusercontent.com/10832531/133517993-2c7d5503-babc-4ac2-809c-e0818ccefddf.png)

**Fix**
Use `bstack:options` for setting the 'source' capability for BrowserStack to comply with W3C spec.