### PR TITLE
style: improve CSS on inspector screen

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -38,7 +38,7 @@
 
 .inspector-main .screenshot-container {
     max-width: 500px;
-    max-height: 90%;
+    max-height: calc(100% - 50px);
     flex-grow: 1;
     flex-shrink: 2;
     flex-basis: 400px;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -11,7 +11,6 @@
     justify-content: center;
     width: 100%;
     height: 50px;
-    margin-bottom: 12px;
     background: linear-gradient(180deg, #e2e2e2, #e0e0e0, 10%, #d6d6d6, 50%, #cacaca);
     border-top: 1px solid #f5f4f5;
     border-bottom: 1px solid #a5a4a5;
@@ -32,9 +31,9 @@
     display: flex;
     flex: 1;
     flex-direction: row;
-    padding: 0em 1em 0 1em;
+    padding: 1em;
     max-width: 100%;
-    height: calc(100% - 48px);
+    height: calc(100% - 50px);
 }
 
 .inspector-main .screenshot-container {
@@ -81,7 +80,6 @@
     flex-grow: 3;
     flex-basis: 550px;
     min-width: 380px;
-    padding-bottom: 1em;
     padding-left: 1em;
     display: flex;
     flex-flow: column;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -93,6 +93,10 @@
     padding: 0px 12px;
 }
 
+.inspector-main :global(.ant-card-head-wrapper) {
+    max-height: 48px;
+}
+
 .inspector-main :global(.ant-card-body) {
     height: calc(100% - 48px);
     padding: 12px;


### PR DESCRIPTION
Following up from #730, I noticed a few other quick CSS fixes on the inspector screen:

* Ensure vertical centering for the source tree container header (now matches the selected element container header)
* Align the bottom coordinates of the screenshot and selected element containers with the source tree container
  * This also fixes the issue where, if an element was selected or the source tree expanded, the panels vertically expanded by 14px. Still not sure of the root cause, but the symptoms are fixed.