### PR TITLE
Build universal binary for macOS releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [
-        "dmg",
-        "zip"
+        {"target": "dmg", "arch": "universal"},
+        {"target": "zip", "arch": "universal"}
       ]
     },
     "dmg": {


### PR DESCRIPTION
Hi :wave:

I've updated the `package.json` config to output a universal binary (`x86_64`, `arm64`) on macOS for anyone that doesn't want to run Rosetta, so Appium Inspector will run natively on M1 Macs 🥳

```sh
$ npx electron-builder build --publish never
  • electron-builder  version=22.14.13 os=21.3.0
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release/builder-effective-config.yaml
  • packaging       platform=darwin arch=x64 electron=13.6.3 appOutDir=release/mac-universal--x64
  • packaging       platform=darwin arch=arm64 electron=13.6.3 appOutDir=release/mac-universal--arm64
  • packaging       platform=darwin arch=universal electron=13.6.3 appOutDir=release/mac-universal
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=  [redacted]
  • building        target=DMG arch=universal file=release/Appium Inspector-mac-2022.2.1.dmg
  • building        target=macOS zip arch=universal file=release/Appium Inspector-2022.2.1-universal-mac.zip
  • Detected arm64 process, HFS+ is unavailable. Creating dmg with APFS - supports Mac OSX 10.12+
  • building block map  blockMapFile=release/Appium Inspector-mac-2022.2.1.dmg.blockmap
  • building block map  blockMapFile=release/Appium Inspector-2022.2.1-universal-mac.zip.blockmap
$ lipo -info ./release/mac-universal/Appium\ Inspector.app/Contents/MacOS/Appium\ Inspector
Architectures in the fat file: ./release/mac-universal/Appium Inspector.app/Contents/MacOS/Appium Inspector are: x86_64 arm64
```