### PR TITLE
fix: Appium recorder bug - Python code generated wrong for XPATH

### DIFF
--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -43,7 +43,7 @@ driver.quit()`;
 
   codeFor_findAndAssign (strategy, locator, localVar, isArray) {
     let suffixMap = {
-      xpath: 'AppiumBy.CLASS_NAME',
+      xpath: 'AppiumBy.XPATH',
       'accessibility id': 'AppiumBy.ACCESSIBILITY_ID',
       'id': 'AppiumBy.ID',
       'name': 'AppiumBy.NAME',


### PR DESCRIPTION
This PR Closes #438 

This PR updates the code generated for python when finding an element using XPATH.