### PR TITLE
feat: ability to download source as a .xml file

### DIFF
--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -19,6 +19,7 @@ import {
   PauseOutlined,
   SearchOutlined,
   CopyOutlined,
+  DownloadOutlined,
   CloseOutlined,
   FileTextOutlined,
   TagOutlined,
@@ -37,6 +38,19 @@ const ButtonGroup = Button.Group;
 const MIN_WIDTH = 1080;
 const MIN_HEIGHT = 570;
 const MAX_SCREENSHOT_WIDTH = 500;
+
+function downloadXML (sourceXML) {
+  let element = document.createElement('a');
+  element.setAttribute('href', 'data:application/xml;charset=utf-8,' + encodeURIComponent(sourceXML));
+  element.setAttribute('download', 'source.xml');
+
+  element.style.display = 'none';
+  document.body.appendChild(element);
+
+  element.click();
+
+  document.body.removeChild(element);
+}
 
 export default class Inspector extends Component {
 
@@ -141,7 +155,17 @@ export default class Inspector extends Component {
           <TabPane tab={t('Source')} key={INTERACTION_MODE.SOURCE}>
             <div className='action-row'>
               <div className='action-col'>
-                <Card title={<span><FileTextOutlined /> {t('App Source')}</span>}>
+                <Card title={<span><FileTextOutlined /> {t('App Source')} </span>}
+                  extra={
+                    <span>
+                      <Tooltip title={t('Copy XML Source to Clipboard')}>
+                        <Button type='text' id='btnSourceXML' icon={<CopyOutlined/>} onClick={() => clipboard.writeText(sourceXML)} />
+                      </Tooltip>
+                      <Tooltip title={t('Download Source as .XML File')}>
+                        <Button type='text' id='btnDownloadSourceXML' icon={<DownloadOutlined/>} onClick={() => downloadXML(sourceXML)}/>
+                      </Tooltip>
+                    </span>
+                  }>
                   <Source {...this.props} />
                 </Card>
               </div>
@@ -220,9 +244,6 @@ export default class Inspector extends Component {
       }
       <Tooltip title={t('Search for element')}>
         <Button id='searchForElement' icon={<SearchOutlined/>} onClick={showLocatorTestModal}/>
-      </Tooltip>
-      <Tooltip title={t('Copy XML Source to Clipboard')}>
-        <Button id='btnSourceXML' icon={<CopyOutlined/>} onClick={() => clipboard.writeText(sourceXML)}/>
       </Tooltip>
       <Tooltip title={t('quitSessionAndClose')}>
         <Button id='btnClose' icon={<CloseOutlined/>} onClick={() => quitSession()}/>


### PR DESCRIPTION
This PR Closes #399 

Added a download icon in the source header to allow users to download the source as a .xml file. Also moved the 'copy XML source to clipboard' button in the source header!

<img width="448" alt="image" src="https://user-images.githubusercontent.com/85202734/167923969-c75eb6cd-a80c-4976-8e6f-074a5a5817a2.png">
<img width="217" alt="image" src="https://user-images.githubusercontent.com/85202734/167924234-78269a6d-5a4e-44e4-879b-cc71324f5476.png">
<img width="215" alt="image" src="https://user-images.githubusercontent.com/85202734/167924278-5e3e8a61-9bb6-4a2f-bde0-39926e261094.png">
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/85202734/167924108-19fac1c0-ae7d-4891-9a97-0a46bb7e3733.png">
