### PR TITLE
include sauce:options by default and give job a name

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -92,6 +92,8 @@ export const DEFAULT_SERVER_PATH = '/';
 export const DEFAULT_SERVER_HOST = '127.0.0.1';
 export const DEFAULT_SERVER_PORT = 4723;
 
+const SAUCE_OPTIONS_CAP = 'sauce:options';
+
 const JSON_TYPES = ['object', 'number', 'boolean'];
 
 export function getCapsObject (caps) {
@@ -251,13 +253,12 @@ export function newSession (caps, attachSessId = null) {
           return;
         }
         https = false;
-        const sauceOptionsCap = 'sauce:options';
-        if (!isPlainObject(desiredCapabilities[sauceOptionsCap])) {
-          desiredCapabilities[sauceOptionsCap] = {};
+        if (!isPlainObject(desiredCapabilities[SAUCE_OPTIONS_CAP])) {
+          desiredCapabilities[SAUCE_OPTIONS_CAP] = {};
         }
-        if (!desiredCapabilities[sauceOptionsCap].name) {
+        if (!desiredCapabilities[SAUCE_OPTIONS_CAP].name) {
           const dateTime = moment().format('MMM DD -- h:mma');
-          desiredCapabilities[sauceOptionsCap].name = `Appium Desktop Session -- ${dateTime}`;
+          desiredCapabilities[SAUCE_OPTIONS_CAP].name = `Appium Desktop Session -- ${dateTime}`;
         }
         break;
       case ServerTypes.headspin: {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -11,6 +11,7 @@ import { Web2Driver } from 'web2driver';
 import { addVendorPrefixes } from '../util';
 import ky from 'ky/umd';
 import moment from 'moment';
+import _ from 'lodash';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
 export const NEW_SESSION_BEGAN = 'NEW_SESSION_BEGAN';
@@ -251,12 +252,13 @@ export function newSession (caps, attachSessId = null) {
           return;
         }
         https = false;
-        if (!desiredCapabilities['sauce:options']) {
-          desiredCapabilities['sauce:options'] = {};
+        const sauceOptionsCap = 'sauce:options';
+        if (!_.isPlainObject(desiredCapabilities[sauceOptionsCap])) {
+          desiredCapabilities[sauceOptionsCap] = {};
         }
-        if (!desiredCapabilities['sauce:options'].name) {
+        if (!desiredCapabilities[sauceOptionsCap].name) {
           const dateTime = moment().format('MMM DD -- h:mma');
-          desiredCapabilities['sauce:options'].name = `Appium Desktop Session -- ${dateTime}`;
+          desiredCapabilities[sauceOptionsCap].name = `Appium Desktop Session -- ${dateTime}`;
         }
         break;
       case ServerTypes.headspin: {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -3,7 +3,7 @@ import { getSetting, setSetting, SAVED_SESSIONS, SERVER_ARGS, SESSION_SERVER_TYP
 import { v4 as UUID } from 'uuid';
 import { push } from 'connected-react-router';
 import { notification } from 'antd';
-import { includes, debounce, toPairs, union, without, keys, isUndefined } from 'lodash';
+import { includes, debounce, toPairs, union, without, keys, isUndefined, isPlainObject } from 'lodash';
 import { setSessionDetails, quitSession } from './Inspector';
 import i18n from '../../configs/i18next.config.renderer';
 import CloudProviders from '../components/Session/CloudProviders';
@@ -11,7 +11,6 @@ import { Web2Driver } from 'web2driver';
 import { addVendorPrefixes } from '../util';
 import ky from 'ky/umd';
 import moment from 'moment';
-import _ from 'lodash';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
 export const NEW_SESSION_BEGAN = 'NEW_SESSION_BEGAN';
@@ -253,7 +252,7 @@ export function newSession (caps, attachSessId = null) {
         }
         https = false;
         const sauceOptionsCap = 'sauce:options';
-        if (!_.isPlainObject(desiredCapabilities[sauceOptionsCap])) {
+        if (!isPlainObject(desiredCapabilities[sauceOptionsCap])) {
           desiredCapabilities[sauceOptionsCap] = {};
         }
         if (!desiredCapabilities[sauceOptionsCap].name) {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -257,7 +257,7 @@ export function newSession (caps, attachSessId = null) {
           desiredCapabilities[SAUCE_OPTIONS_CAP] = {};
         }
         if (!desiredCapabilities[SAUCE_OPTIONS_CAP].name) {
-          const dateTime = moment().format('MMM DD -- h:mma');
+          const dateTime = moment().format('lll');
           desiredCapabilities[SAUCE_OPTIONS_CAP].name = `Appium Desktop Session -- ${dateTime}`;
         }
         break;

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -10,6 +10,7 @@ import CloudProviders from '../components/Session/CloudProviders';
 import { Web2Driver } from 'web2driver';
 import { addVendorPrefixes } from '../util';
 import ky from 'ky/umd';
+import moment from 'moment';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
 export const NEW_SESSION_BEGAN = 'NEW_SESSION_BEGAN';
@@ -250,6 +251,13 @@ export function newSession (caps, attachSessId = null) {
           return;
         }
         https = false;
+        if (!desiredCapabilities['sauce:options']) {
+          desiredCapabilities['sauce:options'] = {};
+        }
+        if (!desiredCapabilities['sauce:options'].name) {
+          const dateTime = moment().format('MMM DD -- h:mma');
+          desiredCapabilities['sauce:options'].name = `Appium Desktop Session -- ${dateTime}`;
+        }
         break;
       case ServerTypes.headspin: {
         let headspinUrl;


### PR DESCRIPTION
* If "sauce:options" is not set, set it so that it defaults to W3C
* Give the Appium Desktop job a name so that it's easier for Sauce Labs users to know which job came from Appium Desktop