### PR TITLE
fix: Unable to set geolocation in Appium inspector #210

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -156,7 +156,7 @@ export const actionDefinitions = {
     },
     'Geolocation': {
       'Get Geolocation': {methodName: 'getGeoLocation'},
-      'Set Geolocation': {methodName: 'setGeoLocation', args: [['locationJSONObject', STRING]]},
+      'Set Geolocation': {methodName: 'setGeoLocation', args: [['latitude', NUMBER], ['longitude', NUMBER], ['altitude', NUMBER]]},
     },
     'Logs': {
       'Get Log Types': {methodName: 'getLogTypes'},


### PR DESCRIPTION
This PR fixes the setGeoLocation bug on Appium Inspector by updating the set GeoLocation with new arguments. 
