### PR TITLE
feat: improve element selection

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -22,6 +22,13 @@ export const SET_FIELD_VALUE = 'SET_FIELD_VALUE';
 export const SET_EXPANDED_PATHS = 'SET_EXPANDED_PATHS';
 export const SELECT_HOVERED_ELEMENT = 'SELECT_HOVERED_ELEMENT';
 export const UNSELECT_HOVERED_ELEMENT = 'UNSELECT_HOVERED_ELEMENT';
+
+export const SELECT_HOVERED_CENTROID = 'SELECT_HOVERED_CENTROID';
+export const UNSELECT_HOVERED_CENTROID = 'UNSELECT_HOVERED_CENTROID';
+export const SELECT_CENTROID = 'SELECT_CENTROID';
+export const UNSELECT_CENTROID = 'UNSELECT_CENTROID';
+export const SET_SHOW_CENTROIDS = 'SET_SHOW_CENTROIDS';
+
 export const SHOW_SEND_KEYS_MODAL = 'SHOW_SEND_KEYS_MODAL';
 export const HIDE_SEND_KEYS_MODAL = 'HIDE_SEND_KEYS_MODAL';
 export const QUIT_SESSION_REQUESTED = 'QUIT_SESSION_REQUESTED';
@@ -138,6 +145,31 @@ export function selectElement (path) {
 export function unselectElement () {
   return (dispatch) => {
     dispatch({type: UNSELECT_ELEMENT});
+  };
+}
+
+
+export function selectCentroid (path) {
+  return (dispatch) => {
+    dispatch({type: SELECT_CENTROID, path});
+  };
+}
+
+export function unselectCentroid () {
+  return (dispatch) => {
+    dispatch({type: UNSELECT_CENTROID});
+  };
+}
+
+export function selectHoveredCentroid (path) {
+  return (dispatch) => {
+    dispatch({type: SELECT_HOVERED_CENTROID, path});
+  };
+}
+
+export function unselectHoveredCentroid () {
+  return (dispatch) => {
+    dispatch({type: UNSELECT_HOVERED_CENTROID});
   };
 }
 
@@ -460,6 +492,14 @@ export function selectAppMode (mode) {
       const action = applyClientMethod({ methodName: 'switchContext', args: [NATIVE_APP] });
       await action(dispatch, getState);
     }
+  };
+}
+
+export function toggleShowCentroids () {
+  return (dispatch, getState) => {
+    const {showCentroids} = getState().inspector;
+    const show = !showCentroids;
+    dispatch({type: SET_SHOW_CENTROIDS, show});
   };
 }
 

