### PR TITLE
fix: improve selected element actions

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -393,6 +393,10 @@
     overflow: auto;
 }
 
+.selectedElemNotInteractableAlertRow {
+    justify-content: center;
+}
+
 .sourceTag {
     color: #7d2020;
     font-weight: normal

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -190,7 +190,7 @@ export default class Inspector extends Component {
     const {screenshot, screenshotError, selectedElement = {},
            applyClientMethod, quitSession, isRecording, showRecord, startRecording,
            pauseRecording, showLocatorTestModal, appMode,
-           screenshotInteractionMode, isFindingElementsTimes, visibleCommandMethod,
+           screenshotInteractionMode, visibleCommandMethod,
            selectedInteractionMode, selectInteractionMode, selectAppMode, setVisibleCommandResult,
            showKeepAlivePrompt, keepSessionAlive, sourceXML, t, visibleCommandResult,
            mjpegScreenshotUrl, isAwaitingMjpegStream, toggleShowCentroids, showCentroids,
@@ -374,29 +374,27 @@ export default class Inspector extends Component {
       {generalControls}
     </div>;
 
-    return (<Spin spinning={isFindingElementsTimes} key="main">
-      <div className={InspectorStyles['inspector-container']}>
-        {controls}
-        {main}
-        <Modal
-          title={t('Session Inactive')}
-          open={showKeepAlivePrompt}
-          onOk={() => keepSessionAlive()}
-          onCancel={() => quitSession()}
-          okText={t('Keep Session Running')}
-          cancelText={t('Quit Session')}
-        >
-          <p>{t('Your session is about to expire')}</p>
-        </Modal>
-        <Modal
-          title={t('methodCallResult', {methodName: visibleCommandMethod})}
-          open={!!visibleCommandResult}
-          onOk={() => setVisibleCommandResult(null)}
-          onCancel={() => setVisibleCommandResult(null)}
-        >
-          <pre><code>{visibleCommandResult}</code></pre>
-        </Modal>
-      </div>
-    </Spin>);
+    return (<div className={InspectorStyles['inspector-container']}>
+      {controls}
+      {main}
+      <Modal
+        title={t('Session Inactive')}
+        open={showKeepAlivePrompt}
+        onOk={() => keepSessionAlive()}
+        onCancel={() => quitSession()}
+        okText={t('Keep Session Running')}
+        cancelText={t('Quit Session')}
+      >
+        <p>{t('Your session is about to expire')}</p>
+      </Modal>
+      <Modal
+        title={t('methodCallResult', {methodName: visibleCommandMethod})}
+        open={!!visibleCommandResult}
+        onOk={() => setVisibleCommandResult(null)}
+        onCancel={() => setVisibleCommandResult(null)}
+      >
+        <pre><code>{visibleCommandResult}</code></pre>
+      </Modal>
+    </div>);
   }
 }

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -85,10 +85,11 @@ class SelectedElement extends Component {
       selectedElementId: elementId,
       sourceXML,
       elementInteractionsNotAvailable,
+      selectedElementSearchInProgress,
       t,
     } = this.props;
     const {attributes, classChain, predicateString, xpath} = selectedElement;
-    const isDisabled = !elementId || isFindingElementsTimes;
+    const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
 
     if (!currentContext) {
       currentContext = NATIVE_APP;
@@ -203,7 +204,7 @@ class SelectedElement extends Component {
     }
 
     let tapIcon = <AimOutlined/>;
-    if (!(elementInteractionsNotAvailable || elementId)) {
+    if (!(elementInteractionsNotAvailable || elementId) || selectedElementSearchInProgress) {
       tapIcon = <LoadingOutlined/>;
     }
 

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -208,7 +208,7 @@ class SelectedElement extends Component {
     }
 
     return <div>
-      {elementInteractionsNotAvailable && <Row type={ROW.FLEX} gutter={10}>
+      {elementInteractionsNotAvailable && <Row type={ROW.FLEX} gutter={10} className={styles.selectedElemNotInteractableAlertRow}>
         <Col>
           <Alert type={ALERT.INFO} message={t('interactionsNotAvailable')} showIcon />
         </Col>

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -210,7 +210,7 @@ class SelectedElement extends Component {
     return <div>
       {elementInteractionsNotAvailable && <Row type={ROW.FLEX} gutter={10}>
         <Col>
-          <Alert type={ALERT.INFO} message={t('Interactions are not available for this element')} showIcon />
+          <Alert type={ALERT.INFO} message={t('interactionsNotAvailable')} showIcon />
         </Col>
       </Row>}
       <Row justify="center" type={ROW.FLEX} align="middle" gutter={10} className={styles.elementActions}>

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import {getLocators} from './shared';
 import styles from './Inspector.css';
-import { Button, Row, Col, Input, Modal, Table, Alert, Tooltip, Select } from 'antd';
+import { Button, Row, Col, Input, Modal, Table, Alert, Tooltip, Select, Spin } from 'antd';
 import { withTranslation } from '../../util';
 import {clipboard, shell} from '../../polyfills';
 import {
@@ -261,12 +261,14 @@ class SelectedElement extends Component {
       </Row>
       {findDataSource.length > 0 &&
         <Row>
-          <Table
-            columns={findColumns}
-            dataSource={findDataSource}
-            size="small"
-            tableLayout='fixed'
-            pagination={false} />
+          <Spin spinning={isFindingElementsTimes}>
+            <Table
+              columns={findColumns}
+              dataSource={findDataSource}
+              size="small"
+              tableLayout='fixed'
+              pagination={false} />
+          </Spin>
         </Row>
       }
       <br />

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -119,6 +119,7 @@ export default function inspector (state = INITIAL_STATE, action) {
         ...state,
         selectedElement: findElementByPath(action.path, state.source),
         selectedElementPath: action.path,
+        selectedElementSearchInProgress: true,
         elementInteractionsNotAvailable: false,
         findElementsExecutionTimes: [],
       };
@@ -131,6 +132,7 @@ export default function inspector (state = INITIAL_STATE, action) {
         selectedElementId: null,
         selectedElementVariableName: null,
         selectedElementVariableType: null,
+        selectedElementSearchInProgress: false,
       };
 
     case SELECT_CENTROID:
@@ -148,6 +150,7 @@ export default function inspector (state = INITIAL_STATE, action) {
         selectedElementId: action.elementId,
         selectedElementVariableName: action.variableName,
         selectedElementVariableType: action.variableType,
+        selectedElementSearchInProgress: false,
         findElementsExecutionTimes: [],
       };
 
@@ -155,6 +158,7 @@ export default function inspector (state = INITIAL_STATE, action) {
       return {
         ...state,
         elementInteractionsNotAvailable: true,
+        selectedElementSearchInProgress: false,
       };
 
     case SELECT_HOVERED_ELEMENT:

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -136,7 +136,7 @@
   "Selector": "Selector",
   "Time": "Time (ms)",
   "Get Timing": "Get Timing",
-  "Interactions are not available for this element": "Interactions are not available for this element",
+  "interactionsNotAvailable": "Interactions for this element may not be available",
   "usingXPathNotRecommended": "Using XPath locators is not recommended and can lead to fragile tests. Ask your development team to provide unique accessibility locators instead!",
   "usingSwitchContextRecommended": "Webview context(s) detected; certain elements might only be accessible after switching to a webview context, which must be done in an Appium script. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
   "usingWebviewContext": "Using the Webview inspector in Appium Inspector is less accurate in retrieving and selecting DOM elements in comparison to using the DevTools of Chrome and Safari.",


### PR DESCRIPTION
This PR aims to fix #353 and add a few more usability improvements along the way:
* Action buttons are no longer disabled if the element could not be found. Instead, they are disabled during the initial element search (starting from selecting an element, until its ID is (not) retrieved), to prevent an invalid state. As before, the buttons also remain disabled while timing search is ongoing.
* Adjust the text and positioning of the info alert about element not being interactable
* During timing search, show spinner only over the locator strategies table, instead of the whole application window