### PR TITLE
style: enhance find element modal

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -392,7 +392,6 @@ export function showLocatorTestModal () {
 export function hideLocatorTestModal () {
   return (dispatch) => {
     dispatch({type: HIDE_LOCATOR_TEST_MODAL});
-    dispatch({type: CLEAR_SEARCHED_FOR_ELEMENT_BOUNDS});
   };
 }
 
@@ -405,7 +404,6 @@ export function showSiriCommandModal () {
 export function hideSiriCommandModal () {
   return (dispatch) => {
     dispatch({type: HIDE_SIRI_COMMAND_MODAL});
-    dispatch({type: CLEAR_SEARCHED_FOR_ELEMENT_BOUNDS});
   };
 }
 
@@ -515,6 +513,7 @@ export function setLocatorTestElement (elementId) {
 export function clearSearchResults () {
   return (dispatch) => {
     dispatch({type: CLEAR_SEARCH_RESULTS});
+    dispatch({type: CLEAR_SEARCHED_FOR_ELEMENT_BOUNDS});
   };
 }
 

--- a/app/renderer/components/Inspector/DeviceActions.js
+++ b/app/renderer/components/Inspector/DeviceActions.js
@@ -18,16 +18,16 @@ class DeviceActions extends Component {
       driver
     } = this.props;
 
-    return <ButtonGroup>
-      {driver.client.isIOS && <div className={InspectorStyles['action-controls']}>
+    return <>
+      {driver.client.isIOS && <ButtonGroup className={InspectorStyles['action-controls']}>
         <Tooltip title={t('Press Home Button')}>
           <Button id='btnPressHomeButton' icon={<HiOutlineHome className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'executeScript', args: ['mobile:pressButton', [{name: 'home'}]]})}/>
         </Tooltip>
         <Tooltip title={t('Execute Siri Command')}>
           <Button id='siriCommand' icon={<HiOutlineMicrophone className={InspectorStyles['custom-button-icon']}/>} onClick={showSiriCommandModal} />
         </Tooltip>
-      </div>}
-      {driver.client.isAndroid && <div className={InspectorStyles['action-controls']}>
+      </ButtonGroup>}
+      {driver.client.isAndroid && <ButtonGroup className={InspectorStyles['action-controls']}>
         <Tooltip title={t('Press Back Button')}>
           <Button id='btnPressHomeButton' icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [4]})}/>
         </Tooltip>
@@ -37,8 +37,8 @@ class DeviceActions extends Component {
         <Tooltip title={t('Press App Switch Button')}>
           <Button id='btnPressHomeButton' icon={<BiSquare className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [187]})}/>
         </Tooltip>
