### PR TITLE
fix: Tap by coordinates does not work inside the current pointer coordinates overlay area 

### DIFF
--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -116,7 +116,7 @@ class Screenshot extends Component {
           onMouseMove={this.handleMouseMove.bind(this)}
           onMouseOut={this.handleMouseOut.bind(this)}
           className={styles.screenshotBox}>
-          {x !== null && <div className={styles.coordinatesContainer}>
+          {screenshotInteractionMode !== SELECT && <div className={styles.coordinatesContainer}>
             <p>{t('xCoordinate', {x})}</p>
             <p>{t('yCoordinate', {y})}</p>
           </div>}


### PR DESCRIPTION
This PR closes #480 

I removed the condition to check if x is null to allow taps to occur within the coordinate overlay on the top left when user is in the 'Tap by Coordinates' mode. This also allows the user to see the coordinate values within the overlay which I think will be useful!