### PR TITLE
feat: save remote connection info alongside capabilities in saved sets

### DIFF
--- a/app/renderer/components/Session/CapabilityEditor.js
+++ b/app/renderer/components/Session/CapabilityEditor.js
@@ -75,9 +75,9 @@ export default class CapabilityEditor extends Component {
   render () {
     const {setCapabilityParam, caps, addCapability, removeCapability, saveSession, hideSaveAsModal,
            saveAsText, showSaveAsModal, setSaveAsText, isEditingDesiredCaps, t,
-           setAddVendorPrefixes, addVendorPrefixes} = this.props;
+           setAddVendorPrefixes, addVendorPrefixes, server, serverType} = this.props;
     const numCaps = caps.length;
-    const onSaveAsOk = () => saveSession(caps, {name: saveAsText});
+    const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
 
     return <>
       <Row type={ROW.FLEX} align="top" justify="start" className={SessionStyles.capsFormRow}>

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -19,9 +19,8 @@ export default class SavedSessions extends Component {
   onRow (record) {
     return {
       onClick: () => {
-        const {setCaps} = this.props;
         let session = this.sessionFromUUID(record.key);
-        setCaps(session.caps, session.uuid);
+        this.handleCapsAndServer(session);
       }
     };
   }
@@ -29,6 +28,14 @@ export default class SavedSessions extends Component {
   getRowClassName (record) {
     const {capsUUID} = this.props;
     return capsUUID === record.key ? SessionCSS.selected : '';
+  }
+
+  handleCapsAndServer (session) {
+    const {setCapsAndServer, server, serverType } = this.props;
+
+    // Incase user has CAPS saved from older version of Inspector which
+    // doesn't contain server and serverType within the session object
+    setCapsAndServer(session.server || server, session.serverType || serverType, session.caps, session.uuid);
   }
 
   handleDelete (uuid) {
@@ -50,7 +57,7 @@ export default class SavedSessions extends Component {
   }
 
   render () {
-    const {savedSessions, setCaps, capsUUID, switchTabs} = this.props;
+    const {savedSessions, capsUUID, switchTabs} = this.props;
 
     const columns = [{
       title: 'Capability Set',
@@ -69,7 +76,7 @@ export default class SavedSessions extends Component {
           <div>
             <Button
               icon={<EditOutlined/>}
-              onClick={() => {setCaps(session.caps, session.uuid); switchTabs('new');}}
+              onClick={() => {this.handleCapsAndServer(session); switchTabs('new');}}
               className={SessionCSS['edit-session']}
             />
             <Button

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -60,7 +60,7 @@ export default class Session extends Component {
 
   render () {
     const {newSessionBegan, savedSessions, tabKey, switchTabs,
-           serverType,
+           serverType, server,
            requestSaveAsModal, newSession, caps, capsUUID, saveSession,
            visibleProviders = [],
            isCapsDirty, sessionLoading, attachSessId, t} = this.props;
@@ -116,7 +116,7 @@ export default class Session extends Component {
                 {t('desiredCapabilitiesDocumentation')}
               </a>
             </div>
-            { (!isAttaching && capsUUID) && <Button onClick={() => saveSession(caps, {uuid: capsUUID})} disabled={!isCapsDirty}>{t('Save')}</Button> }
+            { (!isAttaching && capsUUID) && <Button onClick={() => saveSession(server, serverType, caps, {uuid: capsUUID})} disabled={!isCapsDirty}>{t('Save')}</Button> }
             {!isAttaching && <Button onClick={requestSaveAsModal}>{t('saveAs')}</Button>}
             {!isAttaching && <Button type={BUTTON.PRIMARY} id='btnStartSession'
               onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>{t('startSession')}</Button>

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -4,7 +4,7 @@ import formatJSON from 'format-json';
 import { NEW_SESSION_REQUESTED, NEW_SESSION_BEGAN, NEW_SESSION_DONE,
          SAVE_SESSION_REQUESTED, SAVE_SESSION_DONE, GET_SAVED_SESSIONS_REQUESTED,
          GET_SAVED_SESSIONS_DONE, SESSION_LOADING, SESSION_LOADING_DONE,
-         SET_CAPABILITY_PARAM, ADD_CAPABILITY, REMOVE_CAPABILITY, SET_CAPS,
+         SET_CAPABILITY_PARAM, ADD_CAPABILITY, REMOVE_CAPABILITY, SET_CAPS_AND_SERVER,
          SWITCHED_TABS, SAVE_AS_MODAL_REQUESTED, HIDE_SAVE_AS_MODAL_REQUESTED, SET_SAVE_AS_TEXT,
          DELETE_SAVED_SESSION_REQUESTED, DELETE_SAVED_SESSION_DONE,
          CHANGE_SERVER_TYPE, SET_SERVER_PARAM, SET_SERVER, SET_ATTACH_SESS_ID,
@@ -125,9 +125,11 @@ export default function session (state = INITIAL_STATE, action) {
         }),
       };
 
-    case SET_CAPS:
+    case SET_CAPS_AND_SERVER:
       nextState = {
         ...state,
+        server: action.server,
+        serverType: action.serverType,
         caps: action.caps,
         capsUUID: action.uuid,
       };


### PR DESCRIPTION
This PR Closes #398 

In this PR whenever the user saves their capabilities, the remote connection details (this includes any cloud provider details or advanced settings) are saved as well. So the user can have many different capabilities saved, and when they click on the saved capabilities the remote session/cloud provider connection information associated with that particular CAP set is loaded as well. 