-      </div>}
-    </ButtonGroup>;
+      </ButtonGroup>}
+    </>;
   }
 }
 

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -3,35 +3,35 @@ import { Input, Radio, Row } from 'antd';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
-class ElementLocator extends Component {
-
-  getLocatorStrategies (driver) {
-    let baseLocatorStrategies = [
-      ['id', 'Id'],
-      ['xpath', 'XPath'],
-      ['name', 'Name'],
-      ['class name', 'Class Name'],
-      ['accessibility id', 'Accessibility ID']
-    ];
-    if (driver.client.isIOS) {
+const locatorStrategies = (driver) => {
+  let baseLocatorStrategies = [
+    ['id', 'Id'],
+    ['xpath', 'XPath'],
+    ['name', 'Name'],
+    ['class name', 'Class Name'],
+    ['accessibility id', 'Accessibility ID']
+  ];
+  if (driver.client.isIOS) {
+    baseLocatorStrategies.push(
+      ['-ios predicate string', 'Predicate String'],
+      ['-ios class chain', 'Class Chain']
+    );
+  } else if (driver.client.isAndroid) {
+    if (driver.client.capabilities.automationName.toLowerCase() === 'espresso') {
       baseLocatorStrategies.push(
-        ['-ios predicate string', 'Predicate String'],
-        ['-ios class chain', 'Class Chain']
+        ['-android datamatcher', 'DataMatcher'],
+        ['-android viewtag', 'View Tag']
       );
-    } else if (driver.client.isAndroid) {
-      if (driver.client.capabilities.automationName.toLowerCase() === 'espresso') {
-        baseLocatorStrategies.push(
-          ['-android datamatcher', 'DataMatcher'],
-          ['-android viewtag', 'View Tag']
-        );
-      } else {
-        baseLocatorStrategies.push(
-          ['-android uiautomator', 'UIAutomator'],
-        );
-      }
+    } else {
+      baseLocatorStrategies.push(
+        ['-android uiautomator', 'UIAutomator'],
+      );
     }
-    return baseLocatorStrategies;
   }
+  return baseLocatorStrategies;
+};
+
+class ElementLocator extends Component {
 
   onSubmit () {
     const {locatedElements, locatorTestStrategy, locatorTestValue, searchForElement, clearSearchResults, hideLocatorTestModal} = this.props;
@@ -66,7 +66,7 @@ class ElementLocator extends Component {
         defaultValue={locatorTestStrategy}
       >
         <Row justify="center">
-          {this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
+          {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
             <Radio.Button value={strategyValue} key={strategyValue}>{strategyName}</Radio.Button>
           ))}
         </Row>

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -60,33 +60,36 @@ class ElementLocator extends Component {
       t,
     } = this.props;
 
-    return <Row justify="center">
-      <Radio.Group buttonStyle="solid"
-        className={InspectorStyles.locatorStrategyGroup}
-        onChange={(e) => setLocatorTestStrategy(e.target.value)}
-        defaultValue={locatorTestStrategy}
-      >
-        <Row justify="center">
-          {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
-            <Radio.Button
-              className={InspectorStyles.locatorStrategyBtn}
-              value={strategyValue}
-              key={strategyValue}
-            >
-              {strategyName}
-            </Radio.Button>
-          ))}
-        </Row>
-      </Radio.Group>
+    return <>
+      {t('locatorStrategy')}
+      <Row justify="center">
+        <Radio.Group buttonStyle="solid"
+          className={InspectorStyles.locatorStrategyGroup}
+          onChange={(e) => setLocatorTestStrategy(e.target.value)}
+          defaultValue={locatorTestStrategy}
+        >
+          <Row justify="center">
+            {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
+              <Radio.Button
+                className={InspectorStyles.locatorStrategyBtn}
+                value={strategyValue}
+                key={strategyValue}
+              >
+                {strategyName}
+              </Radio.Button>
+            ))}
+          </Row>
+        </Radio.Group>
+      </Row>
+      {t('selector')}
       <Input.TextArea
         className={InspectorStyles.locatorSelectorTextArea}
-        placeholder={t('selector')}
         onChange={(e) => setLocatorTestValue(e.target.value)}
         value={locatorTestValue}
         allowClear={true}
         rows={3}
       />
-    </Row>;
+    </>;
   }
 }
 

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -3,32 +3,33 @@ import { Input, Radio, Row } from 'antd';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
+const STRAT_ID = ['id', 'Id'];
+const STRAT_XPATH = ['xpath', 'XPath'];
+const STRAT_NAME = ['name', 'Name'];
+const STRAT_CLASS_NAME = ['class name', 'Class Name'];
+const STRAT_ACCESSIBILITY_ID = ['accessibility id', 'Accessibility ID'];
+const STRAT_PREDICATE = ['-ios predicate string', 'Predicate String'];
+const STRAT_CLASS_CHAIN = ['-ios class chain', 'Class Chain'];
+const STRAT_UIAUTOMATOR = ['-android uiautomator', 'UIAutomator'];
+const STRAT_DATAMATCHER = ['-android datamatcher', 'DataMatcher'];
+const STRAT_VIEWTAG = ['-android viewtag', 'View Tag'];
+
 const locatorStrategies = (driver) => {
-  let baseLocatorStrategies = [
-    ['id', 'Id'],
-    ['xpath', 'XPath'],
-    ['name', 'Name'],
-    ['class name', 'Class Name'],
-    ['accessibility id', 'Accessibility ID']
-  ];
-  if (['ios', 'mac'].includes(driver.client.capabilities.platformName.toLowerCase())) {
-    baseLocatorStrategies.push(
-      ['-ios predicate string', 'Predicate String'],
-      ['-ios class chain', 'Class Chain']
-    );
-  } else if (driver.client.isAndroid) {
-    if (driver.client.capabilities.automationName.toLowerCase() === 'espresso') {
-      baseLocatorStrategies.push(
-        ['-android datamatcher', 'DataMatcher'],
-        ['-android viewtag', 'View Tag']
-      );
-    } else {
-      baseLocatorStrategies.push(
-        ['-android uiautomator', 'UIAutomator'],
-      );
-    }
+  const automationName = driver.client.capabilities.automationName.toLowerCase();
+  let strategies = [STRAT_ID, STRAT_XPATH, STRAT_NAME, STRAT_CLASS_NAME, STRAT_ACCESSIBILITY_ID];
+  switch (automationName) {
+    case 'xcuitest':
+    case 'mac2':
+      strategies.push(STRAT_PREDICATE, STRAT_CLASS_CHAIN);
+      break;
+    case 'espresso':
+      strategies.push(STRAT_DATAMATCHER, STRAT_VIEWTAG);
+      break;
+    case 'uiautomator2':
+      strategies.push(STRAT_UIAUTOMATOR);
+      break;
   }
-  return baseLocatorStrategies;
+  return strategies;
 };
 
 class ElementLocator extends Component {

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -1,9 +1,7 @@
 import React, { Component } from 'react';
-import { Input, Select, Row } from 'antd';
+import { Input, Segmented, Row } from 'antd';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
-
-const { Option } = Select;
 
 class ElementLocator extends Component {
 
@@ -61,16 +59,16 @@ class ElementLocator extends Component {
       t,
     } = this.props;
 
-    return <div>
-      <Row>
-        {t('locatorStrategy')}
-        <Select className={InspectorStyles['locator-strategy-selector']}
+    return <>
+      {t('locatorStrategy')}
+      <Row className={InspectorStyles.locatorStrategySegmentedRow}>
+        <Segmented
           onChange={(value) => setLocatorTestStrategy(value)}
-          value={locatorTestStrategy}>
-          {this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
-            <Option key={strategyValue} value={strategyValue}>{strategyName}</Option>
+          value={locatorTestStrategy}
+          options={this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
+            {label: strategyName, value: strategyValue}
           ))}
-        </Select>
+        />
       </Row>
       {t('selector')}
       <Row>
@@ -82,7 +80,7 @@ class ElementLocator extends Component {
           rows={3}
         />
       </Row>
-    </div>;
+    </>;
   }
 }
 

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -11,7 +11,7 @@ const locatorStrategies = (driver) => {
     ['class name', 'Class Name'],
     ['accessibility id', 'Accessibility ID']
   ];
-  if (driver.client.isIOS) {
+  if (['ios', 'mac'].includes(driver.client.capabilities.platformName.toLowerCase())) {
     baseLocatorStrategies.push(
       ['-ios predicate string', 'Predicate String'],
       ['-ios class chain', 'Class Chain']

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -72,7 +72,13 @@ class ElementLocator extends Component {
       >
         <Row justify="center">
           {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
-            <Radio.Button value={strategyValue} key={strategyValue}>{strategyName}</Radio.Button>
+            <Radio.Button
+              className={InspectorStyles.locatorStrategyBtn}
+              value={strategyValue}
+              key={strategyValue}
+            >
+              {strategyName}
+            </Radio.Button>
           ))}
         </Row>
       </Radio.Group>

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -13,6 +13,7 @@ const STRAT_CLASS_CHAIN = ['-ios class chain', 'Class Chain'];
 const STRAT_UIAUTOMATOR = ['-android uiautomator', 'UIAutomator'];
 const STRAT_DATAMATCHER = ['-android datamatcher', 'DataMatcher'];
 const STRAT_VIEWTAG = ['-android viewtag', 'View Tag'];
+const STRAT_TAGNAME = ['tag name', 'Tag Name'];
 
 const locatorStrategies = (driver) => {
   const automationName = driver.client.capabilities.automationName.toLowerCase();
@@ -27,6 +28,9 @@ const locatorStrategies = (driver) => {
       break;
     case 'uiautomator2':
       strategies.push(STRAT_UIAUTOMATOR);
+      break;
+    case 'windows':
+      strategies.push(STRAT_TAGNAME);
       break;
   }
   return strategies;

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Input, Segmented, Row } from 'antd';
+import { Input, Radio, Row } from 'antd';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
@@ -61,25 +61,25 @@ class ElementLocator extends Component {
 
     return <>
       {t('locatorStrategy')}
-      <Row className={InspectorStyles.locatorStrategySegmentedRow}>
-        <Segmented
-          onChange={(value) => setLocatorTestStrategy(value)}
-          value={locatorTestStrategy}
-          options={this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
-            {label: strategyName, value: strategyValue}
+      <Radio.Group buttonStyle="solid"
+        className={InspectorStyles.locatorStrategyGroup}
+        onChange={(e) => setLocatorTestStrategy(e.target.value)}
+        defaultValue={locatorTestStrategy}
+      >
+        <Row justify="center">
+          {this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
+            <Radio.Button value={strategyValue} key={strategyValue}>{strategyName}</Radio.Button>
           ))}
-        />
-      </Row>
+        </Row>
+      </Radio.Group>
       {t('selector')}
-      <Row>
-        <Input.TextArea
-          className={InspectorStyles.locatorStrategySelectorTextarea}
-          onChange={(e) => setLocatorTestValue(e.target.value)}
-          value={locatorTestValue}
-          allowClear={true}
-          rows={3}
-        />
-      </Row>
+      <Input.TextArea
+        className={InspectorStyles.locatorSelectorTextArea}
+        onChange={(e) => setLocatorTestValue(e.target.value)}
+        value={locatorTestValue}
+        allowClear={true}
+        rows={3}
+      />
     </>;
   }
 }

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -72,9 +72,14 @@ class ElementLocator extends Component {
           ))}
         </Select>
       </Row>
