### PR TITLE
feat: support renaming saved capability sets

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -48,8 +48,8 @@ export const GET_SESSIONS_DONE = 'GET_SESSIONS_DONE';
 
 export const ENABLE_DESIRED_CAPS_NAME_EDITOR = 'ENABLE_DESIRED_CAPS_NAME_EDITOR';
 export const ABORT_DESIRED_CAPS_NAME_EDITOR = 'ABORT_DESIRED_CAPS_NAME_EDITOR';
-export const SAVE_RAW_DESIRED_CAPS_NAME = 'SAVE_RAW_DESIRED_CAPS_NAME';
-export const SET_RAW_DESIRED_CAPS_NAME = 'SET_RAW_DESIRED_CAPS_NAME';
+export const SAVE_DESIRED_CAPS_NAME = 'SAVE_DESIRED_CAPS_NAME';
+export const SET_DESIRED_CAPS_NAME = 'SET_DESIRED_CAPS_NAME';
 
 export const ENABLE_DESIRED_CAPS_EDITOR = 'ENABLE_DESIRED_CAPS_EDITOR';
 export const ABORT_DESIRED_CAPS_EDITOR = 'ABORT_DESIRED_CAPS_EDITOR';
@@ -886,17 +886,17 @@ export function abortDesiredCapsNameEditor () {
   };
 }
 
