### PR TITLE
chore(deps): update xmldom to @xmldom/xmldom 0.8.7

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -1,4 +1,4 @@
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import xpath from 'xpath';
 
 export function pixelsToPercentage (px, maxPixels) {

--- a/app/renderer/util.js
+++ b/app/renderer/util.js
@@ -3,7 +3,7 @@ import { withTranslation as wt } from 'react-i18next';
 import _ from 'lodash';
 import { log } from './polyfills';
 import config from '../configs/app.config';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 
 const VALID_W3C_CAPS = ['platformName', 'browserName', 'browserVersion', 'acceptInsecureCerts',
   'pageLoadStrategy', 'proxy', 'setWindowRect', 'timeouts', 'unhandledPromptBehavior'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2023.3.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@xmldom/xmldom": "0.8.7",
         "antd": "4.24.8",
         "bluebird": "3.7.2",
         "cheerio": "1.0.0-rc.10",
@@ -45,7 +46,6 @@
         "source-map-support": "0.5.21",
         "uuid": "8.3.2",
         "web2driver": "3.0.4",
-        "xmldom": "0.6.0",
         "xpath": "0.0.32"
       },
       "bin": {
@@ -4430,6 +4430,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/7zip-bin": {
@@ -24966,6 +24974,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
       "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -28429,6 +28438,11 @@
           }
         }
       }
+    },
+    "@xmldom/xmldom": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.7.tgz",
+      "integrity": "sha512-sI1Ly2cODlWStkINzqGrZ8K6n+MTSbAeQnAipGyL+KZCXuHaRlj2gyyy8B/9MvsFFqN7XHryQnB2QwhzvJXovg=="
     },
     "7zip-bin": {
       "version": "5.1.1",
@@ -44803,7 +44817,8 @@
     "xmldom": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "dev": true
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "ky": "Can't upgrade because newer versions are ESM and parcel tries to bundle them with require"
   },
   "dependencies": {
+    "@xmldom/xmldom": "0.8.7",
     "antd": "4.24.8",
     "bluebird": "3.7.2",
     "cheerio": "1.0.0-rc.10",
@@ -171,7 +172,6 @@
     "source-map-support": "0.5.21",
     "uuid": "8.3.2",
     "web2driver": "3.0.4",
-    "xmldom": "0.6.0",
     "xpath": "0.0.32"
   },
   "//devDependencies": {

--- a/test/unit/util-specs.js
+++ b/test/unit/util-specs.js
@@ -1,7 +1,7 @@
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { getOptimalXPath, xmlToJSON, addVendorPrefixes } from '../../app/renderer/util';
-import { DOMParser } from 'xmldom';
+import { DOMParser } from '@xmldom/xmldom';
 import xpath from 'xpath';
 import sinon from 'sinon';
 


### PR DESCRIPTION
This PR extends #750 by updating to the latest @xmldom/xmldom version, and also updating the imports.
While @xmldom/xmldom v0.8.0 is labeled as a breaking change, I didn't encounter any issues with either unit tests or normal app source retrieval.
Note that xmldom 0.6 is still used in @appium/fake-driver, which will be covered separately.