### PR TITLE
fix: restore scrollbars to source pane (fix #383; fix #194)

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -74,11 +74,12 @@
 
 .inspector-main :global(.ant-card-head) {
     max-height: 48px;
+    padding: 0px 12px;
 }
 
 .inspector-main :global(.ant-card-body) {
     height: calc(100% - 48px);
-    padding-bottom: 48px;
+    padding: 12px;
 }
 
 .inspector-main .interaction-tab-container :global(.ant-tabs) {
@@ -102,20 +103,7 @@
     height: 100%;
 }
 
-.inspector-main .interaction-tab-container :global(.ant-tree) {
-    overflow: auto;
-}
-
 .inspector-main .tree-container {
-    height: 100%;
-    overflow-y: auto;
-}
-
-.inspector-main .tree-container::-webkit-scrollbar {
-    display: none;
-}
-
-.inspector-main .tree-container :global(ul.ant-tree) {
     height: 100%;
     overflow: auto;
 }
@@ -202,6 +190,10 @@
 
 .elementActions {
     margin-bottom: 20px;
+}
+
+.inspector-main #selectedElementContainer {
+    padding-bottom: 0px;
 }
 
 .selected-element-table-cells {

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -76,7 +76,7 @@ class Source extends Component {
 
     const treeData = source && recursive(source);
 
-    return <div id='sourceContainer' className={InspectorStyles['tree-container']}>
+    return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
       {/* Must switch to a new antd Tree component when there's changes to treeData  */}
       {treeData ?
         <Tree


### PR DESCRIPTION
seems like it's confusing not to have visible system scrollbars when necessary.
![Screen Shot 2022-05-09 at 12 05 29](https://user-images.githubusercontent.com/605053/167479919-4b471bba-1f40-4292-a34c-86ba726bed18.png)