--- a/app/renderer/components/Inspector/HighlighterCentroid.js
+++ b/app/renderer/components/Inspector/HighlighterCentroid.js
@@ -1,0 +1,127 @@
+import React, { Component } from 'react';
+import InspectorCSS from './Inspector.css';
+import { RENDER_CENTROID_AS } from './shared';
+
+const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
+const CENTROID_STYLES = {
+  VISIBLE: 'visible',
+  HIDDEN: 'hidden',
+  CONTAINER: '50%',
+  NON_CONTAINER: '0%',
+};
+
+// Generate new coordinates along a circlular trajectory
+// for overlapping elements only
+function getCentroidPos (type, angle, coord) {
+  return type === OVERLAP ?
+    `calc((${angle} * 2.6vh) + ${coord}px)`
+    :
+    coord;
+}
+
+/**
+ * Shows all element centroids
+ */
+export default class HighlighterCentroid extends Component {
+
+  onMouseEnter (path) {
+    const {selectHoveredElement, selectHoveredCentroid,
+           centroidType} = this.props;
+    if (centroidType === EXPAND) {
+      selectHoveredCentroid(path);
+    } else {
+      selectHoveredElement(path);
+    }
+  }
+
+  onMouseLeave () {
+    const {unselectHoveredElement, unselectHoveredCentroid,
+           centroidType} = this.props;
+    if (centroidType === EXPAND) {
+      unselectHoveredCentroid();
+    } else {
+      unselectHoveredElement();
+    }
+  }
+
+  onClickCentroid (path) {
+    const {selectElement, unselectElement,
+           selectCentroid, unselectCentroid, centroidType,
+           selectedCentroid, selectedElementPath} = this.props;
+    if (centroidType === EXPAND) {
+      if (path === selectedCentroid) {
+        unselectCentroid();
+      } else {
+        selectCentroid(path);
+      }
+    } else {
+      if (path === selectedElementPath) {
+        unselectElement();
+      } else {
+        selectElement(path);
+      }
+    }
+  }
+
+  render () {
+    const {selectedElementPath, hoveredElement = {}, element, elementProperties,
+           centroidType, hoveredCentroid, selectedCentroid} = this.props;
+    const {path: hoveredPath} = hoveredElement;
+    const {centerX, centerY, angleX, angleY,
+           keyCode, path, container} = elementProperties;
+    const centroidClasses = [InspectorCSS['centroid-box']];
+    centroidClasses.push(InspectorCSS[centroidType]);
+
+    // Highlght centroids that represent elements
+    if (centroidType !== EXPAND) {
+      if (hoveredPath === path) {
+        centroidClasses.push(InspectorCSS['hovered-element-box']);
+      }
+      if (selectedElementPath === path) {
+        centroidClasses.push(InspectorCSS['inspected-element-box']);
+      }
+    }
+
+    // Highlight +/- centroids
+    if (centroidType !== CENTROID) {
+      if (hoveredCentroid === keyCode) {
+        centroidClasses.push(InspectorCSS['hovered-element-box']);
+      }
+      if (selectedCentroid === keyCode && !element) {
+        centroidClasses.push(InspectorCSS['inspected-element-box']);
+      }
+    }
+
+    const overlapDivStyle = {
+      visibility:
+        keyCode === selectedCentroid ?
+          CENTROID_STYLES.VISIBLE : CENTROID_STYLES.HIDDEN,
+    };
+
+    const centroidDivStyle = {
+      left: getCentroidPos(centroidType, angleX, centerX),
+      top: getCentroidPos(centroidType, angleY, centerY),
+      borderRadius:
+        element && !container ?
+          CENTROID_STYLES.NON_CONTAINER : CENTROID_STYLES.CONTAINER,
+      ...(centroidType === OVERLAP ? overlapDivStyle : {})
+    };
+
+    const placeHolder = centroidType === EXPAND ?
+      <div className={InspectorCSS['plus-minus']}>
+        {keyCode === selectedCentroid ? '-' : '+'}
+      </div>
+      :
+      <div></div>;
+
+    return <div
+      className={centroidClasses.join(' ').trim()}
+      onMouseOver={() => this.onMouseEnter(path)}
+      onMouseOut={() => this.onMouseLeave()}
+      onClick={() => this.onClickCentroid(path)}
+      key={path}
+      style={centroidDivStyle}>
+      {placeHolder}
+    </div>;
+  }
+}

