### PR TITLE
feat: show spinner on source tree when mjpegScreenshotUrl is provided

### DIFF
--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -170,8 +170,8 @@ class Screenshot extends Component {
 
     const points = this.getGestureCoordinates();
 
-    // Show the screenshot and highlighter rects. Show loading indicator if a method call is in progress.
-    return <Spin size='large' spinning={!!methodCallInProgress}>
+    // Show the screenshot and highlighter rects. Show loading indicator if a method call is in progress when in screenshot mode.
+    return <Spin size='large' spinning={!!methodCallInProgress && !mjpegScreenshotUrl}>
       <div className={styles.innerScreenshotContainer}>
         <div ref={(containerEl) => { this.containerEl = containerEl; }}
           style={screenshotStyle}

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Tree } from 'antd';
+import { Tree, Spin } from 'antd';
 import LocatorTestModal from './LocatorTestModal';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
@@ -60,6 +60,8 @@ class Source extends Component {
       selectedElement = {},
       showSourceAttrs,
       t,
+      mjpegScreenshotUrl,
+      methodCallInProgress,
     } = this.props;
     const {path} = selectedElement;
 
@@ -78,6 +80,7 @@ class Source extends Component {
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
       {/* Must switch to a new antd Tree component when there's changes to treeData  */}
+     <Spin size='large' spinning={!!methodCallInProgress && !!mjpegScreenshotUrl}>
       {treeData ?
         <Tree
           defaultExpandAll={true}
@@ -90,6 +93,7 @@ class Source extends Component {
         <Tree
           treeData={[]} />
       }
+      </Spin>
       {!source && !sourceError &&
         <i>{t('Gathering initial app source…')}</i>
       }

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -80,19 +80,19 @@ class Source extends Component {
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
       {/* Must switch to a new antd Tree component when there's changes to treeData  */}
-     <Spin size='large' spinning={!!methodCallInProgress && !!mjpegScreenshotUrl}>
-      {treeData ?
-        <Tree
-          defaultExpandAll={true}
-          onExpand={setExpandedPaths}
-          expandedKeys={expandedPaths}
-          onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
-          selectedKeys={[path]}
-          treeData={treeData} />
-        :
-        <Tree
-          treeData={[]} />
-      }
+      <Spin size='large' spinning={!!methodCallInProgress && !!mjpegScreenshotUrl}>
+        {treeData ?
+          <Tree
+            defaultExpandAll={true}
+            onExpand={setExpandedPaths}
+            expandedKeys={expandedPaths}
+            onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
+            selectedKeys={[path]}
+            treeData={treeData} />
+          :
+          <Tree
+            treeData={[]} />
+        }
       </Spin>
       {!source && !sourceError &&
         <i>{t('Gathering initial app source…')}</i>


### PR DESCRIPTION
Fixes #504 

I have tested it for both scenarios with and without `mjpegScreenshotUrl`

