### PR TITLE
fix: Ensure Appium Protocol is included when attaching to a session id

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -449,6 +449,11 @@ export function newSession (caps, attachSessId = null) {
     let driver = null;
     try {
       if (attachSessId) {
+        // When attaching to a session id, webdriver does not check if the device
+        // is mobile or not. Since we're attaching in appium-inspector, we can
+        // assume the device is mobile so that Appium protocols are included
+        // in the userPrototype.
+        serverOpts.isMobile = true;
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts);
         driver._isAttachedSession = true;
       } else {


### PR DESCRIPTION
There is currently a difference in drivers when a session is started through the Appium inspector and when a session is attached. 

![image](https://user-images.githubusercontent.com/22061507/141877553-1ee11574-3008-43a7-893d-b348f6919c53.png)

The `commandList` are different which is a result of different `userPrototypes` being set up in webdriver. 
https://github.com/webdriverio/webdriverio/blob/e2aa001ecbf240e5240ce551acbfb19f6d004973/packages/webdriver/src/utils.ts#L182

When starting a session, webdriver will determine device type and configure the userPrototypes accordingly. However, when attaching to a session, webdriver doesn't do this which results in the difference in drivers. Since we are attaching to a session in the Appium Inspector, we can assume that the use cases are devices that are mobile so we set `isMobile = true` in the server options.