### PR TITLE
fix: added utils for encoding tap/swip coords properly

### DIFF
--- a/app/renderer/lib/client-frameworks/framework.js
+++ b/app/renderer/lib/client-frameworks/framework.js
@@ -1,3 +1,5 @@
+import { DEFAULT_TAP, DEFAULT_SWIPE } from '../../components/Inspector/shared';
+
 export default class Framework {
 
   constructor (host, port, path, https, caps) {
@@ -11,6 +13,23 @@ export default class Framework {
     this.localVarCount = 0;
     this.localVarCache = {};
     this.lastAssignedVar = null;
+  }
+
+  static getTapCoordinatesFromPointerActions (pointerActions) {
+    const pointerMoveAction = pointerActions[DEFAULT_TAP.POINTER_NAME][0];
+    return {x: pointerMoveAction.x, y: pointerMoveAction.y};
+  }
+
+  static getSwipeCoordinatesFromPointerActions (pointerActions) {
+    const pointerMoveActionStart = pointerActions[DEFAULT_SWIPE.POINTER_NAME][0];
+    const pointerMoveActionEnd = pointerActions[DEFAULT_SWIPE.POINTER_NAME][2];
+
+    return {
+      x1: pointerMoveActionStart.x,
+      y1: pointerMoveActionStart.y,
+      x2: pointerMoveActionEnd.x,
+      y2: pointerMoveActionEnd.y
+    };
   }
 
   get serverUrl () {

--- a/app/renderer/lib/client-frameworks/framework.js
+++ b/app/renderer/lib/client-frameworks/framework.js
@@ -15,12 +15,12 @@ export default class Framework {
     this.lastAssignedVar = null;
   }
 
-  static getTapCoordinatesFromPointerActions (pointerActions) {
+  getTapCoordinatesFromPointerActions (pointerActions) {
     const pointerMoveAction = pointerActions[DEFAULT_TAP.POINTER_NAME][0];
     return {x: pointerMoveAction.x, y: pointerMoveAction.y};
   }
 
-  static getSwipeCoordinatesFromPointerActions (pointerActions) {
+  getSwipeCoordinatesFromPointerActions (pointerActions) {
     const pointerMoveActionStart = pointerActions[DEFAULT_SWIPE.POINTER_NAME][0];
     const pointerMoveActionEnd = pointerActions[DEFAULT_SWIPE.POINTER_NAME][2];
 

--- a/app/renderer/lib/client-frameworks/java.js
+++ b/app/renderer/lib/client-frameworks/java.js
@@ -107,11 +107,15 @@ ${this.indent(code, 4)}
     return `driver.navigate().back();`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `(new TouchAction(driver)).tap(${x}, ${y}).perform()`;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `(new TouchAction(driver))
   .press(PointOption.point(${x1}, ${y1}}))
   .moveTo(PointOption.point(${x2}, ${y2}}))

--- a/app/renderer/lib/client-frameworks/java.js
+++ b/app/renderer/lib/client-frameworks/java.js
@@ -108,13 +108,13 @@ ${this.indent(code, 4)}
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `(new TouchAction(driver)).tap(${x}, ${y}).perform()`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `(new TouchAction(driver))
   .press(PointOption.point(${x1}, ${y1}}))

--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -85,13 +85,13 @@ ${code}
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `${this.type}.tap(${x}, ${y});`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `${this.type}.swipeScreen(${x1}, ${y1}, ${x2}, ${y2});`;
   }

--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -84,11 +84,15 @@ ${code}
     return `${this.type}.back();`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `${this.type}.tap(${x}, ${y});`;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `${this.type}.swipeScreen(${x1}, ${y1}, ${x2}, ${y2});`;
   }
 

--- a/app/renderer/lib/client-frameworks/js-wd.js
+++ b/app/renderer/lib/client-frameworks/js-wd.js
@@ -71,14 +71,18 @@ main().catch(console.log);
     return `await driver.back();`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `await (new wd.TouchAction(driver))
   .tap({x: ${x}, y: ${y}})
   .perform()
     `;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `await (new wd.TouchAction(driver))
   .press({x: ${x1}, y: ${y1}})
   .moveTo({x: ${x2}, y: ${y2}})

--- a/app/renderer/lib/client-frameworks/js-wd.js
+++ b/app/renderer/lib/client-frameworks/js-wd.js
@@ -72,7 +72,7 @@ main().catch(console.log);
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `await (new wd.TouchAction(driver))
   .tap({x: ${x}, y: ${y}})
@@ -81,7 +81,7 @@ main().catch(console.log);
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `await (new wd.TouchAction(driver))
   .press({x: ${x1}, y: ${y1}})

--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -84,13 +84,13 @@ main().catch(console.log);`;
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `await driver.touchAction({actions: 'tap', x: ${x}, y: ${y}})`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `await driver.touchAction([
   {action: 'press', x: ${x1}, y: ${y1}},

--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -83,11 +83,15 @@ main().catch(console.log);`;
     return `await driver.back();`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `await driver.touchAction({actions: 'tap', x: ${x}, y: ${y}})`;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `await driver.touchAction([
   {action: 'press', x: ${x1}, y: ${y1}},
   {action: 'moveTo', x: ${x2}, y: ${y2}},

--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -81,7 +81,7 @@ driver.quit()`;
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `actions = ActionChains(driver)
 actions.w3c_actions = ActionBuilder(driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
@@ -94,7 +94,7 @@ actions.perform()
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `actions = ActionChains(driver)
 actions.w3c_actions = ActionBuilder(driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))

--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -80,7 +80,9 @@ driver.quit()`;
     return `driver.back()`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `actions = ActionChains(driver)
 actions.w3c_actions = ActionBuilder(driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
 actions.w3c_actions.pointer_action.move_to_location(${x}, ${y})
@@ -91,7 +93,9 @@ actions.perform()
     `;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `actions = ActionChains(driver)
 actions.w3c_actions = ActionBuilder(driver, mouse=PointerInput(interaction.POINTER_TOUCH, "touch"))
 actions.w3c_actions.pointer_action.move_to_location(${x1}, ${y1})

--- a/app/renderer/lib/client-frameworks/robot.js
+++ b/app/renderer/lib/client-frameworks/robot.js
@@ -99,13 +99,13 @@ ${this.indent(code, 4)}
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `Tap    ${this.lastID}    ${x}    ${y}`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `Swipe    ${x1}    ${y1}    ${x2}    ${y2}`;
   }

--- a/app/renderer/lib/client-frameworks/robot.js
+++ b/app/renderer/lib/client-frameworks/robot.js
@@ -98,11 +98,15 @@ ${this.indent(code, 4)}
     return `Go Back`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `Tap    ${this.lastID}    ${x}    ${y}`;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `Swipe    ${x1}    ${y1}    ${x2}    ${y2}`;
   }
 

--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -69,7 +69,9 @@ driver.quit`;
     return `driver.back`;
   }
 
-  codeFor_tap (varNameIgnore, varIndexIgnore, x, y) {
+  codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+
     return `driver
   .action
   .move_to_location(${x}, ${y})
@@ -79,7 +81,9 @@ driver.quit`;
   `;
   }
 
-  codeFor_swipe (varNameIgnore, varIndexIgnore, x1, y1, x2, y2) {
+  codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
+    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+
     return `driver
   .action
   .move_to_location(${x1}, ${y1})

--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -70,7 +70,7 @@ driver.quit`;
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x, y} = Framework.getTapCoordinatesFromPointerActions(pointerActions);
+    const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
 
     return `driver
   .action
@@ -82,7 +82,7 @@ driver.quit`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
-    const {x1, y1, x2, y2} = Framework.getSwipeCoordinatesFromPointerActions(pointerActions);
+    const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
 
     return `driver
   .action


### PR DESCRIPTION
The method for calling the various `codeFor_*` functions doesn't seem to be aligned with the way that the corresponding actions are constructed to execute a task. E.g., a swipe consists of _move, down, pause, release_, under a specific pointer, _finger1_. These functions are, instead, expecting x and y coordinates.

This patch add some util functions to the `Framework` class so that its subclasses can write the appropriate code for _tap_ and _swipe_ actions by unpacking the more complex pointer action object that is constructed elsewhere within the inspector.

fixes: #615 