-export function saveRawDesiredCapsName () {
+export function saveDesiredCapsName () {
   return (dispatch, getState) => {
-    const {server, serverType, caps, capsUUID, rawDesiredCapsName} = getState().session;
-    dispatch({type: SAVE_RAW_DESIRED_CAPS_NAME, name: rawDesiredCapsName});
-    saveSession(server, serverType, caps, {name: rawDesiredCapsName, uuid: capsUUID})(dispatch);
+    const {server, serverType, caps, capsUUID, desiredCapsName} = getState().session;
+    dispatch({type: SAVE_DESIRED_CAPS_NAME, name: desiredCapsName});
+    saveSession(server, serverType, caps, {name: desiredCapsName, uuid: capsUUID})(dispatch);
   };
 }
 
-export function setRawDesiredCapsName (rawDesiredCapsName) {
+export function setDesiredCapsName (desiredCapsName) {
   return (dispatch) => {
-    dispatch({type: SET_RAW_DESIRED_CAPS_NAME, rawDesiredCapsName});
+    dispatch({type: SET_DESIRED_CAPS_NAME, desiredCapsName});
   };
 }
 

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -46,6 +46,10 @@ export const SET_ATTACH_SESS_ID = 'SET_ATTACH_SESS_ID';
 export const GET_SESSIONS_REQUESTED = 'GET_SESSIONS_REQUESTED';
 export const GET_SESSIONS_DONE = 'GET_SESSIONS_DONE';
 
+export const ENABLE_DESIRED_CAPS_NAME_EDITOR = 'ENABLE_DESIRED_CAPS_NAME_EDITOR';
+export const ABORT_DESIRED_CAPS_NAME_EDITOR = 'ABORT_DESIRED_CAPS_NAME_EDITOR';
+export const SAVE_RAW_DESIRED_CAPS_NAME = 'SAVE_RAW_DESIRED_CAPS_NAME';
+export const SET_RAW_DESIRED_CAPS_NAME = 'SET_RAW_DESIRED_CAPS_NAME';
 
 export const ENABLE_DESIRED_CAPS_EDITOR = 'ENABLE_DESIRED_CAPS_EDITOR';
 export const ABORT_DESIRED_CAPS_EDITOR = 'ABORT_DESIRED_CAPS_EDITOR';
@@ -162,9 +166,9 @@ export function showError (e, methodName, secs = 5) {
 /**
  * Change the caps object, along with the server details and then go back to the new session tab
  */
-export function setCapsAndServer (server, serverType, caps, uuid) {
+export function setCapsAndServer (server, serverType, caps, uuid, name) {
   return (dispatch) => {
-    dispatch({type: SET_CAPS_AND_SERVER, server, serverType, caps, uuid});
+    dispatch({type: SET_CAPS_AND_SERVER, server, serverType, caps, uuid, name});
   };
 }
 
@@ -205,9 +209,9 @@ export function removeCapability (index) {
 }
 
 function _addVendorPrefixes (caps, dispatch, getState) {
-  const {server, serverType, capsUUID} = getState().session;
+  const {server, serverType, capsUUID, capsName} = getState().session;
   const prefixedCaps = addVendorPrefixes(caps);
-  setCapsAndServer(server, serverType, prefixedCaps, capsUUID)(dispatch);
+  setCapsAndServer(server, serverType, prefixedCaps, capsUUID, capsName)(dispatch);
   return prefixedCaps;
 }
 
@@ -618,6 +622,7 @@ export function saveSession (server, serverType, caps, params) {
       // If it's an existing session, overwrite it
       for (let session of savedSessions) {
         if (session.uuid === uuid) {
+          session.name = name;
           session.caps = caps;
           session.server = server;
           session.serverType = serverType;
@@ -627,7 +632,7 @@ export function saveSession (server, serverType, caps, params) {
     await setSetting(SAVED_SESSIONS, savedSessions);
     const action = getSavedSessions();
     await action(dispatch);
-    dispatch({type: SET_CAPS_AND_SERVER, server, serverType, caps, uuid});
+    dispatch({type: SET_CAPS_AND_SERVER, server, serverType, caps, uuid, name});
     dispatch({type: SAVE_SESSION_DONE});
   };
 }
@@ -866,6 +871,32 @@ export function getRunningSessions () {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console
       dispatch({type: GET_SESSIONS_DONE});
     }
+  };
+}
+
+export function startDesiredCapsNameEditor () {
+  return (dispatch) => {
+    dispatch({type: ENABLE_DESIRED_CAPS_NAME_EDITOR});
+  };
+}
+
+export function abortDesiredCapsNameEditor () {
+  return (dispatch) => {
+    dispatch({type: ABORT_DESIRED_CAPS_NAME_EDITOR});
+  };
+}
+
+export function saveRawDesiredCapsName () {
+  return (dispatch, getState) => {
+    const {server, serverType, caps, capsUUID, rawDesiredCapsName} = getState().session;
+    dispatch({type: SAVE_RAW_DESIRED_CAPS_NAME, name: rawDesiredCapsName});
+    saveSession(server, serverType, caps, {name: rawDesiredCapsName, uuid: capsUUID})(dispatch);
+  };
+}
+
+export function setRawDesiredCapsName (rawDesiredCapsName) {
+  return (dispatch) => {
+    dispatch({type: SET_RAW_DESIRED_CAPS_NAME, rawDesiredCapsName});
   };
 }
 

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -17,12 +17,12 @@ export default class FormattedCaps extends Component {
   }
 
   render () {
-    const {caps, title, isEditingDesiredCapsName, startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveRawDesiredCapsName, setRawDesiredCapsName, rawDesiredCapsName,
+    const {caps, title, isEditingDesiredCapsName, startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName, setDesiredCapsName, desiredCapsName,
            isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor, saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
            isValidCapsJson, invalidCapsJsonReason, t} = this.props;
     return caps && <Card className={SessionStyles.formattedCaps}
       title={!title ? 'JSON Representation' : (!isEditingDesiredCapsName ? title :
-        <input onChange={(e) => setRawDesiredCapsName(e.target.value)} value={rawDesiredCapsName} className={SessionStyles.capsEditorTitle} />
+        <input onChange={(e) => setDesiredCapsName(e.target.value)} value={desiredCapsName} className={SessionStyles.capsEditorTitle} />
       )}
       extra={title && (
         (!isEditingDesiredCapsName && <Tooltip title={t('Edit')}>
@@ -42,7 +42,7 @@ export default class FormattedCaps extends Component {
         <Tooltip title={t('Save')}>
           <Button
             size='small'
-            onClick={saveRawDesiredCapsName}
+            onClick={saveDesiredCapsName}
             icon={<SaveOutlined/>}
             className={SessionStyles.capsNameEditorButton} />
         </Tooltip></div>

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -17,9 +17,36 @@ export default class FormattedCaps extends Component {
   }
 
   render () {
-    const {caps, title, isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor, saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
+    const {caps, title, isEditingDesiredCapsTitle, startDesiredCapsTitleEditor, abortDesiredCapsTitleEditor, saveRawDesiredCapsTitle, setRawDesiredCapsTitle, rawDesiredCapsTitle,
+           isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor, saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
            isValidCapsJson, invalidCapsJsonReason, t} = this.props;
-    return caps && <Card title={title || 'JSON Representation'} className={SessionStyles.formattedCaps}>
+    return caps && <Card className={SessionStyles.formattedCaps}
+      title={!title ? 'JSON Representation' : (!isEditingDesiredCapsTitle ? title :
+        <textarea onChange={(e) => setRawDesiredCapsTitle(e.target.value)} value={rawDesiredCapsTitle} className={SessionStyles.capsEditorTitle} />
+      )}
+      extra={title && (
+        (!isEditingDesiredCapsTitle && <Tooltip title={t('Edit')}>
+          <Button
+            size='small'
+            onClick={startDesiredCapsTitleEditor}
+            icon={<EditOutlined/>}
+            className={SessionStyles.capsTitleEditorButton} />
+        </Tooltip>) ||
+        (isEditingDesiredCapsTitle && <div><Tooltip title={t('Cancel')}>
+          <Button
+            size='small'
+            onClick={abortDesiredCapsTitleEditor}
+            icon={<CloseOutlined/>}
+            className={SessionStyles.capsTitleEditorButton} />
+        </Tooltip>
+        <Tooltip title={t('Save')}>
+          <Button
+            size='small'
+            onClick={saveRawDesiredCapsTitle}
+            icon={<SaveOutlined/>}
+            className={SessionStyles.capsTitleEditorButton} />
+        </Tooltip></div>
+        ))}>
       <div className={SessionStyles.capsEditorControls}>
         {isEditingDesiredCaps && <Tooltip title={t('Cancel')}>
           <Button

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -22,7 +22,7 @@ export default class FormattedCaps extends Component {
            isValidCapsJson, invalidCapsJsonReason, t} = this.props;
     return caps && <Card className={SessionStyles.formattedCaps}
       title={!title ? 'JSON Representation' : (!isEditingDesiredCapsName ? title :
-        <textarea onChange={(e) => setRawDesiredCapsName(e.target.value)} value={rawDesiredCapsName} className={SessionStyles.capsEditorTitle} />
+        <input onChange={(e) => setRawDesiredCapsName(e.target.value)} value={rawDesiredCapsName} className={SessionStyles.capsEditorTitle} />
       )}
       extra={title && (
         (!isEditingDesiredCapsName && <Tooltip title={t('Edit')}>

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -17,34 +17,34 @@ export default class FormattedCaps extends Component {
   }
 
   render () {
-    const {caps, title, isEditingDesiredCapsTitle, startDesiredCapsTitleEditor, abortDesiredCapsTitleEditor, saveRawDesiredCapsTitle, setRawDesiredCapsTitle, rawDesiredCapsTitle,
+    const {caps, title, isEditingDesiredCapsName, startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveRawDesiredCapsName, setRawDesiredCapsName, rawDesiredCapsName,
            isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor, saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
            isValidCapsJson, invalidCapsJsonReason, t} = this.props;
     return caps && <Card className={SessionStyles.formattedCaps}
-      title={!title ? 'JSON Representation' : (!isEditingDesiredCapsTitle ? title :
-        <textarea onChange={(e) => setRawDesiredCapsTitle(e.target.value)} value={rawDesiredCapsTitle} className={SessionStyles.capsEditorTitle} />
+      title={!title ? 'JSON Representation' : (!isEditingDesiredCapsName ? title :
+        <textarea onChange={(e) => setRawDesiredCapsName(e.target.value)} value={rawDesiredCapsName} className={SessionStyles.capsEditorTitle} />
       )}
       extra={title && (
-        (!isEditingDesiredCapsTitle && <Tooltip title={t('Edit')}>
+        (!isEditingDesiredCapsName && <Tooltip title={t('Edit')}>
           <Button
             size='small'
-            onClick={startDesiredCapsTitleEditor}
+            onClick={startDesiredCapsNameEditor}
             icon={<EditOutlined/>}
-            className={SessionStyles.capsTitleEditorButton} />
+            className={SessionStyles.capsNameEditorButton} />
         </Tooltip>) ||
-        (isEditingDesiredCapsTitle && <div><Tooltip title={t('Cancel')}>
+        (isEditingDesiredCapsName && <div><Tooltip title={t('Cancel')}>
           <Button
             size='small'
-            onClick={abortDesiredCapsTitleEditor}
+            onClick={abortDesiredCapsNameEditor}
             icon={<CloseOutlined/>}
-            className={SessionStyles.capsTitleEditorButton} />
+            className={SessionStyles.capsNameEditorButton} />
         </Tooltip>
         <Tooltip title={t('Save')}>
           <Button
             size='small'
-            onClick={saveRawDesiredCapsTitle}
+            onClick={saveRawDesiredCapsName}
             icon={<SaveOutlined/>}
-            className={SessionStyles.capsTitleEditorButton} />
+            className={SessionStyles.capsNameEditorButton} />
         </Tooltip></div>
         ))}>
       <div className={SessionStyles.capsEditorControls}>

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -12,41 +12,63 @@ import { ALERT } from '../../../../gui-common/components/AntdTypes';
 
 export default class FormattedCaps extends Component {
 
+  setCapsTitle (title, isEditingDesiredCapsName) {
+    const {setDesiredCapsName, desiredCapsName} = this.props;
+    if (!title) {
+      return 'JSON Representation';
+    } else if (!isEditingDesiredCapsName) {
+      return title;
+    } else {
+      return <input
+        onChange={(e) => setDesiredCapsName(e.target.value)}
+        value={desiredCapsName}
+        className={SessionStyles.capsEditorTitle}
+      />;
+    }
+  }
+
+  setCapsTitleButtons (title, isEditingDesiredCapsName, t) {
+    const {startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName} = this.props;
+    if (!title) {
+      return null;
+    } else if (!isEditingDesiredCapsName) {
+      return <Tooltip title={t('Edit')}>
+        <Button
+          size='small'
+          onClick={startDesiredCapsNameEditor}
+          icon={<EditOutlined/>}
+          className={SessionStyles.capsNameEditorButton}/>
+      </Tooltip>;
+    } else {
+      return <div><Tooltip title={t('Cancel')}>
+        <Button
+          size='small'
+          onClick={abortDesiredCapsNameEditor}
+          icon={<CloseOutlined/>}
+          className={SessionStyles.capsNameEditorButton} />
+      </Tooltip>
+      <Tooltip title={t('Save')}>
+        <Button
+          size='small'
+          onClick={saveDesiredCapsName}
+          icon={<SaveOutlined/>}
+          className={SessionStyles.capsNameEditorButton} />
+      </Tooltip></div>;
+    }
+  }
+
   getFormattedJSON (caps) {
     return formatJSON.plain(getCapsObject(caps));
   }
 
   render () {
-    const {caps, title, isEditingDesiredCapsName, startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName, setDesiredCapsName, desiredCapsName,
-           isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor, saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
-           isValidCapsJson, invalidCapsJsonReason, t} = this.props;
-    return caps && <Card className={SessionStyles.formattedCaps}
-      title={!title ? 'JSON Representation' : (!isEditingDesiredCapsName ? title :
-        <input onChange={(e) => setDesiredCapsName(e.target.value)} value={desiredCapsName} className={SessionStyles.capsEditorTitle} />
-      )}
-      extra={title && (
-        (!isEditingDesiredCapsName && <Tooltip title={t('Edit')}>
-          <Button
-            size='small'
-            onClick={startDesiredCapsNameEditor}
-            icon={<EditOutlined/>}
-            className={SessionStyles.capsNameEditorButton} />
-        </Tooltip>) ||
-        (isEditingDesiredCapsName && <div><Tooltip title={t('Cancel')}>
-          <Button
-            size='small'
-            onClick={abortDesiredCapsNameEditor}
-            icon={<CloseOutlined/>}
-            className={SessionStyles.capsNameEditorButton} />
-        </Tooltip>
-        <Tooltip title={t('Save')}>
-          <Button
-            size='small'
-            onClick={saveDesiredCapsName}
-            icon={<SaveOutlined/>}
-            className={SessionStyles.capsNameEditorButton} />
-        </Tooltip></div>
-        ))}>
+    const {caps, title, isEditingDesiredCapsName, isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor,
+           saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps, isValidCapsJson, invalidCapsJsonReason, t} = this.props;
+    return caps && <Card
+      className={SessionStyles.formattedCaps}
+      title={this.setCapsTitle(title, isEditingDesiredCapsName)}
+      extra={this.setCapsTitleButtons(title, isEditingDesiredCapsName, t)}
+    >
       <div className={SessionStyles.capsEditorControls}>
         {isEditingDesiredCaps && <Tooltip title={t('Cancel')}>
           <Button

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -38,7 +38,7 @@ export default class SavedSessions extends Component {
 
     // Incase user has CAPS saved from older version of Inspector which
     // doesn't contain server and serverType within the session object
-    setCapsAndServer(session.server || server, session.serverType || serverType, session.caps, session.uuid);
+    setCapsAndServer(session.server || server, session.serverType || serverType, session.caps, session.uuid, session.name);
   }
 
   handleDelete (uuid) {

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -33,8 +33,17 @@ export default class SavedSessions extends Component {
   }
 
   handleCapsAndServer (uuid) {
-    const {setCapsAndServer, server, serverType } = this.props;
+    const {setCapsAndServer, server, serverType, isEditingDesiredCapsName, abortDesiredCapsNameEditor,
+           isEditingDesiredCaps, abortDesiredCapsEditor} = this.props;
     const session = this.sessionFromUUID(uuid);
+
+    // Disable any editors before changing the selected caps
+    if (isEditingDesiredCapsName) {
+      abortDesiredCapsNameEditor();
+    }
+    if (isEditingDesiredCaps) {
+      abortDesiredCapsEditor();
+    }
 
     // Incase user has CAPS saved from older version of Inspector which
     // doesn't contain server and serverType within the session object

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -22,8 +22,7 @@ export default class SavedSessions extends Component {
   onRow (record) {
     return {
       onClick: () => {
-        let session = this.sessionFromUUID(record.key);
-        this.handleCapsAndServer(session);
+        this.handleCapsAndServer(record.key);
       }
     };
   }
@@ -33,8 +32,9 @@ export default class SavedSessions extends Component {
     return capsUUID === record.key ? SessionStyles.selected : '';
   }
 
-  handleCapsAndServer (session) {
+  handleCapsAndServer (uuid) {
     const {setCapsAndServer, server, serverType } = this.props;
+    const session = this.sessionFromUUID(uuid);
 
     // Incase user has CAPS saved from older version of Inspector which
     // doesn't contain server and serverType within the session object
@@ -75,21 +75,16 @@ export default class SavedSessions extends Component {
       title: 'Actions',
       key: 'action',
       width: ACTIONS_COLUMN_WIDTH,
-      render: (text, record) => {
-        let session = this.sessionFromUUID(record.key);
-        return (
-          <div>
-            <Button
-              icon={<EditOutlined/>}
-              onClick={() => {this.handleCapsAndServer(session); switchTabs('new');}}
-              className={SessionStyles.editSession}
-            />
-            <Button
-              icon={<DeleteOutlined/>}
-              onClick={this.handleDelete(session.uuid)}/>
-          </div>
-        );
-      }
+      render: (text, record) => <div>
+        <Button
+          icon={<EditOutlined/>}
+          onClick={() => {this.handleCapsAndServer(record.key); switchTabs('new');}}
+          className={SessionStyles.editSession}
+        />
+        <Button
+          icon={<DeleteOutlined/>}
+          onClick={this.handleDelete(record.key)}/>
+      </div>
     }];
 
     let dataSource = [];

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -154,11 +154,19 @@
   height: 100%;
 }
 
+.formattedCaps :global(.ant-card-head-title) {
+  height: 54px;
+}
+
 .formattedCaps :global(.ant-card-body) {
   height: calc(100% - 54px);
   padding: 0 14px 0 24px;
   flex: 1;
   overflow-y: auto;
+}
+
+.formattedCaps :global(.ant-card-extra) {
+  padding: 15px 0;
 }
 
 .formattedCapsBody pre {
@@ -220,6 +228,11 @@
   background-color: #d6e8ff;
 }
 
+.capsTitleEditorButton {
+  margin: 0 8px 0 0;
+  padding: 0;
+}
+
 .capsEditorControls {
   position: absolute;
   right: 0;
@@ -234,6 +247,14 @@
   width: 100%;
   height: 100%;
   padding: 24px 0;
+}
+
+.capsEditorTitle {
+  width: 98%;
+  height: 22px;
+  padding: 0;
+  margin: 0;
+  resize: none;
 }
 
 .capsEditorBody {

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -156,6 +156,7 @@
 
 .formattedCaps :global(.ant-card-head-title) {
   height: 54px;
+  padding-right: 10px;
 }
 
 .formattedCaps :global(.ant-card-body) {
@@ -250,7 +251,7 @@
 }
 
 .capsEditorTitle {
-  width: 98%;
+  width: 100%;
   height: 22px;
   padding: 0;
   margin: 0;

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -228,7 +228,7 @@
   background-color: #d6e8ff;
 }
 
-.capsTitleEditorButton {
+.capsNameEditorButton {
   margin: 0 8px 0 0;
   padding: 0;
 }

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -60,7 +60,7 @@ export default class Session extends Component {
   render () {
     const {newSessionBegan, savedSessions, tabKey, switchTabs,
            serverType, server,
-           requestSaveAsModal, newSession, caps, capsUUID, saveSession,
+           requestSaveAsModal, newSession, caps, capsUUID, capsName, saveSession,
            visibleProviders = [],
            isCapsDirty, sessionLoading, attachSessId, t} = this.props;
 
@@ -111,7 +111,7 @@ export default class Session extends Component {
                 {t('desiredCapabilitiesDocumentation')}
               </a>
             </div>
-            { (!isAttaching && capsUUID) && <Button onClick={() => saveSession(server, serverType, caps, {uuid: capsUUID})} disabled={!isCapsDirty}>{t('Save')}</Button> }
+            { (!isAttaching && capsUUID) && <Button onClick={() => saveSession(server, serverType, caps, {name: capsName, uuid: capsUUID})} disabled={!isCapsDirty}>{t('Save')}</Button> }
             {!isAttaching && <Button onClick={requestSaveAsModal}>{t('saveAs')}</Button>}
             {!isAttaching && <Button type={BUTTON.PRIMARY} id='btnStartSession'
               onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>{t('startSession')}</Button>

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -9,6 +9,7 @@ import { NEW_SESSION_REQUESTED, NEW_SESSION_BEGAN, NEW_SESSION_DONE,
          DELETE_SAVED_SESSION_REQUESTED, DELETE_SAVED_SESSION_DONE,
          CHANGE_SERVER_TYPE, SET_SERVER_PARAM, SET_SERVER, SET_ATTACH_SESS_ID,
          GET_SESSIONS_REQUESTED, GET_SESSIONS_DONE,
+         ENABLE_DESIRED_CAPS_NAME_EDITOR, ABORT_DESIRED_CAPS_NAME_EDITOR, SAVE_RAW_DESIRED_CAPS_NAME, SET_RAW_DESIRED_CAPS_NAME,
          ENABLE_DESIRED_CAPS_EDITOR, ABORT_DESIRED_CAPS_EDITOR, SAVE_RAW_DESIRED_CAPS, SET_RAW_DESIRED_CAPS, SHOW_DESIRED_CAPS_JSON_ERROR,
          IS_ADDING_CLOUD_PROVIDER, SET_PROVIDERS, SET_ADD_VENDOR_PREFIXES, SET_STATE_FROM_URL, SET_STATE_FROM_SAVED,
          ServerTypes } from '../actions/Session';
@@ -60,6 +61,7 @@ const INITIAL_STATE = {
   isCapsDirty: true,
   gettingSessions: false,
   runningAppiumSessions: [],
+  isEditingDesiredCapsName: false,
   isEditingDesiredCaps: false,
   isValidCapsJson: true,
   isValidatingCapsJson: false,
@@ -134,6 +136,7 @@ export default function session (state = INITIAL_STATE, action) {
         serverType: action.serverType,
         caps: action.caps,
         capsUUID: action.uuid,
+        capsName: action.name,
       };
       return omit(nextState, 'isCapsDirty');
 
@@ -170,7 +173,8 @@ export default function session (state = INITIAL_STATE, action) {
       return {
         ...state,
         deletingSession: false,
-        capsUUID: null
+        capsUUID: null,
+        capsName: null,
       };
 
     case SWITCHED_TABS:
@@ -263,6 +267,33 @@ export default function session (state = INITIAL_STATE, action) {
         runningAppiumSessions: action.sessions || [],
       };
     }
+
+    case ENABLE_DESIRED_CAPS_NAME_EDITOR:
+      return {
+        ...state,
+        isEditingDesiredCapsName: true,
+        rawDesiredCapsName: state.capsName,
+      };
+
+    case ABORT_DESIRED_CAPS_NAME_EDITOR:
+      return {
+        ...state,
+        isEditingDesiredCapsName: false,
+        rawDesiredCapsName: null,
+      };
+
+    case SAVE_RAW_DESIRED_CAPS_NAME:
+      return {
+        ...state,
+        isEditingDesiredCapsName: false,
+        capsName: action.name,
+      };
+
+    case SET_RAW_DESIRED_CAPS_NAME:
+      return {
+        ...state,
+        rawDesiredCapsName: action.rawDesiredCapsName,
+      };
 
     case ENABLE_DESIRED_CAPS_EDITOR:
       return {

--- a/app/renderer/reducers/Session.js
+++ b/app/renderer/reducers/Session.js
@@ -9,7 +9,7 @@ import { NEW_SESSION_REQUESTED, NEW_SESSION_BEGAN, NEW_SESSION_DONE,
          DELETE_SAVED_SESSION_REQUESTED, DELETE_SAVED_SESSION_DONE,
          CHANGE_SERVER_TYPE, SET_SERVER_PARAM, SET_SERVER, SET_ATTACH_SESS_ID,
          GET_SESSIONS_REQUESTED, GET_SESSIONS_DONE,
-         ENABLE_DESIRED_CAPS_NAME_EDITOR, ABORT_DESIRED_CAPS_NAME_EDITOR, SAVE_RAW_DESIRED_CAPS_NAME, SET_RAW_DESIRED_CAPS_NAME,
+         ENABLE_DESIRED_CAPS_NAME_EDITOR, ABORT_DESIRED_CAPS_NAME_EDITOR, SAVE_DESIRED_CAPS_NAME, SET_DESIRED_CAPS_NAME,
          ENABLE_DESIRED_CAPS_EDITOR, ABORT_DESIRED_CAPS_EDITOR, SAVE_RAW_DESIRED_CAPS, SET_RAW_DESIRED_CAPS, SHOW_DESIRED_CAPS_JSON_ERROR,
          IS_ADDING_CLOUD_PROVIDER, SET_PROVIDERS, SET_ADD_VENDOR_PREFIXES, SET_STATE_FROM_URL, SET_STATE_FROM_SAVED,
          ServerTypes } from '../actions/Session';
@@ -272,27 +272,27 @@ export default function session (state = INITIAL_STATE, action) {
       return {
         ...state,
         isEditingDesiredCapsName: true,
-        rawDesiredCapsName: state.capsName,
+        desiredCapsName: state.capsName,
       };
 
     case ABORT_DESIRED_CAPS_NAME_EDITOR:
       return {
         ...state,
         isEditingDesiredCapsName: false,
-        rawDesiredCapsName: null,
+        desiredCapsName: null,
       };
 
-    case SAVE_RAW_DESIRED_CAPS_NAME:
+    case SAVE_DESIRED_CAPS_NAME:
       return {
         ...state,
         isEditingDesiredCapsName: false,
         capsName: action.name,
       };
 
-    case SET_RAW_DESIRED_CAPS_NAME:
+    case SET_DESIRED_CAPS_NAME:
       return {
         ...state,
-        rawDesiredCapsName: action.rawDesiredCapsName,
+        desiredCapsName: action.desiredCapsName,
       };
 
     case ENABLE_DESIRED_CAPS_EDITOR:


### PR DESCRIPTION
This PR adds the ability to rename any saved capability set, through a new edit button next to the title.

Why is this useful? I have had situations where I need to replace one of my test phones, for which I had saved multiple capability sets. In order to update the caps and the set names, previously I would need to create entirely new sets, and delete the old ones. With this change, I only need to edit caps for the device udid/name, and rename the set title.

The implementation is fairly similar to that of editing the saved capabilities themselves. One key difference is that the new title is saved immediately after pressing the small save button - the Save button in the footer is not used.

Here is a brief video to show how this works:

https://user-images.githubusercontent.com/37242620/232803329-94b9c04e-57bf-4992-9157-e4b012bf7e74.mp4

Also, the changes in `SavedSessions.js` are not directly related, but they greatly reduce the number of calls to `sessionFromUUID` when switching between saved sets.

