### PR TITLE
chore(deps): update react-i18next to 12.2.2

### DIFF
--- a/app/configs/app.config.js
+++ b/app/configs/app.config.js
@@ -20,10 +20,7 @@ function getI18NextOptions (backend) {
     },
     lng: settings && settings.getSync('PREFERRED_LANGUAGE') || 'en',
     fallbackLng: config.fallbackLng,
-    whitelist: config.languages,
-    react: {
-      wait: false
-    }
+    whitelist: config.languages
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "prop-types": "15.8.1",
         "react": "17.0.2",
         "react-dom": "17.0.2",
-        "react-i18next": "11.18.6",
+        "react-i18next": "12.2.2",
         "react-icons": "4.8.0",
         "react-redux": "7.2.9",
         "react-router": "5.3.4",
@@ -21263,11 +21263,11 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "11.18.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
-      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-12.2.2.tgz",
+      "integrity": "sha512-KBB6buBmVKXUWNxXHdnthp+38gPyBT46hJCAIQ8rX19NFL/m2ahte2KARfIDf2tMnSAL7wwck6eDOd/9zn6aFg==",
       "dependencies": {
-        "@babel/runtime": "^7.14.5",
+        "@babel/runtime": "^7.20.6",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
@@ -43135,11 +43135,11 @@
       }
     },
     "react-i18next": {
-      "version": "11.18.6",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-11.18.6.tgz",
-      "integrity": "sha512-yHb2F9BiT0lqoQDt8loZ5gWP331GwctHz9tYQ8A2EIEUu+CcEdjBLQWli1USG3RdWQt3W+jqQLg/d4rrQR96LA==",
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-12.2.2.tgz",
+      "integrity": "sha512-KBB6buBmVKXUWNxXHdnthp+38gPyBT46hJCAIQ8rX19NFL/m2ahte2KARfIDf2tMnSAL7wwck6eDOd/9zn6aFg==",
       "requires": {
-        "@babel/runtime": "^7.14.5",
+        "@babel/runtime": "^7.20.6",
         "html-parse-stringify": "^3.0.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "prop-types": "15.8.1",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "react-i18next": "11.18.6",
+    "react-i18next": "12.2.2",
     "react-icons": "4.8.0",
     "react-redux": "7.2.9",
     "react-router": "5.3.4",


### PR DESCRIPTION
Also removes the deprecated `wait: false` option. The new syntax would be `useSuspense: false`, but I didn't see any differences after removing it (and if anything, it might be safer this way).