### PR TITLE
fix: add connection retry timeout

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -512,9 +512,6 @@ export function newSession (caps, attachSessId = null) {
         // assume the device is mobile so that Appium protocols are included
         // in the userPrototype.
         serverOpts.isMobile = true;
-        // Need to set connectionRetryTimeout as same as the new session request.
-        // TODO: make configurable?
-        serverOpts.connectionRetryTimeout = 5 * 60 * 1000;
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts);
         driver._isAttachedSession = true;
       } else {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -481,6 +481,7 @@ export function newSession (caps, attachSessId = null) {
       protocol: https ? 'https' : 'http',
       path,
       connectionRetryCount: CONN_RETRIES,
+      connectionRetryTimeout: 10 * 60 * 1000,
     };
 
     if (username && accessKey) {


### PR DESCRIPTION
The connection retry timeout we have currently is too short for some cloud providers.