### PR TITLE
Multiple fixes

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -6,7 +6,7 @@ import { xmlToJSON } from '../util';
 import frameworks from '../lib/client-frameworks';
 import { getSetting, setSetting, SAVED_FRAMEWORK } from '../../shared/settings';
 import i18n from '../../configs/i18next.config.renderer';
-import AppiumClient from '../lib/appium-client';
+import AppiumClient, { NATIVE_APP } from '../lib/appium-client';
 import { notification } from 'antd';
 
 export const SET_SESSION_DETAILS = 'SET_SESSION_DETAILS';
@@ -449,6 +449,10 @@ export function selectAppMode (mode) {
       const action = applyClientMethod({methodName: 'getPageSource'});
       await action(dispatch, getState);
     }
+    if (appMode !== mode && mode === APP_MODE.NATIVE) {
+      const action = applyClientMethod({ methodName: 'switchContext', args: [NATIVE_APP] });
+      await action(dispatch, getState);
+    }
   };
 }
 
@@ -612,7 +616,6 @@ export function callClientMethod (params) {
       setVisibleCommandResult(result, methodName)(dispatch);
     }
     res.elementId = res.id;
-    console.log('res = ', JSON.stringify(res, null, '  ')); // eslint-disable-line no-console
     return res;
   };
 }

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -312,9 +312,9 @@ export function toggleShowBoilerplate () {
   };
 }
 
-export function setSessionDetails (driver, sessionDetails) {
+export function setSessionDetails (driver, sessionDetails, mode) {
   return (dispatch) => {
-    dispatch({type: SET_SESSION_DETAILS, driver, sessionDetails});
+    dispatch({type: SET_SESSION_DETAILS, driver, sessionDetails, mode});
   };
 }
 

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -158,8 +158,8 @@ export function applyClientMethod (params) {
     try {
       dispatch({type: METHOD_CALL_REQUESTED});
       const callAction = callClientMethod(params);
-      const {contexts, contextsError, currentContext, currentContextError,
-             source, screenshot, windowSize, result, sourceError,
+      const {contexts, contextsError, commandRes, currentContext, currentContextError,
+             source, screenshot, windowSize, sourceError,
              screenshotError, windowSizeError, variableName,
              variableIndex, strategy, selector} = await callAction(dispatch, getState);
 
@@ -193,7 +193,7 @@ export function applyClientMethod (params) {
           windowSizeError,
         });
       }
-      return result;
+      return commandRes;
     } catch (error) {
       console.log(error); // eslint-disable-line no-console
       let methodName = params.methodName === 'click' ? 'tap' : params.methodName;
@@ -612,6 +612,7 @@ export function callClientMethod (params) {
       setVisibleCommandResult(result, methodName)(dispatch);
     }
     res.elementId = res.id;
+    console.log('res = ', JSON.stringify(res, null, '  ')); // eslint-disable-line no-console
     return res;
   };
 }

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -11,6 +11,7 @@ import { Web2Driver } from 'web2driver';
 import { addVendorPrefixes } from '../util';
 import ky from 'ky/umd';
 import moment from 'moment';
+import { APP_MODE } from '../components/Inspector/shared';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
 export const NEW_SESSION_BEGAN = 'NEW_SESSION_BEGAN';
@@ -521,9 +522,11 @@ export function newSession (caps, attachSessId = null) {
     // we want to keep the process equal to prevent complexity so we launch a default url here to make
     // sure we don't start with an empty page which will not show proper HTML in the inspector
     const {browserName = ''} = desiredCapabilities;
+    let mode = APP_MODE.NATIVE;
 
     if (browserName.trim() !== '') {
       try {
+        mode = APP_MODE.WEB_HYBRID;
         await driver.navigateTo('http://appium.io/docs/en/about-appium/intro/');
       } catch (ign) {}
     }
@@ -538,7 +541,7 @@ export function newSession (caps, attachSessId = null) {
       username,
       accessKey,
       https,
-    });
+    }, mode);
     action(dispatch);
     dispatch(push('/inspector'));
   };

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -3,7 +3,7 @@ import Bluebird from 'bluebird';
 import {getWebviewStatusAddressBarHeight, parseSource, setHtmlElementAttributes} from './webview-helpers';
 import {SCREENSHOT_INTERACTION_MODE, APP_MODE} from '../components/Inspector/shared';
 
-const NATIVE_APP = 'NATIVE_APP';
+export const NATIVE_APP = 'NATIVE_APP';
 let _instance = null;
 
 export default class AppiumClient {

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -97,7 +97,7 @@ export default class AppiumClient {
           actions: [
             {type: 'pointerMove', duration: 0, x, y},
             {type: 'pointerDown', button: 0},
-            {type: 'pause', duration: 500},
+            {type: 'pause', duration: 100},
             {type: 'pointerUp', button: 0}
           ]
         }]);

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -242,7 +242,7 @@ export default function inspector (state = INITIAL_STATE, action) {
       return {...state, showBoilerplate: action.show};
 
     case SET_SESSION_DETAILS:
-      return {...state, sessionDetails: action.sessionDetails, driver: action.driver};
+      return {...state, sessionDetails: action.sessionDetails, driver: action.driver, appMode: action.mode};
 
     case SHOW_LOCATOR_TEST_MODAL:
       return {


### PR DESCRIPTION
This PR fixes the following things:

- The `applyClientMethod` method always returned an undefined result, due to an incorrect mapping
- When a session was started with a browser (Chrome/Safari) the source was automatically translated to HTML, but the app mode was still in "Native App Mode", see screenshot below. It will now already start in "Web/Hybrid AppMode"
  ![image](https://user-images.githubusercontent.com/11979740/161997717-5766f990-9143-4245-95f1-0f254364d286.png) ![image](https://user-images.githubusercontent.com/11979740/161997992-4a06c966-57a5-4075-a231-01937fab614a.png)
- Switching between "Web/Hybrid AppMode", where the source is HTML, and "Native App Mode" didn't trigger:
  - switching back to `NATIVE_APP`-mode
  - a refresh of the source
  This is now fixed and the native source code will be shown when "Native App Mode" is selected
- A tap was sometimes seen as a long press because it was set at 500ms, this PR changes it to 100ms which should be handled as a tap
  

