### PR TITLE
fix: session panel info and padding

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -109,6 +109,31 @@
     overflow: auto;
 }
 
+.session-info-table {
+    margin-right: -1em;
+}
+
+.session-code-box {
+    margin-top: 1em;
+}
+
+.session-inner-table,
+.session-inner-table :global(.ant-table) {
+    width: 102%;
+    margin-left: -32px;
+} 
+
+.session-inner-table :global(.ant-table-body)::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+}
+
+.session-inner-table :global(.ant-table-body)::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, .5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+}
+
 .inspector-main .interaction-tab-container .scroll-buttons {
     position: absolute;
     bottom: 0;

--- a/app/renderer/components/Inspector/SessionInfo.js
+++ b/app/renderer/components/Inspector/SessionInfo.js
@@ -1,44 +1,67 @@
 import React, { Component } from 'react';
-import { Table, Card } from 'antd';
+import { Table, Row, Col } from 'antd';
 import SessionCodeBox from './SessionCodeBox';
 import { withTranslation } from '../../util';
+import InspectorStyles from './Inspector.css';
+import formatJSON from 'format-json';
 
 const SESSION_OBJ = {
   session_id: 'Session ID', session_url: 'Session URL',
   server_details: 'Server Details', session_length: 'Session Length',
-  session_caps: 'Session Capabilities', server_response: 'Server Details from Server',
-  active_appId: 'Currently Active App ID'
+  session_details: 'Session Details', active_appId: 'Currently Active App ID'
 };
 
-const SCROLL_DISTANCE_Y = 105;
-const SCROLL_DISTANCE_X = 100;
+const OUTER_TABLE_KEY = 'sessionInfo';
+const SESSION_TABLE_KEY = 'sessionDetails';
+const SERVER_TABLE_KEY = 'serverDetails';
+
+const SCROLL_DISTANCE_Y = 104;
 const COLUMN_WIDTH = 200;
+let SESSION_DETAILS;
 
 class SessionInfo extends Component {
 
+  constructor (props) {
+    super(props);
+    this.interval = null;
+    this.state = { time: this.generateSessionTime() };
+  }
+
   componentDidMount () {
-    const {driver, getActiveAppId, getServerStatus} = this.props;
+    const {driver, getActiveAppId, getServerStatus, applyClientMethod} = this.props;
     const {isIOS, isAndroid} = driver.client;
 
     getActiveAppId(isIOS, isAndroid);
     getServerStatus();
+
+    this.sessionDetails(applyClientMethod);
+    this.interval = setInterval(() => {
+      this.setState({
+        time: this.generateSessionTime(),
+      });
+    }, 1000);
+  }
+
+  componentWillUnmount () {
+    clearInterval(this.interval);
+  }
+
+  async sessionDetails (applyClientMethod) {
+    SESSION_DETAILS = await applyClientMethod({methodName: 'getSession'});
   }
 
   generateSessionTime () {
     const { sessionStartTime } = this.props;
     const currentTime = Date.now();
-    const time = currentTime - sessionStartTime;
+    const timeDiff = currentTime - sessionStartTime;
 
-    const hourDiff = time / 3600000;
-    const hours = Math.floor(hourDiff);
+    const hours = timeDiff / 3600000;
+    const minutes = (hours - Math.floor(hours)) * 60;
+    const seconds = (minutes - Math.floor(minutes)) * 60;
 
-    const minDiff = (hourDiff - hours) * 60;
-    const minutes = Math.floor(minDiff);
+    const showTime = (time) => String(Math.floor(time)).padStart(2, '0');
 
-    const secDiff = (minDiff - minutes) * 60;
-    const seconds = Math.floor(secDiff);
-
-    return `${minutes}:${(seconds < 10) ? '0' : ''}${seconds}`;
+    return `${showTime(hours)}:${showTime(minutes)}:${showTime(seconds)}`;
   }
 
   getTable (tableValues, keyName, outerTable) {
@@ -55,39 +78,58 @@ class SessionInfo extends Component {
     }, {
       dataIndex: keyValue,
       key: keyValue,
-      ...(outerTable && { render: (text) => this.generateSessionInfo(text) })
+      render: outerTable ?
+        (text) => this.generateSessionInfo(text)
+        :
+        (text) => typeof text === 'object' ?
+          <pre>{formatJSON.plain(text)}</pre>
+          :
+          String(text)
     }];
 
     return outerTable ?
+      <div className={InspectorStyles['session-info-table']}>
+        <Row>
+          <Col span={24}>
+            <Table
+              columns={columns}
+              dataSource={dataSource}
+              pagination={false}
+              showHeader={false}
+              bordered={true}
+              size="small"
+            />
+          </Col>
+        </Row>
+        <div className={InspectorStyles['session-code-box']}>
+          <Row>
+            <SessionCodeBox {...this.props} />
+          </Row>
+        </div>
+      </div>
+      :
       <Table
+        className={InspectorStyles['session-inner-table']}
         columns={columns}
         dataSource={dataSource}
         pagination={false}
         showHeader={false}
-        footer={() => <SessionCodeBox {...this.props} />} />
-      :
-      <Card>
-        <Table
-          columns={columns}
-          dataSource={dataSource}
-          pagination={false}
-          showHeader={false}
-          scroll={{ y: SCROLL_DISTANCE_Y, x: SCROLL_DISTANCE_X }}
-        />
-      </Card>;
+        size="small"
+        scroll={{ y: SCROLL_DISTANCE_Y }}
+      />;
   }
 
   generateSessionInfo (name) {
     const { driver, sessionDetails, appId, status } = this.props;
-    const { host, path, port, desiredCapabilities } = sessionDetails;
+    const { host, path, port } = sessionDetails;
     const { sessionId, connectedUrl } = driver || '';
 
     const isOuterTable = false;
 
     const serverDetailsArray = [['host', host], ['path', path], ['port', port]];
-    const capsArray = desiredCapabilities != null ?
-      Object.keys(desiredCapabilities).map(
-        (key) => [key, String(desiredCapabilities[key])])
+    const sessionArray = SESSION_DETAILS != null ?
+      Object.keys(SESSION_DETAILS).map(
+        (key) => [key, (SESSION_DETAILS[key])])
       :
       [];
     const serverStatusArray = status != null ?
@@ -99,20 +141,19 @@ class SessionInfo extends Component {
     // TODO: Fetch URL from Cloud Providers
     const sessionUrl =
       sessionId && connectedUrl ?
-        connectedUrl + sessionId
+        `${connectedUrl}session/${sessionId}`
         :
         'Error Fetching Session Url';
-    const intoHTML = (text) => <p>{text}</p>;
 
     switch (name) {
-      case 'Session ID': return intoHTML(sessionId);
-      case 'Session URL': return intoHTML(sessionUrl);
-      case 'Server Details': return this.getTable(serverDetailsArray, 'serverDetails', isOuterTable);
-      case 'Session Length': return intoHTML(this.generateSessionTime());
-      case 'Session Capabilities': return this.getTable(capsArray, 'caps', isOuterTable);
-      case 'Server Details from Server': return this.getTable(serverStatusArray, 'serverStatus', isOuterTable);
-      case 'Currently Active App ID': return intoHTML(appId);
-      default: return intoHTML('Invalid Header');
+      case 'Session ID': return sessionId;
+      case 'Session URL': return sessionUrl;
+      case 'Server Details': return this.getTable([...serverDetailsArray, ...serverStatusArray],
+        SERVER_TABLE_KEY, isOuterTable);
+      case 'Session Length': return this.state.time;
+      case 'Session Details': return this.getTable(sessionArray, SESSION_TABLE_KEY, isOuterTable);
+      case 'Currently Active App ID': return appId;
+      default: return name;
     }
   }
 
@@ -121,7 +162,7 @@ class SessionInfo extends Component {
     const sessionArray = Object.keys(SESSION_OBJ).map(
       (key) => [key, String(SESSION_OBJ[key])]);
 
-    return this.getTable(sessionArray, 'session', isOuterTable);
+    return this.getTable(sessionArray, OUTER_TABLE_KEY, isOuterTable);
   }
 }
 


### PR DESCRIPTION
This PR fixes some bugs and frontend features of the session information panel. 

This includes: 

1.) Updating Session URL to display the correct URL: http://<host>:<port><path>/session/<session-id>
2.) Fixing some padding issues 
3.) Setting the session timer to update live instead of updating when user interacts with the UI
4.) Combining the server details into one row
5.) Removed the session CAPS row with session details, which now retrieves all session info from the webdriver.io command 'getSession'

However, I could not determine a way to display the scroll bar on default, still looking into antd docs to determine what properties need to change in order to accomplish that.

<img width="1282" alt="image" src="https://user-images.githubusercontent.com/85202734/170762993-080d9da6-4de5-489a-9351-8a2eadcb759d.png">
