### PR TITLE
chore(deps): update uuid to v9

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -349,11 +349,11 @@ export function getSavedActionFramework () {
 }
 
 export function setActionFramework (framework) {
-  return (dispatch) => {
+  return async (dispatch) => {
     if (!frameworks[framework]) {
       throw new Error(i18n.t('frameworkNotSupported', {framework}));
     }
-    setSetting(SAVED_FRAMEWORK, framework);
+    await setSetting(SAVED_FRAMEWORK, framework);
     dispatch({type: SET_ACTION_FRAMEWORK, framework});
   };
 }
@@ -791,7 +791,7 @@ export function saveGesture (params) {
       }
     }
     dispatch({type: SET_SAVED_GESTURES, savedGestures});
-    setSetting(SET_SAVED_GESTURES, savedGestures);
+    await setSetting(SET_SAVED_GESTURES, savedGestures);
     const action = getSavedGestures();
     await action(dispatch);
   };
@@ -810,7 +810,7 @@ export function deleteSavedGesture (id) {
     dispatch({type: DELETE_SAVED_GESTURES_REQUESTED, deleteGesture: id});
     const gestures = await getSetting(SET_SAVED_GESTURES);
     const newGestures = gestures.filter((gesture) => gesture.id !== id);
-    setSetting(SET_SAVED_GESTURES, newGestures);
+    await setSetting(SET_SAVED_GESTURES, newGestures);
     dispatch({type: DELETE_SAVED_GESTURES_DONE});
     dispatch({type: GET_SAVED_GESTURES_DONE, savedGestures: newGestures});
   };

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -542,7 +542,7 @@ export function newSession (caps, attachSessId = null) {
     } finally {
       dispatch({type: NEW_SESSION_DONE});
       // Save the current server settings
-      setSetting(SESSION_SERVER_PARAMS, session.server);
+      await setSetting(SESSION_SERVER_PARAMS, session.server);
     }
 
     // The homepage arg in ChromeDriver is not working with Appium. iOS can have a default url, but
@@ -627,7 +627,7 @@ export function saveSession (server, serverType, caps, params) {
         }
       }
     }
-    setSetting(SAVED_SESSIONS, savedSessions);
+    await setSetting(SAVED_SESSIONS, savedSessions);
     const action = getSavedSessions();
     await action(dispatch);
     dispatch({type: SET_CAPS_AND_SERVER, server, serverType, caps, uuid, name});
@@ -690,7 +690,7 @@ export function deleteSavedSession (uuid) {
     dispatch({type: DELETE_SAVED_SESSION_REQUESTED, uuid});
     let savedSessions = await getSetting(SAVED_SESSIONS);
     let newSessions = savedSessions.filter((session) => session.uuid !== uuid);
-    setSetting(SAVED_SESSIONS, newSessions);
+    await setSetting(SAVED_SESSIONS, newSessions);
     dispatch({type: DELETE_SAVED_SESSION_DONE});
     dispatch({type: GET_SAVED_SESSIONS_DONE, savedSessions: newSessions});
   };
@@ -709,8 +709,8 @@ export function setAttachSessId (attachSessId) {
  * Change the server type
  */
 export function changeServerType (serverType) {
-  return (dispatch, getState) => {
-    setSetting(SESSION_SERVER_TYPE, serverType);
+  return async (dispatch, getState) => {
+    await setSetting(SESSION_SERVER_TYPE, serverType);
     dispatch({type: CHANGE_SERVER_TYPE, serverType});
     const action = getRunningSessions();
     action(dispatch, getState);
@@ -722,9 +722,9 @@ export function changeServerType (serverType) {
  */
 export function setServerParam (name, value, serverType) {
   const debounceGetRunningSessions = debounce(getRunningSessions(), 5000);
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     serverType = serverType || getState().session.serverType;
-    setSetting(SESSION_SERVER_TYPE, serverType);
+    await setSetting(SESSION_SERVER_TYPE, serverType);
     dispatch({type: SET_SERVER_PARAM, serverType, name, value});
     debounceGetRunningSessions(dispatch, getState);
   };
@@ -977,19 +977,19 @@ export function stopAddCloudProvider () {
 }
 
 export function addVisibleProvider (provider) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     let currentProviders = getState().session.visibleProviders;
     const providers = union(currentProviders, [provider]);
-    setSetting(VISIBLE_PROVIDERS, providers);
+    await setSetting(VISIBLE_PROVIDERS, providers);
     dispatch({type: SET_PROVIDERS, providers});
   };
 }
 
 export function removeVisibleProvider (provider) {
-  return (dispatch, getState) => {
+  return async (dispatch, getState) => {
     let currentProviders = getState().session.visibleProviders;
     const providers = without(currentProviders, provider);
-    setSetting(VISIBLE_PROVIDERS, providers);
+    await setSetting(VISIBLE_PROVIDERS, providers);
     dispatch({type: SET_PROVIDERS, providers});
   };
 }

--- a/app/shared/settings.js
+++ b/app/shared/settings.js
@@ -23,8 +23,8 @@ export async function getSetting (setting) {
   return DEFAULT_SETTINGS[setting];
 }
 
-export function setSetting (setting, value) {
-  settings.set(setting, value);
+export async function setSetting (setting, value) {
+  await settings.set(setting, value);
 }
 
 export default settings;

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "request-promise": "4.2.6",
         "semver": "7.5.1",
         "source-map-support": "0.5.21",
-        "uuid": "8.3.2",
+        "uuid": "9.0.0",
         "web2driver": "3.0.4",
         "xpath": "0.0.32"
       },
@@ -659,15 +659,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@appium/support/node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@appium/support/node_modules/which": {
@@ -9959,6 +9950,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devtools/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/devtron": {
@@ -26067,9 +26067,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -27497,12 +27497,6 @@
           "version": "3.8.0",
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.8.0.tgz",
           "integrity": "sha512-FVNSzGQz9Th+/9R6Lvv7WIAkstylfHN2/JYxkyhhmKFYh9At2DST8t6L6Lref9eYO8PXFTfG9Sg1Agg0K3vq3Q==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-          "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
           "dev": true
         },
         "which": {
@@ -34790,6 +34784,12 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "dev": true
         }
       }
     },
@@ -47534,9 +47534,9 @@
       "peer": true
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
+      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "request-promise": "4.2.6",
     "semver": "7.5.1",
     "source-map-support": "0.5.21",
-    "uuid": "8.3.2",
+    "uuid": "9.0.0",
     "web2driver": "3.0.4",
     "xpath": "0.0.32"
   },


### PR DESCRIPTION
This PR updates `uuid` to 9.0.0, and also reverts a previous commit where `setSetting` was changed to sync. For some reason `uuid` v9 causes saved session retrieval to start before the new session is finished saving, resulting in an error. With the re-added `await`, it works just fine.

Note: this package can probably be replaced with node's built-in `crypto.randomUUID`, once we update to `electron` 14+.