### PR TITLE
ci: cleanup validation workflow

### DIFF
--- a/.github/workflows/node.build.yml
+++ b/.github/workflows/node.build.yml
@@ -6,8 +6,6 @@ name: Node.js CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/node.build.yml
+++ b/.github/workflows/node.build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -26,9 +26,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Update to npm > 6 if needed
-      if: ${{ matrix.node-version == '14.x' }}
-      run: sudo npm i -g npm@8
     - run: npm ci
     - run: npm run build
     - run: npm test

--- a/.github/workflows/node.build.yml
+++ b/.github/workflows/node.build.yml
@@ -26,6 +26,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Update to npm > 6 if needed
+      if: ${{ matrix.node-version == '14.x' }}
+      run: sudo npm -i -g npm@8
     - run: npm ci
     - run: npm run build
     - run: npm test

--- a/.github/workflows/node.build.yml
+++ b/.github/workflows/node.build.yml
@@ -28,7 +28,7 @@ jobs:
         cache: 'npm'
     - name: Update to npm > 6 if needed
       if: ${{ matrix.node-version == '14.x' }}
-      run: sudo npm -i -g npm@8
+      run: sudo npm i -g npm@8
     - run: npm ci
     - run: npm run build
     - run: npm test

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -25,10 +25,10 @@ jobs:
         cache: 'npm'
     - name: Update to npm > 6 if needed
       if: ${{ matrix.node-version == '14.x' && matrix.image != 'ubuntu-latest' }}
-      run: npm -i -g npm@8
+      run: npm i -g npm@8
     - name: Update to npm > 6 if needed (Linux)
       if: ${{ matrix.node-version == '14.x' && matrix.image == 'ubuntu-latest' }}
-      run: sudo npm -i -g npm@8
+      run: sudo npm i -g npm@8
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
+    - name: Update to npm > 6 if needed
+      if: ${{ matrix.node-version == '14.x' && matrix.image != 'ubuntu-latest' }}
+      run: npm -i -g npm@8
+    - name: Update to npm > 6 if needed (Linux)
+      if: ${{ matrix.node-version == '14.x' && matrix.image == 'ubuntu-latest' }}
+      run: sudo npm -i -g npm@8
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         image: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.image }}
@@ -23,12 +23,6 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
-    - name: Update to npm > 6 if needed
-      if: ${{ matrix.node-version == '14.x' && matrix.image != 'ubuntu-latest' }}
-      run: npm i -g npm@8
-    - name: Update to npm > 6 if needed (Linux)
-      if: ${{ matrix.node-version == '14.x' && matrix.image == 'ubuntu-latest' }}
-      run: sudo npm i -g npm@8
     - run: npm ci
     - run: npm run build --if-present
     - run: npm test


### PR DESCRIPTION
This PR ensures that CI runs for Node 14 use NPM 8 instead of the default NPM 6. This is because NPM 6 does not auto-install peer dependencies, which are used in newer `@appium/fake-driver` versions.

I used `npm@8` instead of `npm@latest` to prevent any breaking changes in the future.

Worth noting that [Node 14 support ends on 2023-04-30](https://github.com/nodejs/release#release-schedule), so maybe it's simpler to just wait a few days and then remove it from CI entirely? 🤔 

Also, this is a good place to ask, perhaps it's worth removing the `on: pull_request` trigger in `node.build.yml`? That workflow is already fully covered by the PR validation workflow.