### PR TITLE
fix: add connectionRetryTimeout in attaching to an existing session

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -469,6 +469,9 @@ export function newSession (caps, attachSessId = null) {
         // assume the device is mobile so that Appium protocols are included
         // in the userPrototype.
         serverOpts.isMobile = true;
+        // Need to set connectionRetryTimeout as same as the new session request.
+        // TODO: make configurable?
+        serverOpts.connectionRetryTimeout = 120000;
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts);
         driver._isAttachedSession = true;
       } else {


### PR DESCRIPTION
Current requests after attach to an existing session is default each end client's default timeout instead of webdriverio's default one.
As our future work, we could make them customizable, but let me make the timeout as same as webdriverio's default value for now.

For example, ky (browser) one is 10 sec. `/source` endpoint can take over the time easily.