--- a/app/renderer/components/Inspector/HighlighterRect.js
+++ b/app/renderer/components/Inspector/HighlighterRect.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import InspectorCSS from './Inspector.css';
-import { parseCoordinates } from './shared';
 
 /**
  * Absolute positioned divs that overlay the app screenshot and highlight the bounding
@@ -10,7 +9,7 @@ export default class HighlighterRect extends Component {
 
   render () {
     const {selectedElement = {}, selectHoveredElement, unselectHoveredElement, hoveredElement = {}, selectElement, unselectElement, element,
-           zIndex, scaleRatio, xOffset, elLocation, elSize} = this.props;
+           scaleRatio, xOffset, elLocation, elSize, dimensions} = this.props;
     const {path: hoveredPath} = hoveredElement;
     const {path: selectedPath} = selectedElement;
 
@@ -18,12 +17,7 @@ export default class HighlighterRect extends Component {
     highlighterClasses = [InspectorCSS['highlighter-box']];
 
     if (element) {
-      // Calculate left, top, width and height coordinates
-      const {x1, y1, x2, y2} = parseCoordinates(element);
-      left = x1 / scaleRatio + xOffset;
-      top = y1 / scaleRatio;
-      width = (x2 - x1) / scaleRatio;
-      height = (y2 - y1) / scaleRatio;
+      ({width, height, left, top} = dimensions);
 
       // Add class + special classes to hovered and selected elements
       if (hoveredPath === element.path) {
@@ -47,7 +41,7 @@ export default class HighlighterRect extends Component {
       onMouseOut={unselectHoveredElement}
       onClick={() => key === selectedPath ? unselectElement() : selectElement(key)}
       key={key}
-      style={{zIndex, left: (left || 0), top: (top || 0), width: (width || 0), height: (height || 0)}}>
+      style={{left: (left || 0), top: (top || 0), width: (width || 0), height: (height || 0)}}>
       <div></div>
     </div>;
   }

--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -1,20 +1,159 @@
 import React, { Component } from 'react';
 import HighlighterRect from './HighlighterRect';
+import HighlighterCentroid from './HighlighterCentroid';
 import B from 'bluebird';
-import { SCREENSHOT_INTERACTION_MODE } from './shared';
+import { SCREENSHOT_INTERACTION_MODE, parseCoordinates, RENDER_CENTROID_AS } from './shared';
 
 const {TAP, SWIPE, SELECT} = SCREENSHOT_INTERACTION_MODE;
+const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
 
 /**
  * Shows screenshot of running application and divs that highlight the elements' bounding boxes
  */
 export default class HighlighterRects extends Component {
 
+  getElements (source) {
+    const elementsByOverlap = this.buildElementsWithProps(source, null, [], {});
+    let elements = [];
+
+    // Adjust overlapping elements
+    for (const key of Object.keys(elementsByOverlap)) {
+      if (elementsByOverlap[key].length > 1) {
+        const {centerX, centerY} = elementsByOverlap[key][0].properties;
+
+        // Create new element obj which will be a +/- centroid
+
+        const element = {
+          type: EXPAND,
+          element: null,
+          parent: null,
+          properties: {
+            left: null,
+            top: null,
+            width: null,
+            height: null,
+            centerX,
+            centerY,
+            angleX: null,
+            angleY: null,
+            path: key,
+            keyCode: key,
+            container: null,
+            accessible: null
+          }
+        };
+        elements = [...elements, element,
+          ...this.updateOverlapsAngles(elementsByOverlap[key], key)];
+      } else {
+        elements.push(elementsByOverlap[key][0]);
+      }
+    }
+
+    return elements;
+  }
+
+  // This func creates a new object for each element and determines its properties
+  // 'elements' is an array that stores all prev elements
+  // 'overlaps' is an object which organzies elements by their positions
+  buildElementsWithProps (source, prevElement, elements, overlaps) {
+    if (!source) {
+      return {};
+    }
+    const {scaleRatio} = this.props;
+    const {x1, y1, x2, y2} = parseCoordinates(source);
+    const xOffset = this.highlighterXOffset || 0;
+    const centerPoint = (v1, v2) =>
+      Math.round(v1 + ((v2 - v1) / 2)) / scaleRatio;
+    const obj = {
+      type: CENTROID,
+      element: source,
+      parent: prevElement,
+      properties: {
+        left: x1 / scaleRatio + xOffset,
+        top: y1 / scaleRatio,
+        width: (x2 - x1) / scaleRatio,
+        height: (y2 - y1) / scaleRatio,
+        centerX: centerPoint(x1, x2) + xOffset,
+        centerY: centerPoint(y1, y2),
+        angleX: null,
+        angleY: null,
+        path: source.path,
+        keyCode: null,
+        container: false,
+        accessible: source.attributes.accessible
+      }
+    };
+    const coordinates = `${obj.properties.centerX}.${obj.properties.centerY}`;
+    obj.properties.container = this.isElementContainer(obj, elements);
+
+    elements.push(obj);
+
+    if (source.path) {
+      if (overlaps[coordinates]) {
+        overlaps[coordinates].push(obj);
+      } else {
+        overlaps[coordinates] = [obj];
+      }
+    }
+
+    if (source.children) {
+      for (const childEl of source.children) {
+        this.buildElementsWithProps(childEl, source, elements, overlaps);
+      }
+    }
+
+    return overlaps;
+  }
+
+  isElementContainer (element1, elements) {
+    for (const element2 of elements) {
+      if (element2.element !== element1.element
+        && this.isElementOverElement(element1.properties, element2.properties)
+        && !this.isAncestor(element1.parent, element2.element, elements)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  isElementOverElement (element1, element2) {
+    return element1.left <= element2.left
+        && element1.width >= element2.width
+        && element1.top >= element2.top
+        && element1.height >= element2.height;
+  }
+
+  // Traverse through parent elements until we reach maybeAncestor
+  isAncestor (curElement, maybeAncestor, elements) {
+    if (elements.length > 0) {
+      while (curElement !== null) {
+        if (curElement === maybeAncestor) { return true; }
+
+        for (const elem of elements) {
+          if (elem.element === curElement) { curElement = elem.parent; }
+        }
+      }
+    }
+    return false;
+  }
+
+  // Generate angles for circular positioning for overlaping elements
+  updateOverlapsAngles (elements, key) {
+    const steps = elements.length;
+    for (let step = 0; step < steps; step++) {
+      const [el, elProps] = [elements[step], elements[step].properties];
+      el.type = OVERLAP;
+      elProps.keyCode = key;
+      elProps.angleX = Math.cos(2 * Math.PI * (step / steps));
+      elProps.angleY = Math.sin(2 * Math.PI * (step / steps));
+    }
+    return elements;
+  }
+
   async handleScreenshotClick () {
     const {screenshotInteractionMode, applyClientMethod,
            swipeStart, swipeEnd, setSwipeStart, setSwipeEnd} = this.props;
     const {x, y} = this.state;
-
     if (screenshotInteractionMode === TAP) {
       applyClientMethod({
         methodName: TAP,
@@ -66,38 +205,48 @@ export default class HighlighterRects extends Component {
 
   render () {
     const {source, screenshotInteractionMode, containerEl, searchedForElementBounds,
-           isLocatorTestModalVisible, scaleRatio} = this.props;
+           isLocatorTestModalVisible, scaleRatio, showCentroids} = this.props;
 
-    // Recurse through the 'source' JSON and render a highlighter rect for each element
+    // Array of all element objects with properties to draw rectangles and/or centroids
+    const elements = this.getElements(source);
+
     const highlighterRects = [];
-
+    const highlighterCentroids = [];
     let highlighterXOffset = 0;
+    let screenshotEl = null;
+
     if (containerEl) {
-      const screenshotEl = containerEl.querySelector('img');
+      screenshotEl = containerEl.querySelector('img');
       highlighterXOffset = screenshotEl.getBoundingClientRect().left -
                            containerEl.getBoundingClientRect().left;
     }
 
-    let recursive = (element, zIndex = 0) => {
-      if (!element) {
-        return;
-      }
-      highlighterRects.push(<HighlighterRect {...this.props}
-        element={element}
-        zIndex={zIndex}
-        scaleRatio={scaleRatio}
-        key={element.path}
-        xOffset={highlighterXOffset}
-      />);
-
-      if (element.children) {
-        for (let childEl of element.children) {
-          recursive(childEl, zIndex + 1);
-        }
+    // Displays element rectangles only
+    let renderElements = (source) => {
+      for (const elem of source) {
+        highlighterRects.push(<HighlighterRect {...this.props}
+          dimensions={elem.properties}
+          element={elem.element}
+          scaleRatio={scaleRatio}
+          key={elem.properties.path}
+          xOffset={highlighterXOffset}
+        />);
       }
     };
 
-    // If the use selected an element that they searched for, highlight that element
+    // Displays centroids only
+    let renderCentroids = (centroids) => {
+      for (const elem of centroids) {
+        highlighterCentroids.push(<HighlighterCentroid {...this.props}
+          centroidType={elem.type}
+          elementProperties={elem.properties}
+          element={elem.element}
+          key={elem.properties.path}
+        />);
+      }
+    };
+
+    // If the user selected an element that they searched for, highlight that element
     if (searchedForElementBounds && isLocatorTestModalVisible) {
       const {location: elLocation, size} = searchedForElementBounds;
       highlighterRects.push(<HighlighterRect elSize={size} elLocation={elLocation} scaleRatio={scaleRatio} xOffset={highlighterXOffset} />);
@@ -111,9 +260,12 @@ export default class HighlighterRects extends Component {
 
     // Don't show highlighter rects when Search Elements modal is open
     if (!isLocatorTestModalVisible) {
-      recursive(source);
+      renderElements(elements);
+      if (showCentroids) {
+        renderCentroids(elements);
+      }
     }
 
-    return <div>{ highlighterRects }</div>;
+    return <div>{ highlighterRects }{ highlighterCentroids }</div>;
   }
 }

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -39,10 +39,23 @@
 
 .inspector-main .screenshot-container {
     max-width: 500px;
+    max-height: 90%;
     flex-grow: 1;
     flex-shrink: 2;
     flex-basis: 400px;
 }
+
+.screenshot-container .screenshot-controls {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 38px;
+    margin-bottom: 12px;
+    -webkit-app-region: drag;
+}
+
 
 .inspector-main .screenshot-container img {
     max-width: 100%;
@@ -55,8 +68,7 @@
     width: 100%;
     height: 100%;
     text-align: left;
-    padding-bottom: 13px;
-    position: relative;
+    position: absolute;
     overflow: hidden;
 }
 
@@ -194,23 +206,152 @@
 }
 
 .highlighter-box.inspected-element-box div {
-    background-color: blue;
+    background-color: rgb(90, 90, 178);
     visibility: hidden;
+    transition: background-color 0.2s ease-in-out;
 }
 
 .highlighter-box.hovered-element-box div {
     background-color: yellow;
     visibility: hidden;
+    transition: background-color 0.2s ease-in-out;
 }
 
 .highlighter-box.inspected-element-box.hovered-element-box div {
-    background-color: green;
+    background-color: rgb(100, 255, 100);
+    transition: background-color 0.2s ease-in-out;
 }
 
 .highlighter-box.hovered-element-box div,
 .highlighter-box.inspected-element-box div {
     position: relative;
     height: 100%;
+    width: 100%;
+    visibility: visible;
+}
+
+.centroid-box {
+    width: 2.2vh;
+    height: 2.2vh;
+    border-style: solid;
+    border-color: #ff4141;
+    border-width: 2px;
+    position: absolute;
+    overflow: hidden;
+    cursor: pointer;
+    visibility: visible;
+    transform: translate(-50%, -50%); 
+}
+
+.centroid-box.centroid {
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.centroid-box.centroid.inspected-element-box div {
+    background-color: blue;
+    opacity: 0.5;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.centroid.hovered-element-box div {
+    background-color: #ff0000;
+    opacity: 0.5;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.centroid.inspected-element-box.hovered-element-box div {
+    background-color: green;
+    opacity: 0.5;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.centroid.hovered-element-box div,
+.centroid-box.centroid.inspected-element-box div {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    visibility: visible;
+}
+
+.centroid-box.overlap {
+    border-style: dashed;
+    border-color: #178b00;
+    z-index: 4;
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.centroid-box.overlap.inspected-element-box div {
+    background-color: blue;
+    opacity: 0.5;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.overlap.hovered-element-box div {
+    background-color: #178b00;
+    opacity: 0.5;
+    visibility: hidden;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.overlap.inspected-element-box.hovered-element-box div {
+    background-color: rgb(113, 253, 113);
+    opacity: 0.5;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.overlap.hovered-element-box div,
+.centroid-box.overlap.inspected-element-box div {
+    position: relative;
+    height: 100%;
+    width: 100%;
+    visibility: visible;
+}
+
+.centroid-box.expand {
+    z-index: 3;
+    background-color: #ffffff;
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.plus-minus {
+    position: relative;
+    top: -0.8vh;
+    text-align: center;
+    font-size: 2vh;
+    font-weight: 800;
+    color: #ff4141;
+    opacity: 1;
+    transition: opacity 0.2s ease-in-out, background-color 0.2s ease-in-out;
+}
+
+.centroid-box.expand.inspected-element-box div {
+    background-color: rgb(62, 57, 57);
+    transition: background-color 0.2s ease-in-out;
+    visibility: hidden;
+}
+
+.centroid-box.expand.hovered-element-box div {
+    background-color: #2f2f2f;
+    transition: background-color 0.2s ease-in-out;
+    visibility: hidden;
+}
+
+.centroid-box.expand.inspected-element-box.hovered-element-box div {
+    background-color: rgb(255, 133, 133);
+    transition: background-color 0.2s ease-in-out;
+    
+}
+
+.centroid-box.expand.hovered-element-box div,
+.centroid-box.expand.inspected-element-box div {
+    position: relative;
+    height: 150%;
     width: 100%;
     visibility: visible;
 }

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { debounce } from 'lodash';
 import { SCREENSHOT_INTERACTION_MODE, INTERACTION_MODE, APP_MODE } from './shared';
-import { Card, Button, Spin, Tooltip, Modal, Tabs } from 'antd';
+import { Card, Button, Spin, Tooltip, Modal, Tabs, Switch } from 'antd';
 import Screenshot from './Screenshot';
 import SelectedElement from './SelectedElement';
 import Source from './Source';
@@ -15,6 +15,8 @@ import {
   ScanOutlined,
   SwapRightOutlined,
   ArrowLeftOutlined,
+  CheckCircleOutlined,
+  CloseCircleOutlined,
   ReloadOutlined,
   EyeOutlined,
   PauseOutlined,
@@ -186,14 +188,47 @@ export default class Inspector extends Component {
            screenshotInteractionMode, isFindingElementsTimes, visibleCommandMethod,
            selectedInteractionMode, selectInteractionMode, selectAppMode, setVisibleCommandResult,
            showKeepAlivePrompt, keepSessionAlive, sourceXML, t, visibleCommandResult,
-           mjpegScreenshotUrl, isAwaitingMjpegStream} = this.props;
+           mjpegScreenshotUrl, isAwaitingMjpegStream, toggleShowCentroids, showCentroids} = this.props;
     const {path} = selectedElement;
 
     const showScreenshot = ((screenshot && !screenshotError) ||
                             (mjpegScreenshotUrl && !isAwaitingMjpegStream));
 
+    let screenShotControls = <div className={InspectorStyles['screenshot-controls']}>
+      <div className={InspectorStyles['action-controls']}>
+        <Tooltip title={t(showCentroids ? 'Hide Element Handles' : 'Show Element Handles')} placement="topRight">
+          <Switch
+            checkedChildren={<CheckCircleOutlined />}
+            unCheckedChildren={<CloseCircleOutlined />}
+            defaultChecked={false}
+            onChange={() => toggleShowCentroids()}
+          />
+        </Tooltip>
+      </div>
+      <div className={InspectorStyles['action-controls']}>
+        <ButtonGroup value={screenshotInteractionMode}>
+          <Tooltip title={t('Select Elements')}>
+            <Button icon={<SelectOutlined/>} onClick={() => {this.screenshotInteractionChange(SELECT);}}
+              type={screenshotInteractionMode === SELECT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+            />
+          </Tooltip>
+          <Tooltip title={t('Swipe By Coordinates')}>
+            <Button icon={<SwapRightOutlined/>} onClick={() => {this.screenshotInteractionChange(SWIPE);}}
+              type={screenshotInteractionMode === SWIPE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+            />
+          </Tooltip>
+          <Tooltip title={t('Tap By Coordinates')}>
+            <Button icon={<ScanOutlined/>} onClick={() => {this.screenshotInteractionChange(TAP);}}
+              type={screenshotInteractionMode === TAP ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+            />
+          </Tooltip>
+        </ButtonGroup>
+      </div>
+    </div>;
+
     let main = <div className={InspectorStyles['inspector-main']} ref={(el) => {this.screenAndSourceEl = el;}}>
       <div id='screenshotContainer' className={InspectorStyles['screenshot-container']} ref={(el) => {this.screenshotEl = el;}}>
+        {screenShotControls}
         {showScreenshot && <Screenshot {...this.props} scaleRatio={this.state.scaleRatio}/>}
         {screenshotError && t('couldNotObtainScreenshot', {screenshotError})}
         {!showScreenshot &&
@@ -269,26 +304,6 @@ export default class Inspector extends Component {
       </ButtonGroup>
     </div>;
 
-    let actionControls = <div className={InspectorStyles['action-controls']}>
-      <ButtonGroup value={screenshotInteractionMode}>
-        <Tooltip title={t('Select Elements')}>
-          <Button icon={<SelectOutlined/>} onClick={() => {this.screenshotInteractionChange(SELECT);}}
-            type={screenshotInteractionMode === SELECT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-          />
-        </Tooltip>
-        <Tooltip title={t('Swipe By Coordinates')}>
-          <Button icon={<SwapRightOutlined/>} onClick={() => {this.screenshotInteractionChange(SWIPE);}}
-            type={screenshotInteractionMode === SWIPE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-          />
-        </Tooltip>
-        <Tooltip title={t('Tap By Coordinates')}>
-          <Button icon={<ScanOutlined/>} onClick={() => {this.screenshotInteractionChange(TAP);}}
-            type={screenshotInteractionMode === TAP ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-          />
-        </Tooltip>
-      </ButtonGroup>
-    </div>;
-
     const generalControls = <ButtonGroup>
       <Tooltip title={t('Back')}>
         <Button id='btnGoBack' icon={<ArrowLeftOutlined/>} onClick={() => applyClientMethod({methodName: 'back'})}/>
@@ -316,7 +331,6 @@ export default class Inspector extends Component {
 
     let controls = <div className={InspectorStyles['inspector-toolbar']}>
       {appModeControls}
-      {actionControls}
       {generalControls}
     </div>;
 

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -120,7 +120,7 @@ class Screenshot extends Component {
             <p>{t('xCoordinate', {x})}</p>
             <p>{t('yCoordinate', {y})}</p>
           </div>}
-          {swipeInstructions && <Tooltip visible={true} placement="top" title={swipeInstructions}>{screenImg}</Tooltip>}
+          {swipeInstructions && <Tooltip visible={true} title={swipeInstructions} placement="topLeft">{screenImg}</Tooltip>}
           {!swipeInstructions && screenImg}
           {screenshotInteractionMode === SELECT && this.containerEl && <HighlighterRects
             {...this.props}

--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -6,7 +6,11 @@ export function parseCoordinates (element) {
 
   if (bounds) {
     let boundsArray = bounds.split(/\[|\]|,/).filter((str) => str !== '');
-    return {x1: boundsArray[0], y1: boundsArray[1], x2: boundsArray[2], y2: boundsArray[3]};
+    const x1 = parseInt(boundsArray[0], 10);
+    const x2 = parseInt(boundsArray[2], 10);
+    const y1 = parseInt(boundsArray[1], 10);
+    const y2 = parseInt(boundsArray[3], 10);
+    return { x1, y1, x2, y2 };
   } else if (x) {
     x = parseInt(x, 10);
     y = parseInt(y, 10);
@@ -46,6 +50,16 @@ export function getLocators (attributes, sourceXML) {
   }
   return res;
 }
+
+// 3 Types of Centroids:
+// CENTROID is the circle/square displayed on the screen
+// EXPAND is the +/- circle displayed on the screen
+// OVERLAP is the same as CENTROID but is only visible when clicked on +/- circle
+export const RENDER_CENTROID_AS = {
+  CENTROID: 'centroid',
+  EXPAND: 'expand',
+  OVERLAP: 'overlap'
+};
 
 export const SCREENSHOT_INTERACTION_MODE = {
   SELECT: 'select',

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -13,7 +13,8 @@ import { SET_SOURCE_AND_SCREENSHOT, QUIT_SESSION_REQUESTED, QUIT_SESSION_DONE,
          SELECT_ACTION_GROUP, SELECT_SUB_ACTION_GROUP, SET_APP_MODE,
          SELECT_INTERACTION_MODE, ENTERING_ACTION_ARGS, SET_ACTION_ARG, REMOVE_ACTION, SET_CONTEXT,
          SET_KEEP_ALIVE_INTERVAL, SET_USER_WAIT_TIMEOUT, SET_LAST_ACTIVE_MOMENT, SET_VISIBLE_COMMAND_RESULT,
-         SET_AWAITING_MJPEG_STREAM, SET_APP_ID, SET_SERVER_STATUS, SET_SESSION_TIME,
+         SET_AWAITING_MJPEG_STREAM, SET_APP_ID, SET_SERVER_STATUS, SET_SESSION_TIME, SELECT_HOVERED_CENTROID, UNSELECT_HOVERED_CENTROID, SELECT_CENTROID, UNSELECT_CENTROID,
+         SET_SHOW_CENTROIDS,
 } from '../actions/Inspector';
 import { SCREENSHOT_INTERACTION_MODE, INTERACTION_MODE, APP_MODE } from '../components/Inspector/shared';
 
@@ -33,6 +34,7 @@ const INITIAL_STATE = {
   actionFramework: DEFAULT_FRAMEWORK,
   sessionDetails: {},
   isLocatorTestModalVisible: false,
+  showCentroids: false,
   locatorTestStrategy: 'id',
   locatorTestValue: '',
   isSearchingForElements: false,
@@ -120,6 +122,15 @@ export default function inspector (state = INITIAL_STATE, action) {
         selectedElementVariableType: null,
       };
 
+    case SELECT_CENTROID:
+      return {
+        ...state,
+        selectedCentroid: action.path,
+      };
+
+    case UNSELECT_CENTROID:
+      return omit(state, 'selectedCentroid');
+
     case SET_SELECTED_ELEMENT_ID:
       return {
         ...state,
@@ -143,6 +154,15 @@ export default function inspector (state = INITIAL_STATE, action) {
 
     case UNSELECT_HOVERED_ELEMENT:
       return omit(state, 'hoveredElement');
+
+    case SELECT_HOVERED_CENTROID:
+      return {
+        ...state,
+        hoveredCentroid: action.path,
+      };
+
+    case UNSELECT_HOVERED_CENTROID:
+      return omit(state, 'hoveredCentroid');
 
     case METHOD_CALL_REQUESTED:
       return {
@@ -397,6 +417,12 @@ export default function inspector (state = INITIAL_STATE, action) {
       return {
         ...state,
         appMode: action.mode,
+      };
+
+    case SET_SHOW_CENTROIDS:
+      return {
+        ...state,
+        showCentroids: action.show,
       };
 
     case ENTERING_ACTION_ARGS:

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -138,6 +138,8 @@
   "selector": "Selector:",
   "couldNotObtainScreenshot": "Could not obtain screenshot: {{screenshotError}}",
   "selectElementInSource": "Select an element in the source to begin.",
+  "Show Element Handles": "Show Element Handles",
+  "Hide Element Handles": "Hide Element Handles",
   "Select Elements": "Select Elements",
   "Swipe By Coordinates": "Swipe By Coordinates",
   "Tap By Coordinates": "Tap By Coordinates",


### PR DESCRIPTION
This PR closes #276 

This PR seeks to improve the element selection within Appium Inspector by rendering all the elements as small centroids so users can see and highlight certain difficult elements. Square boxes represent non container elements, circle centroids represent containers, dashed green centroids/boxes represent elements not in the current hierarchy/overlapping elements, and the +/- circles are just expandable circles to show those overlapping elements.

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/85202734/175578643-f628381f-a780-467a-821b-f69ab0cc28d0.png">
