### PR TITLE
fix: prevent TypeError when SAVED_SESSIONS setting is undeinfed

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -508,7 +508,7 @@ export function saveSession (caps, params) {
   return async (dispatch) => {
     let {name, uuid} = params;
     dispatch({type: SAVE_SESSION_REQUESTED});
-    let savedSessions = await getSetting(SAVED_SESSIONS);
+    let savedSessions = await getSetting(SAVED_SESSIONS) || [];
     if (!uuid) {
 
       // If it's a new session, add it to the list


### PR DESCRIPTION
getSetting(SAVED_SESSIONS) can return undefined:
![image](https://user-images.githubusercontent.com/668156/148680636-7f4db72d-0c27-4a9b-89ff-14245e4138b5.png)

Since we have no direct control over the saved data, it's reasonable to introduce a basic guard clause:
`let savedSessions = await getSetting(SAVED_SESSIONS) || []`

otherwise, `savedSessions.push()` down below throws an unprocessed exception