### PR TITLE
chore: relax getTimeouts interval

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -107,7 +107,7 @@ export const CLEAR_TAP_COORDINATES = 'CLEAR_TAP_COORDINATES';
 
 export const TOGGLE_SHOW_ATTRIBUTES = 'TOGGLE_SHOW_ATTRIBUTES';
 
-const KEEP_ALIVE_PING_INTERVAL = 5 * 1000;
+const KEEP_ALIVE_PING_INTERVAL = 20 * 1000;  
 const NO_NEW_COMMAND_LIMIT = 24 * 60 * 60 * 1000; // Set timeout to 24 hours
 const WAIT_FOR_USER_KEEP_ALIVE = 60 * 60 * 1000; // Give user 1 hour to reply
 

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -107,7 +107,7 @@ export const CLEAR_TAP_COORDINATES = 'CLEAR_TAP_COORDINATES';
 
 export const TOGGLE_SHOW_ATTRIBUTES = 'TOGGLE_SHOW_ATTRIBUTES';
 
-const KEEP_ALIVE_PING_INTERVAL = 20 * 1000;  
+const KEEP_ALIVE_PING_INTERVAL = 20 * 1000;
 const NO_NEW_COMMAND_LIMIT = 24 * 60 * 60 * 1000; // Set timeout to 24 hours
 const WAIT_FOR_USER_KEEP_ALIVE = 60 * 60 * 1000; // Give user 1 hour to reply
 


### PR DESCRIPTION
This interval is how often appium inspector sends getTimeouts request to keep the session alive.

The default newCommadnTimeout in appium inspector is 3600, so 5 sec is not necessary interval. 20 sec, or more also should be sufficient.


Potentially this will slightly improve https://github.com/appium/appium-inspector/issues/736