### PR TITLE
chore: tweak the initial page

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -552,7 +552,7 @@ export function newSession (caps, attachSessId = null) {
     if (browserName.trim() !== '') {
       try {
         mode = APP_MODE.WEB_HYBRID;
-        await driver.navigateTo('http://appium.io/docs/en/about-appium/intro/');
+        await driver.navigateTo('https://appium.io');
       } catch (ign) {}
     }
 


### PR DESCRIPTION
appium-inspector opens a url after starting a new session if it was in WebView. Current path is 404 since today, so lets change the path to the top.