### PR TITLE
fix: when selecting element, source is not unfolded to show selected element #384

### DIFF
--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -77,6 +77,7 @@ class Source extends Component {
     const treeData = source && recursive(source);
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']}>
+      {/* Must switch to a new antd Tree component when there's changes to treeData  */}
       {treeData ?
         <Tree
           defaultExpandAll={true}

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -77,14 +77,17 @@ class Source extends Component {
     const treeData = source && recursive(source);
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']}>
-      {source &&
+      {treeData ?
         <Tree
+          defaultExpandAll={true}
           onExpand={setExpandedPaths}
-          autoExpandParent={false}
           expandedKeys={expandedPaths}
           onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
           selectedKeys={[path]}
           treeData={treeData} />
+        :
+        <Tree
+          treeData={[]} />
       }
       {!source && !sourceError &&
         <i>{t('Gathering initial app source…')}</i>


### PR DESCRIPTION
This PR fixes the page source not folding down when selecting an element in the screenshot box on the first load of the inspector.