+      {t('selector')}
       <Row>
-        {t('selector')}
-        <Input.TextArea className={InspectorStyles['locator-strategy-selector']} onChange={(e) => setLocatorTestValue(e.target.value)} value={locatorTestValue} />
+        <Input.TextArea
+          className={InspectorStyles.locatorStrategySelectorTextarea}
+          onChange={(e) => setLocatorTestValue(e.target.value)}
+          value={locatorTestValue}
+          rows={3}
+        />
       </Row>
     </div>;
   }

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -78,6 +78,7 @@ class ElementLocator extends Component {
           className={InspectorStyles.locatorStrategySelectorTextarea}
           onChange={(e) => setLocatorTestValue(e.target.value)}
           value={locatorTestValue}
+          allowClear={true}
           rows={3}
         />
       </Row>

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -17,18 +17,18 @@ class ElementLocator extends Component {
     ];
     if (driver.client.isIOS) {
       baseLocatorStrategies.push(
-        ['-ios predicate string', 'Predicate String (iOS)'],
-        ['-ios class chain', 'Class Chain (iOS)']
+        ['-ios predicate string', 'Predicate String'],
+        ['-ios class chain', 'Class Chain']
       );
     } else if (driver.client.isAndroid) {
       if (driver.client.capabilities.automationName.toLowerCase() === 'espresso') {
         baseLocatorStrategies.push(
-          ['-android datamatcher', 'DataMatcher Selector (Android Espresso)'],
-          ['-android viewtag', 'Android View Tag (Android Espresso)']
+          ['-android datamatcher', 'DataMatcher'],
+          ['-android viewtag', 'View Tag']
         );
       } else {
         baseLocatorStrategies.push(
-          ['-android uiautomator', 'UIAutomator Selector (Android UiAutomator2)'],
+          ['-android uiautomator', 'UIAutomator'],
         );
       }
     }

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -7,6 +7,34 @@ const { Option } = Select;
 
 class ElementLocator extends Component {
 
+  getLocatorStrategies (driver) {
+    let baseLocatorStrategies = [
+      ['id', 'Id'],
+      ['xpath', 'XPath'],
+      ['name', 'Name'],
+      ['class name', 'Class Name'],
+      ['accessibility id', 'Accessibility ID']
+    ];
+    if (driver.client.isIOS) {
+      baseLocatorStrategies.push(
+        ['-ios predicate string', 'Predicate String (iOS)'],
+        ['-ios class chain', 'Class Chain (iOS)']
+      );
+    } else if (driver.client.isAndroid) {
+      if (driver.client.capabilities.automationName.toLowerCase() === 'espresso') {
+        baseLocatorStrategies.push(
+          ['-android datamatcher', 'DataMatcher Selector (Android Espresso)'],
+          ['-android viewtag', 'Android View Tag (Android Espresso)']
+        );
+      } else {
+        baseLocatorStrategies.push(
+          ['-android uiautomator', 'UIAutomator Selector (Android UiAutomator2)'],
+        );
+      }
+    }
+    return baseLocatorStrategies;
+  }
+
   onSubmit () {
     const {locatedElements, locatorTestStrategy, locatorTestValue, searchForElement, clearSearchResults, hideLocatorTestModal} = this.props;
     if (locatedElements) {
@@ -29,21 +57,9 @@ class ElementLocator extends Component {
       locatorTestValue,
       setLocatorTestStrategy,
       locatorTestStrategy,
+      driver,
       t,
     } = this.props;
-
-    const locatorStrategies = [
-      ['id', 'Id'],
-      ['xpath', 'XPath'],
-      ['name', 'Name'],
-      ['class name', 'Class Name'],
-      ['accessibility id', 'Accessibility ID'],
-      ['-android uiautomator', 'UIAutomator Selector (Android UiAutomator2)'],
-      ['-android datamatcher', 'DataMatcher Selector (Android Espresso)'],
-      ['-android viewtag', 'Android View Tag (Android Espresso)'],
-      ['-ios predicate string', 'Predicate String (iOS)'],
-      ['-ios class chain', 'Class Chain (iOS)'],
-    ];
 
     return <div>
       <Row>
@@ -51,7 +67,7 @@ class ElementLocator extends Component {
         <Select className={InspectorStyles['locator-strategy-selector']}
           onChange={(value) => setLocatorTestStrategy(value)}
           value={locatorTestStrategy}>
-          {locatorStrategies.map(([strategyValue, strategyName]) => (
+          {this.getLocatorStrategies(driver).map(([strategyValue, strategyName]) => (
             <Option key={strategyValue} value={strategyValue}>{strategyName}</Option>
           ))}
         </Select>

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -60,7 +60,6 @@ class ElementLocator extends Component {
     } = this.props;
 
     return <>
-      {t('locatorStrategy')}
       <Radio.Group buttonStyle="solid"
         className={InspectorStyles.locatorStrategyGroup}
         onChange={(e) => setLocatorTestStrategy(e.target.value)}
@@ -72,9 +71,9 @@ class ElementLocator extends Component {
           ))}
         </Row>
       </Radio.Group>
-      {t('selector')}
       <Input.TextArea
         className={InspectorStyles.locatorSelectorTextArea}
+        placeholder={t('selector')}
         onChange={(e) => setLocatorTestValue(e.target.value)}
         value={locatorTestValue}
         allowClear={true}

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -59,7 +59,7 @@ class ElementLocator extends Component {
       t,
     } = this.props;
 
-    return <>
+    return <Row justify="center">
       <Radio.Group buttonStyle="solid"
         className={InspectorStyles.locatorStrategyGroup}
         onChange={(e) => setLocatorTestStrategy(e.target.value)}
@@ -79,7 +79,7 @@ class ElementLocator extends Component {
         allowClear={true}
         rows={3}
       />
-    </>;
+    </Row>;
   }
 }
 

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -13,7 +13,6 @@ const STRAT_CLASS_CHAIN = ['-ios class chain', 'Class Chain'];
 const STRAT_UIAUTOMATOR = ['-android uiautomator', 'UIAutomator'];
 const STRAT_DATAMATCHER = ['-android datamatcher', 'DataMatcher'];
 const STRAT_VIEWTAG = ['-android viewtag', 'View Tag'];
-const STRAT_TAGNAME = ['tag name', 'Tag Name'];
 
 const locatorStrategies = (driver) => {
   const automationName = driver.client.capabilities.automationName.toLowerCase();
@@ -28,9 +27,6 @@ const locatorStrategies = (driver) => {
       break;
     case 'uiautomator2':
       strategies.push(STRAT_UIAUTOMATOR);
-      break;
-    case 'windows':
-      strategies.push(STRAT_TAGNAME);
       break;
   }
   return strategies;

--- a/app/renderer/components/Inspector/GestureEditor.js
+++ b/app/renderer/components/Inspector/GestureEditor.js
@@ -441,7 +441,7 @@ class GestureEditor extends Component {
         extra={<>{tick.type === POINTER_MOVE && tapCoordinatesBtn(tick.id)}
           <Button size='small' type='text' icon={<CloseOutlined />} key={`${tick.id}.remove`}
             onClick={() => this.deleteTick(tick.id[0], tick.id)}/></>}>
-        <Space className={InspectorCSS['space-container']} direction='vertical' size='middle'>
+        <Space className={InspectorCSS.spaceContainer} direction='vertical' size='middle'>
           {tickType(tick)}
           {(tick.type === POINTER_MOVE || tick.type === PAUSE) && tickDuration(tick)}
           {(tick.type === POINTER_DOWN || tick.type === POINTER_UP) && tickButton(tick)}

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -471,8 +471,7 @@
     width: 100%;
 }
 
-.locator-strategy-selector {
-    width: 100%;
+.locatorStrategySegmentedRow {
     margin-bottom: 1em;
 }
 

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -467,6 +467,7 @@
 }
 
 .locatorStrategyBtn {
+    margin-top: -1px;
     min-width: 25%;
     text-align: center;
 }

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -466,6 +466,11 @@
     margin-bottom: 12px;
 }
 
+.locatorStrategyBtn {
+    min-width: 25%;
+    text-align: center;
+}
+
 .locatorSelectorTextArea {
     width: 100%;
 }

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -397,6 +397,11 @@
     justify-content: center;
 }
 
+.context-selector {
+    width: 100%;
+    margin-bottom: 1em;
+}
+
 .sourceTag {
     color: #7d2020;
     font-weight: normal

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -433,7 +433,27 @@
     margin-top: 0.5em;
 }
 
-.locator-test-interactions-container div {
+.searchResultsContainer {
+    width: 100%;
+    flex: 1;
+    min-height: 24px;
+    max-height: 150px;
+    overflow: auto;
+    border-style: solid;
+    border-width: 1px;
+}
+
+.searchResultsContainer :global(.ant-list-item) {
+    padding: 4px 6px !important;
+    height: 25px;
+    text-align: left;
+}
+
+.searchResultsSelectedItem {
+    background-color: #b8ddff;
+}
+
+.locator-test-interactions-container .searchResultsInnerDiv {
     display: inline-block;
     width: 50%;
     padding: 4px;
@@ -465,10 +485,6 @@
 .element-count-container {
     margin-top: 0.5em;
     margin-left: 0.5em;
-}
-
-.locator-search-results {
-    width: 100%;
 }
 
 .locatorStrategyGroup {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -428,11 +428,6 @@
     width: 150px;
 }
 
-.locator-test-interactions-container {
-    float: right;
-    margin-top: 0.5em;
-}
-
 .searchResultsContainer {
     width: 100%;
     flex: 1;
@@ -453,33 +448,13 @@
     background-color: #b8ddff;
 }
 
-.locator-test-interactions-container .searchResultsInnerDiv {
-    display: inline-block;
-    width: 50%;
-    padding: 4px;
+.searchResultsActions {
+    width: 350px;
 }
 
-.locator-test-interactions-container .send-keys-container {
-    width: 100%;
-}
-
-.locator-test-interactions-container .send-keys-container input {
-    width: 76%;
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-.locator-test-interactions-container .send-keys-container button {
-    position: absolute;
-    right: 0;
-    width: 25%;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
-}
-
-.locator-test-interactions-container div button,
-.locator-test-interactions-container div input {
-    width: 100%;
+.searchResultsKeyInput {
+    height: 32px;
+    width: calc(100% - 96px) !important;
 }
 
 .element-count-container {
@@ -702,7 +677,7 @@
     top: 40%;
 }
 
-.space-container {
+.spaceContainer {
     display: flex;
 }
 

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -471,11 +471,11 @@
     width: 100%;
 }
 
-.locatorStrategySegmentedRow {
-    margin-bottom: 1em;
+.locatorStrategyGroup {
+    margin-bottom: 12px;
 }
 
-.locatorStrategySelectorTextarea {
+.locatorSelectorTextArea {
     width: 100%;
 }
 

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -428,7 +428,7 @@
     width: 150px;
 }
 
-.searchResultsContainer {
+.searchResultsList {
     width: 100%;
     flex: 1;
     min-height: 24px;
@@ -438,7 +438,7 @@
     border-width: 1px;
 }
 
-.searchResultsContainer :global(.ant-list-item) {
+.searchResultsList :global(.ant-list-item) {
     padding: 4px 6px !important;
     height: 25px;
     text-align: left;

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -454,7 +454,7 @@
 
 .searchResultsKeyInput {
     height: 32px;
-    width: calc(100% - 96px) !important;
+    width: calc(100% - 64px);
 }
 
 .element-count-container {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -445,7 +445,7 @@
 }
 
 .searchResultsSelectedItem {
-    background-color: #b8ddff;
+    background-color: #bae7ff;
 }
 
 .searchResultsActions {

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -476,6 +476,10 @@
     margin-bottom: 1em;
 }
 
+.locatorStrategySelectorTextarea {
+    width: 100%;
+}
+
 .coordinatesContainer {
     position: absolute;
     background: rgba(255, 250, 205, 0.8);

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { clipboard } from '../../polyfills';
 import { Input, Row, Button, Badge, List, Space, Tooltip } from 'antd';
-import { CopyOutlined, AimOutlined, UndoOutlined } from '@ant-design/icons';
+import { CopyOutlined, AimOutlined, ClearOutlined, SendOutlined } from '@ant-design/icons';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
@@ -54,52 +54,45 @@ class LocatedElements extends Component {
           </div>
         </Row>
         <Row justify='center'>
-          <ButtonGroup>
-            <Tooltip title={t('Copy ID')} placement='bottom'>
-              <Button
+          <Space direction='horizontal' size='small'>
+            <ButtonGroup>
+              <Tooltip title={t('Copy ID')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  icon={<CopyOutlined/>}
+                  onClick={() => clipboard.writeText(locatorTestElement)}/>
+              </Tooltip>
+            </ButtonGroup>
+            <Input.Group compact className={InspectorStyles.searchResultsActions}>
+              <Tooltip title={t('Tap Element')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  icon={<AimOutlined/>}
+                  onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
+                />
+              </Tooltip>
+              <Input className={InspectorStyles.searchResultsKeyInput}
                 disabled={!locatorTestElement}
-                icon={<CopyOutlined/>}
-                onClick={() => clipboard.writeText(locatorTestElement)}/>
-            </Tooltip>
-            <Tooltip title={t('Tap Element')} placement='bottom'>
-              <Button
-                disabled={!locatorTestElement}
-                icon={<AimOutlined/>}
-                onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
-              />
-            </Tooltip>
-            <Tooltip title={t('Clear')} placement='bottom'>
-              <Button
-                disabled={!locatorTestElement}
-                id='btnClearElement'
-                icon={<UndoOutlined/>}
-                onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
-              />
-            </Tooltip>
-          </ButtonGroup>
-          <Input.Group compact>
-            <Input
-              disabled={!locatorTestElement}
-              placeholder={t('Enter keys')}
-              onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
-            <Button
-              disabled={!locatorTestElement}
-              onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
-            >
-              {t('Send Keys')}
-            </Button>
-          </Input.Group>
-          <div className={InspectorStyles['locator-test-interactions-container']}>
-            <div className={InspectorStyles['send-keys-container']}>
-              <Input size='small' placeholder={t('Enter keys')} onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
-              <Button size='small'
-                disabled={!locatorTestElement}
-                onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
-              >
-                {t('Send Keys')}
-              </Button>
-            </div>
-          </div>
+                placeholder={t('Enter keys')}
+                allowClear={true}
+                onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
+              <Tooltip title={t('Send Keys')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  icon={<SendOutlined/>}
+                  onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
+                />
+              </Tooltip>
+              <Tooltip title={t('Clear')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  id='btnClearElement'
+                  icon={<ClearOutlined/>}
+                  onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
+                />
+              </Tooltip>
+            </Input.Group>
+          </Space>
         </Row>
       </Space>}
     </>;

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -55,14 +55,12 @@ class LocatedElements extends Component {
         </Row>
         <Row justify='center'>
           <Space direction='horizontal' size='small'>
-            <ButtonGroup>
-              <Tooltip title={t('Copy ID')} placement='bottom'>
-                <Button
-                  disabled={!locatorTestElement}
-                  icon={<CopyOutlined/>}
-                  onClick={() => clipboard.writeText(locatorTestElement)}/>
-              </Tooltip>
-            </ButtonGroup>
+            <Tooltip title={t('Copy ID')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<CopyOutlined/>}
+                onClick={() => clipboard.writeText(locatorTestElement)}/>
+            </Tooltip>
             <ButtonGroup className={InspectorStyles.searchResultsActions}>
               <Tooltip title={t('Tap')} placement='bottom'>
                 <Button

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -42,7 +42,7 @@ class LocatedElements extends Component {
         {locatedElements.length > 0 &&
         <div className={InspectorStyles['locator-test-interactions-container']}>
           <select className={InspectorStyles['locator-search-results']}
-            multiple='true'
+            multiple={true}
             onChange={(e) => setLocatorTestElement(e.target.value)}
             value={[locatorTestElement]}>
             {locatedElements.map((elementId) => (

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { clipboard } from '../../polyfills';
-import { Input, Row, Col, Button } from 'antd';
+import { Input, Row, Col, Button, Badge } from 'antd';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
@@ -32,12 +32,12 @@ class LocatedElements extends Component {
     } = this.props;
 
     return <Row>
-      <p className={InspectorStyles['element-count-container']}>
+      <div>
         {locatedElements.length === 0 &&
           <i>{t('couldNotFindAnyElements')}</i>}
         {locatedElements.length > 0 &&
-          t('elementsCount', {elementCount: locatedElements.length})}
-      </p>
+          <span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span>}
+      </div>
       <Col>
         {locatedElements.length > 0 &&
         <div className={InspectorStyles['locator-test-interactions-container']}>

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -70,7 +70,7 @@ class LocatedElements extends Component {
             <ButtonGroup className={InspectorStyles.searchResultsActions}>
               <Input className={InspectorStyles.searchResultsKeyInput}
                 disabled={!locatorTestElement}
-                placeholder={t('Enter keys')}
+                placeholder={t('Enter Keys to Send')}
                 allowClear={true}
                 onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
               <Tooltip title={t('Send Keys')} placement='bottom'>

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -39,19 +39,18 @@ class LocatedElements extends Component {
       {locatedElements.length > 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
         <Row><span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span></Row>
         <Row>
-          <div className={InspectorStyles.searchResultsContainer}>
-            <List bordered size='small'
-              dataSource={locatedElements}
-              renderItem={(elementId) =>
-                <List.Item type='text'
-                  className={locatorTestElement === elementId ? InspectorStyles.searchResultsSelectedItem : ''}
-                  onClick={() => setLocatorTestElement(elementId)}
-                >
-                  {elementId}
-                </List.Item>
-              }
-            />
-          </div>
+          <List className={InspectorStyles.searchResultsList}
+            size='small'
+            dataSource={locatedElements}
+            renderItem={(elementId) =>
+              <List.Item type='text'
+                className={locatorTestElement === elementId ? InspectorStyles.searchResultsSelectedItem : ''}
+                onClick={() => setLocatorTestElement(elementId)}
+              >
+                {elementId}
+              </List.Item>
+            }
+          />
         </Row>
         <Row justify='center'>
           <Space direction='horizontal' size='small'>

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,8 +1,11 @@
 import React, { Component } from 'react';
 import { clipboard } from '../../polyfills';
-import { Input, Row, Col, Button, Badge } from 'antd';
+import { Input, Row, Button, Badge, List, Space, Tooltip } from 'antd';
+import { CopyOutlined, AimOutlined, UndoOutlined } from '@ant-design/icons';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
+
+const ButtonGroup = Button.Group;
 
 class LocatedElements extends Component {
 
@@ -31,60 +34,75 @@ class LocatedElements extends Component {
       t,
     } = this.props;
 
-    return <Row>
-      <div>
-        {locatedElements.length === 0 &&
-          <i>{t('couldNotFindAnyElements')}</i>}
-        {locatedElements.length > 0 &&
-          <span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span>}
-      </div>
-      <Col>
-        {locatedElements.length > 0 &&
-        <div className={InspectorStyles['locator-test-interactions-container']}>
-          <select className={InspectorStyles['locator-search-results']}
-            multiple={true}
-            onChange={(e) => setLocatorTestElement(e.target.value)}
-            value={[locatorTestElement]}>
-            {locatedElements.map((elementId) => (
-              <option key={elementId} value={elementId}>{elementId}</option>
-            ))}
-          </select>
-          <div>
-            <Button size='small'
-              disabled={!locatorTestElement}
-              onClick={() => clipboard.writeText(locatorTestElement)}
-            >
-              {t('Copy ID')}
-            </Button>
+    return <>
+      {locatedElements.length === 0 && <Row><i>{t('couldNotFindAnyElements')}</i></Row>}
+      {locatedElements.length > 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+        <Row><span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span></Row>
+        <Row>
+          <div className={InspectorStyles.searchResultsContainer}>
+            <List bordered size='small'
+              dataSource={locatedElements}
+              renderItem={(elementId) =>
+                <List.Item type='text'
+                  className={locatorTestElement === elementId ? InspectorStyles.searchResultsSelectedItem : ''}
+                  onClick={() => setLocatorTestElement(elementId)}
+                >
+                  {elementId}
+                </List.Item>
+              }
+            />
           </div>
-          <div>
-            <Button size='small'
+        </Row>
+        <Row justify='center'>
+          <ButtonGroup>
+            <Tooltip title={t('Copy ID')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<CopyOutlined/>}
+                onClick={() => clipboard.writeText(locatorTestElement)}/>
+            </Tooltip>
+            <Tooltip title={t('Tap Element')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<AimOutlined/>}
+                onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
+              />
+            </Tooltip>
+            <Tooltip title={t('Clear')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                id='btnClearElement'
+                icon={<UndoOutlined/>}
+                onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
+              />
+            </Tooltip>
+          </ButtonGroup>
+          <Input.Group compact>
+            <Input
               disabled={!locatorTestElement}
-              onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
-            >
-              {t('Tap Element')}
-            </Button>
-          </div>
-          <div>
-            <Button size='small'
-              disabled={!locatorTestElement}
-              onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
-            >
-              {t('Clear')}
-            </Button>
-          </div>
-          <div className={InspectorStyles['send-keys-container']}>
-            <Input size='small' placeholder={t('Enter keys')} onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
-            <Button size='small'
+              placeholder={t('Enter keys')}
+              onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
+            <Button
               disabled={!locatorTestElement}
               onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
             >
               {t('Send Keys')}
             </Button>
+          </Input.Group>
+          <div className={InspectorStyles['locator-test-interactions-container']}>
+            <div className={InspectorStyles['send-keys-container']}>
+              <Input size='small' placeholder={t('Enter keys')} onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
+              <Button size='small'
+                disabled={!locatorTestElement}
+                onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
+              >
+                {t('Send Keys')}
+              </Button>
+            </div>
           </div>
-        </div>}
-      </Col>
-    </Row>;
+        </Row>
+      </Space>}
+    </>;
   }
 }
 

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -64,7 +64,7 @@ class LocatedElements extends Component {
               </Tooltip>
             </ButtonGroup>
             <ButtonGroup className={InspectorStyles.searchResultsActions}>
-              <Tooltip title={t('Tap Element')} placement='bottom'>
+              <Tooltip title={t('Tap')} placement='bottom'>
                 <Button
                   disabled={!locatorTestElement}
                   icon={<AimOutlined/>}

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -61,14 +61,14 @@ class LocatedElements extends Component {
                 icon={<CopyOutlined/>}
                 onClick={() => clipboard.writeText(locatorTestElement)}/>
             </Tooltip>
+            <Tooltip title={t('Tap')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<AimOutlined/>}
+                onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
+              />
+            </Tooltip>
             <ButtonGroup className={InspectorStyles.searchResultsActions}>
-              <Tooltip title={t('Tap')} placement='bottom'>
-                <Button
-                  disabled={!locatorTestElement}
-                  icon={<AimOutlined/>}
-                  onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
-                />
-              </Tooltip>
               <Input className={InspectorStyles.searchResultsKeyInput}
                 disabled={!locatorTestElement}
                 placeholder={t('Enter keys')}

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -63,7 +63,7 @@ class LocatedElements extends Component {
                   onClick={() => clipboard.writeText(locatorTestElement)}/>
               </Tooltip>
             </ButtonGroup>
-            <Input.Group compact className={InspectorStyles.searchResultsActions}>
+            <ButtonGroup className={InspectorStyles.searchResultsActions}>
               <Tooltip title={t('Tap Element')} placement='bottom'>
                 <Button
                   disabled={!locatorTestElement}
@@ -91,7 +91,7 @@ class LocatedElements extends Component {
                   onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
                 />
               </Tooltip>
-            </Input.Group>
+            </ButtonGroup>
           </Space>
         </Row>
       </Space>}

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -47,18 +47,15 @@ class LocatorTestModal extends Component {
       confirmLoading={isSearchingForElements}
       onCancel={this.onCancel.bind(this)}
       footer=
-        {[
-          locatedElements &&
+        {<>
+          {locatedElements &&
           <Button onClick={(e) => e.preventDefault() || clearSearchResults()}>
             Back
-          </Button>,
+          </Button>}
           <Button onClick={this.onSubmit.bind(this)} type="primary">
-            {locatedElements ?
-              t('Done')
-              :
-              t('Search')}
+            {locatedElements ? t('Done') : t('Search')}
           </Button>
-        ]}>
+        </>}>
       {!locatedElements && <ElementLocator {...this.props} />}
       {locatedElements && <LocatedElements {...this.props} />}
     </Modal>;

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -50,7 +50,7 @@ class LocatorTestModal extends Component {
         {<>
           {locatedElements &&
           <Button onClick={(e) => e.preventDefault() || clearSearchResults()}>
-            Back
+            {t('Back')}
           </Button>}
           <Button onClick={this.onSubmit.bind(this)} type="primary">
             {locatedElements ? t('Done') : t('Search')}

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -43,7 +43,6 @@ class LocatorTestModal extends Component {
     // Footer displays all the buttons at the bottom of the Modal
     return <Modal open={isLocatorTestModalVisible}
       title={t('Search for element')}
-      confirmLoading={isSearchingForElements}
       onCancel={this.onCancel.bind(this)}
       footer=
         {<>
@@ -51,7 +50,7 @@ class LocatorTestModal extends Component {
           <Button onClick={(e) => e.preventDefault() || clearSearchResults()}>
             {t('Back')}
           </Button>}
-          <Button onClick={this.onSubmit.bind(this)} type="primary">
+          <Button loading={isSearchingForElements} onClick={this.onSubmit.bind(this)} type="primary">
             {locatedElements ? t('Done') : t('Search')}
           </Button>
         </>}>

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -43,6 +43,7 @@ class LocatorTestModal extends Component {
     // Footer displays all the buttons at the bottom of the Modal
     return <Modal open={isLocatorTestModalVisible}
       title={t('Search for element')}
+      width={600}
       confirmLoading={isSearchingForElements}
       onCancel={this.onCancel.bind(this)}
       footer=

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -43,7 +43,6 @@ class LocatorTestModal extends Component {
     // Footer displays all the buttons at the bottom of the Modal
     return <Modal open={isLocatorTestModalVisible}
       title={t('Search for element')}
-      width={600}
       confirmLoading={isSearchingForElements}
       onCancel={this.onCancel.bind(this)}
       footer=

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -325,7 +325,7 @@ class SelectedElement extends Component {
         onOk={this.handleSendKeys}
       >
         <Input
-          placeholder={t('Enter keys')}
+          placeholder={t('Enter Keys to Send')}
           value={sendKeys}
           onChange={(e) => setFieldValue('sendKeys', e.target.value)}
         />

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -59,7 +59,7 @@ class SelectedElement extends Component {
           setContext(value);
           applyClientMethod({methodName: 'switchContext', args: [value]});
         }}
-        className={styles['locator-strategy-selector']}>
+        className={styles['context-selector']}>
           {contexts.map(({id, title}) =>
             <Select.Option key={id} value={id}>{title ? `${title} (${id})` : id}</Select.Option>
           )}

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -152,7 +152,7 @@
   "attachToSession": "Attach to Session",
   "selectedElement": "Selected Element",
   "couldNotFindAnyElements": "Could not find any elements",
-  "elementsCount": "Elements ({{elementCount}})",
+  "elementsCount": "Elements found:",
   "xCoordinate": "X: {{x}}",
   "yCoordinate": "Y: {{y}}",
   "SauceLabs Data Center": "SauceLabs Data Center",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -83,6 +83,7 @@
   "experitestAccessKeyURLRequired": "Experitest AccessKey and URL are required",
   "experitestAccessKey": "Experitest AccessKey",
   "experitestUrl": "Experitest Url",
+  "locatorStrategy": "Locator Strategy:",
   "selector": "Selector:",
   "couldNotObtainScreenshot": "Could not obtain screenshot: {{screenshotError}}",
   "selectElementInSource": "Select an element in the source to begin.",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -115,7 +115,6 @@
   "Your session is about to expire": "Your session is about to expire",
   "Enter keys": "Enter keys",
   "Copy ID": "Copy ID",
-  "Tap Element": "Tap Element",
   "Clear": "Clear",
   "Send Keys": "Send Keys",
   "Done": "Done",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -83,7 +83,6 @@
   "experitestAccessKeyURLRequired": "Experitest AccessKey and URL are required",
   "experitestAccessKey": "Experitest AccessKey",
   "experitestUrl": "Experitest Url",
-  "locatorStrategy": "Locator Strategy:",
   "selector": "Selector:",
   "couldNotObtainScreenshot": "Could not obtain screenshot: {{screenshotError}}",
   "selectElementInSource": "Select an element in the source to begin.",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -113,7 +113,7 @@
   "Keep Session Running": "Keep Session Running",
   "Quit Session": "Quit Session",
   "Your session is about to expire": "Your session is about to expire",
-  "Enter keys": "Enter keys",
+  "Enter Keys to Send": "Enter Keys to Send",
   "Copy ID": "Copy ID",
   "Clear": "Clear",
   "Send Keys": "Send Keys",


### PR DESCRIPTION
This PR provides various visual improvements to the find element modal:
* Replace locator strategy dropdown with radio buttons (one less click and no scroll)
* Hide locator strategies that are unavailable for current `automationType`
* Render results count using antd Badge
* Render results list with responsive height (1-6 rows)
* Replace text for found element action buttons with icons + tooltip
* Add a clear button to selector and send keys input fields if text is entered

Here is a demonstration of the new behavior:

https://github.com/appium/appium-inspector/assets/37242620/3c553e19-bb62-4535-a95a-d4a63377f70f
