### PR TITLE
chore: update route initialisation style

### DIFF
--- a/app/renderer/routes.js
+++ b/app/renderer/routes.js
@@ -17,9 +17,15 @@ export default () => (
   <Suspense fallback={<Spinner />}>
     <App>
       <Switch>
-        <Route exact path="/" component={SessionPage} />
-        <Route path="/session" component={SessionPage} />
-        <Route path="/inspector" component={InspectorPage} />
+        <Route exact path="/">
+          <SessionPage />
+        </Route>
+        <Route path="/session">
+          <SessionPage />
+        </Route>
+        <Route path="/inspector">
+          <InspectorPage />
+        </Route>
       </Switch>
     </App>
   </Suspense>


### PR DESCRIPTION
Small change needed for the eventual update to react-router v6. This updates the style of route initialisation to the one introduced in react-router 5.1, [as described here](https://github.com/remix-run/react-router/blob/main/docs/upgrading/v5.md#upgrade-to-react-router-v51).