### PR TITLE
fix: fix to start browser by removing unused electron

### DIFF
--- a/app/main/helpers.js
+++ b/app/main/helpers.js
@@ -1,19 +1,4 @@
-import {BrowserWindow, Menu} from 'electron';
-import settings from '../shared/settings';
-import i18n from '../configs/i18next.config';
-import { makeOpenBrowserWindow, makeSetSavedEnv } from '../../gui-common/util';
-
 const APPIUM_SESSION_FILE_VERSION = '1.0';
-
-export function openBrowserWindow (route, opts) {
-  const open = makeOpenBrowserWindow({BrowserWindow, Menu, i18n});
-  return open(route, opts);
-}
-
-export function setSavedEnv () {
-  const set = makeSetSavedEnv(settings);
-  return set();
-}
 
 export function getAppiumSessionFilePath (argv, isPackaged, isDev) {
   if (isDev) {


### PR DESCRIPTION
Current main raises an exception in the browser mode as an electron dependency.
This PR drops them since they no longer used in this repository.