### PR TITLE
chore: update readme and fix Android system buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ any other command: `./Appium-Inspector-linux.AppImage`.
 * Start and stop "recording" mode, which translates your actions in the Inspector to code samples you can use in your scripts
 * Start and stop "source refreshing", which allows you to interact with screen without reloading page source after every request
 * Tap on the screen at an arbitrary location
-* Simulate system buttons for iOS (home/Siri) and Android (back/home/app switch)
 * Perform a swipe gesture
+* Simulate system buttons for iOS (home) and Android (back/home/app switch)
+* Simulate Siri commands for iOS
 * Switch into web context modes and interact with web elements
 * Test out your own locator strategies
 * Access a huge library of Appium actions to run with a simple click, including providing your own parameters

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ any other command: `./Appium-Inspector-linux.AppImage`.
 * Start and stop "recording" mode, which translates your actions in the Inspector to code samples you can use in your scripts
 * Start and stop "source refreshing", which allows you to interact with screen without reloading page source after every request
 * Tap on the screen at an arbitrary location
-* Hard buttons for iOS and Android
+* Simulate system buttons for iOS (home/Siri) and Android (back/home/app switch)
 * Perform a swipe gesture
 * Switch into web context modes and interact with web elements
 * Test out your own locator strategies

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ any other command: `./Appium-Inspector-linux.AppImage`.
 * Get a list of suggested element locator strategies and selectors to be used in your scripts
 * Compare the speed of different element finding strategies
 * Start and stop "recording" mode, which translates your actions in the Inspector to code samples you can use in your scripts
-* Start and stop "source refreshing", which allows you to interact with screen without reloading page source after every request
+* Start and stop "source refreshing", which allows interacting with the device screen without reloading page source (MJPEG stream capabilities are required)
 * Tap on the screen at an arbitrary location
 * Perform a swipe gesture
 * Simulate system buttons for iOS (home) and Android (back/home/app switch)

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -522,7 +522,7 @@ export function newSession (caps, attachSessId = null) {
     let driver = null;
     try {
       if (attachSessId) {
-        // When attaching to a session id, webdriver does not fully populdate
+        // When attaching to a session id, webdriver does not fully populate
         // client information, so we should supplement by attaching session
         // capabilities that we are attaching to.
         const attachedSessionCaps = session.runningAppiumSessions.find((session) => session.id === attachSessId).capabilities;

--- a/app/renderer/components/Inspector/DeviceActions.js
+++ b/app/renderer/components/Inspector/DeviceActions.js
@@ -27,10 +27,10 @@ class DeviceActions extends Component {
       </div>}
       {driver.client.isAndroid && <div className={InspectorStyles['action-controls']}>
         <Tooltip title={t('Press Back button')}>
-          <Button id='btnPressHomeButton' icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [3]})}/>
+          <Button id='btnPressHomeButton' icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [4]})}/>
         </Tooltip>
         <Tooltip title={t('Press Home button')}>
-          <Button id='btnPressHomeButton' icon={<BiCircle className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [4]})}/>
+          <Button id='btnPressHomeButton' icon={<BiCircle className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [3]})}/>
         </Tooltip>
         <Tooltip title={t('Press Overview button')}>
           <Button id='btnPressHomeButton' icon={<BiSquare className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [187]})}/>

--- a/app/renderer/components/Inspector/DeviceActions.js
+++ b/app/renderer/components/Inspector/DeviceActions.js
@@ -32,7 +32,7 @@ class DeviceActions extends Component {
         <Tooltip title={t('Press Home button')}>
           <Button id='btnPressHomeButton' icon={<BiCircle className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [3]})}/>
         </Tooltip>
-        <Tooltip title={t('Press Overview button')}>
+        <Tooltip title={t('Press App Switch button')}>
           <Button id='btnPressHomeButton' icon={<BiSquare className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [187]})}/>
         </Tooltip>
       </div>}


### PR DESCRIPTION
This PR fixes a few minor things in #746: 
* pause source refresh button
  * turns out that if MJPEG stream is not used, toggling this button also stops refreshing screenshot - this has been added to the readme
* system buttons
  * rename Android Overview button to App Switch, according to [Android Developer reference](https://developer.android.com/reference/android/view/KeyEvent#KEYCODE_APP_SWITCH)
  * swap keycodes for Android Back and Android Home buttons, also according to Android Developer reference
  * add more details in readme