### PR TITLE
fix: crash when accessing 'accessible' attribute in non mobile driver…

### DIFF
--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -83,7 +83,7 @@ export default class HighlighterRects extends Component {
         path: source.path,
         keyCode: null,
         container: false,
-        accessible: source.attributes.accessible
+        accessible: source.attributes ? source.attributes.accessible : null
       }
     };
     const coordinates = `${obj.properties.centerX}.${obj.properties.centerY}`;


### PR DESCRIPTION
… (fix #662)