### PR TITLE
fix: remove leftover 'savedSessionsCount'

### DIFF
--- a/assets/locales/ru/translation.json
+++ b/assets/locales/ru/translation.json
@@ -217,7 +217,7 @@
   "Automatic Server": "Сервер по умолчанию",
   "Custom Server": "Пользовательский сервер",
   "Desired Capabilities": "Желаемые возможности",
-  "Saved Capability Sets": "Сохраненные наборы возможностей ({{savedSessionsCount}})",
+  "Saved Capability Sets": "Сохраненные наборы возможностей",
   "Attach to Session": "Прикрепиться к сессии…",
   "localhost": "localhost",
   "Host": "Хост",


### PR DESCRIPTION
This is a minor fix for [commit e87bf9b](https://github.com/appium/appium-inspector/commit/e87bf9b393d8972725f23df5e59aa1f69073bd75).

Also, it seems that CI is failing (as it cannot build Inspector v2023.4.1). This is likely related to the package-lock changes in the same commit.