### PR TITLE
Fix: Tap by coordinates inside the coordinates overlay does not show correct Y values

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -494,6 +494,15 @@
     fill: rgba(255, 153, 153, 0.8);
 }
 
+.tapDiv {
+    position: absolute;
+    z-index: 100000000;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%; 
+}
+
 .innerScreenshotContainer {
     display: flex;
     flex-direction: column;

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -140,6 +140,9 @@ class Screenshot extends Component {
               />}
             </svg>
           }
+          {screenshotInteractionMode === TAP &&
+            <div className={styles.tapDiv}></div>
+          }
         </div>
       </div>
     </Spin>;


### PR DESCRIPTION
This PR Closes #530 

The overlay that shows the x and y values during a tap gesture within the inspector has now been fixed so that it shows the correct and accurate y-values. 

https://user-images.githubusercontent.com/85202734/181113730-b42c2302-4465-411b-8e2b-8830b0de7903.mov


