### PR TITLE
feat: add class name locator strategy where applicable

### DIFF
--- a/app/renderer/components/Inspector/shared.js
+++ b/app/renderer/components/Inspector/shared.js
@@ -50,6 +50,8 @@ const STRATEGY_MAPPINGS = [
   ['id', 'id'],
   ['rntestid', 'id'],
   ['resource-id', 'id'],
+  ['class', 'class name'],
+  ['type', 'class name'],
 ];
 
 export function getLocators (attributes, sourceXML) {


### PR DESCRIPTION
This PR adds the class name locator strategy in the 'Find By' table when selecting elements with unique class names.
Considering that this strategy is listed as the fastest for both [iOS](https://github.com/facebookarchive/WebDriverAgent/wiki/How-To-Achieve-The-Best-Lookup-Performance#select-the-most-effective-lookup-strategy) and [Android](https://github.com/appium/appium-uiautomator2-driver#element-location), I think it is worth adding.
Android uses the `class` element property, whereas iOS uses `type`.

Example:
![image](https://user-images.githubusercontent.com/37242620/236843235-b28bf6d0-a8d6-45ab-9422-d33837a47849.png)
