### PR TITLE
feat: use monospace font in capability names and values so whitespace is obvious

### DIFF
--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -35,17 +35,18 @@ export default class CapabilityControl extends Component {
       onClick={async () => {onSetCapabilityParam(await this.getLocalFilePath() || currentFilePath);}} />;
 
     switch (cap.type) {
-      case 'text': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} onPressEnter={onPressEnter}/>;
+      case 'text': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} onPressEnter={onPressEnter}
+        className={SessionStyles.capsBoxFont} />;
       case 'boolean': return <Switch disabled={isEditingDesiredCaps} id={id} checkedChildren={'true'} unCheckedChildren={'false'}
         placeholder={t('Value')} checked={cap.value} onChange={(value) => onSetCapabilityParam(value)} />;
       case 'number': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
-        onChange={(e) => !isNaN(parseInt(e.target.value, 10)) ? onSetCapabilityParam(parseInt(e.target.value, 10)) : onSetCapabilityParam(undefined)} onPressEnter={onPressEnter} />;
+        onChange={(e) => !isNaN(parseInt(e.target.value, 10)) ? onSetCapabilityParam(parseInt(e.target.value, 10)) : onSetCapabilityParam(undefined)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />;
       case 'object':
       case 'json_object':
         return <Input disabled={isEditingDesiredCaps} id={id} type={INPUT.TEXTAREA} rows={4} placeholder={t('Value')} value={cap.value}
-          onChange={(e) => onSetCapabilityParam(e.target.value)} />;
+          onChange={(e) => onSetCapabilityParam(e.target.value)} className={SessionStyles.capsBoxFont} />;
       case 'file': return <div className={SessionStyles.fileControlWrapper}>
-        <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} addonAfter={buttonAfter(cap.value)} onPressEnter={onPressEnter}/>
+        <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} addonAfter={buttonAfter(cap.value)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />
       </div>;
 
       default:

--- a/app/renderer/components/Session/CapabilityEditor.js
+++ b/app/renderer/components/Session/CapabilityEditor.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Checkbox, Input, Modal, Form, Row, Col, Select } from 'antd';
+import { Button, Checkbox, Input, Modal, Form, Row, Col, Select, Tooltip } from 'antd';
 import FormattedCaps from './FormattedCaps';
 import CapabilityControl from './CapabilityControl';
 import SessionStyles from './Session.css';
@@ -11,6 +11,16 @@ import { ROW } from '../../../../gui-common/components/AntdTypes';
 
 const {Item: FormItem} = Form;
 const {Option} = Select;
+const whitespaces = /^\s|\s$/;
+
+function whitespaceMsg (value) {
+  const leadingSpace = /^\s/.test(value);
+  const trailingSpace = /\s$/.test(value);
+
+  if (leadingSpace && trailingSpace) {return 'Contains Leading & Trailing Whitespace';}
+  if (leadingSpace) {return 'Contains Leading Whitespace';}
+  if (trailingSpace) {return 'Contains Trailing Whitespace';}
+}
 
 export default class CapabilityEditor extends Component {
 
@@ -89,10 +99,13 @@ export default class CapabilityEditor extends Component {
             {caps.map((cap, index) => <Row gutter={8} key={index}>
               <Col span={7}>
                 <FormItem>
-                  <Input disabled={isEditingDesiredCaps} id={`desiredCapabilityName_${index}`} placeholder={t('Name')}
-                    value={cap.name} onChange={(e) => setCapabilityParam(index, 'name', e.target.value)}
-                    ref={index === numCaps - 1 ? this.latestCapField : ''}
-                  />
+                  <Tooltip title={whitespaceMsg(cap.name)} visible={whitespaces.test(cap.name)}>
+                    <Input disabled={isEditingDesiredCaps} id={`desiredCapabilityName_${index}`} placeholder={t('Name')}
+                      value={cap.name} onChange={(e) => setCapabilityParam(index, 'name', e.target.value)}
+                      ref={index === numCaps - 1 ? this.latestCapField : ''}
+                      className={SessionStyles.capsBoxFont}
+                    />
+                  </Tooltip>
                 </FormItem>
               </Col>
               <Col span={8}>
@@ -108,10 +121,12 @@ export default class CapabilityEditor extends Component {
               </Col>
               <Col span={7}>
                 <FormItem>
-                  <CapabilityControl {...this.props} cap={cap} id={`desiredCapabilityValue_${index}`}
-                    onSetCapabilityParam={(value) => setCapabilityParam(index, 'value', value)}
-                    onPressEnter={(index === numCaps - 1) ? addCapability : () => {}}
-                  />
+                  <Tooltip title={whitespaceMsg(cap.value)} visible={whitespaces.test(cap.value)}>
+                    <CapabilityControl {...this.props} cap={cap} id={`desiredCapabilityValue_${index}`}
+                      onSetCapabilityParam={(value) => setCapabilityParam(index, 'value', value)}
+                      onPressEnter={(index === numCaps - 1) ? addCapability : () => {}}
+                    />
+                  </Tooltip>
                 </FormItem>
               </Col>
               <Col span={2}>

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -1,15 +1,15 @@
 .active-session {
-    background-color: #662d91;
-    color: white;
+  background-color: #662d91;
+  color: white;
 }
 
 .sessionContainer {
-    width: 100%;
-    height: 100%;
-    padding: 1em;
-    background: linear-gradient(180deg, #f9f9f9, #f2f2f2, 5%, #f2f2f2, 95%, #d9d9d9);
-    display: flex;
-    flex-flow: column;
+  width: 100%;
+  height: 100%;
+  padding: 1em;
+  background: linear-gradient(180deg, #f9f9f9, #f2f2f2, 5%, #f2f2f2, 95%, #d9d9d9);
+  display: flex;
+  flex-flow: column;
 }
 
 .sessionContainer :global(.ant-tabs-tab .anticon.anticon-close-square) {
@@ -149,8 +149,7 @@
   overflow-y: auto;
 }
 
-.formattedCaps :global(.ant-card-body::-webkit-scrollbar) {
-}
+.formattedCaps :global(.ant-card-body::-webkit-scrollbar) {}
 
 
 .formattedCaps pre {
@@ -160,21 +159,25 @@
 
 
 .start-session-button {
-    margin-left: 1em;
+  margin-left: 1em;
 }
 
 .filepath-button {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .capsFormCol {
-    min-width: 476px;
-    height: 100%;
+  min-width: 476px;
+  height: 100%;
 }
 
 .capsFormRow {
   font-size: 14px;
   height: 100%;
+}
+
+.capsBoxFont {
+  font-family: monospace;
 }
 
 .capsFormRow :global(.ant-form-item) {
@@ -191,10 +194,10 @@
 }
 
 .localDesc {
-    font-style: italic;
-    color: #666;
-    margin-top: 8px;
-    margin-left: 8px;
+  font-style: italic;
+  color: #666;
+  margin-top: 8px;
+  margin-left: 8px;
 }
 
 .selected {
@@ -221,8 +224,7 @@
   width: 100%;
 }
 
-.advancedSettingsContainer {
-}
+.advancedSettingsContainer {}
 
 .add-desired-capability-button {
   float: right;


### PR DESCRIPTION
This PR Closes #188 

Changed the font in the capabilities text boxes to monospace so that whitespaces are more apparent!

<img width="583" alt="image" src="https://user-images.githubusercontent.com/85202734/167876916-d9b3e0ed-a4ec-40d3-a399-e043554a7c23.png">
