### PR TITLE
feat: show search time in locator search results

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -436,11 +436,11 @@ export function searchForElement (strategy, selector) {
     dispatch({type: SEARCHING_FOR_ELEMENTS});
     try {
       const callAction = callClientMethod({strategy, selector, fetchArray: true});
-      let {elements, variableName} = await callAction(dispatch, getState);
+      let { elements, variableName, executionTime } = await callAction(dispatch, getState);
       const findAction = findAndAssign(strategy, selector, variableName, true);
       findAction(dispatch, getState);
       elements = elements.map((el) => el.id);
-      dispatch({type: SEARCHING_FOR_ELEMENTS_COMPLETED, elements});
+      dispatch({type: SEARCHING_FOR_ELEMENTS_COMPLETED, elements, executionTime});
     } catch (error) {
       dispatch({type: SEARCHING_FOR_ELEMENTS_COMPLETED});
       showError(error, 10);

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -28,6 +28,7 @@ class LocatedElements extends Component {
   render () {
     const {
       locatedElements,
+      locatedElementsExecutionTime,
       applyClientMethod,
       setLocatorTestElement,
       locatorTestElement,
@@ -37,7 +38,10 @@ class LocatedElements extends Component {
     return <>
       {locatedElements.length === 0 && <Row><i>{t('couldNotFindAnyElements')}</i></Row>}
       {locatedElements.length > 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
-        <Row><span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span></Row>
+        <Row justify='space-between'>
+          <span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span>
+          <>{t('Time')}: {locatedElementsExecutionTime}</>
+        </Row>
         <Row>
           <List className={InspectorStyles.searchResultsList}
             size='small'

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -131,7 +131,9 @@ export default class AppiumClient {
   }
 
   async fetchElements ({strategy, selector}) {
+    const start = Date.now();
     const els = await this.driver.findElements(strategy, selector);
+    const executionTime = Date.now() - start;
 
     this.elArrayVarCount += 1;
     const variableName = `els${this.elArrayVarCount}`;
@@ -155,7 +157,14 @@ export default class AppiumClient {
 
     this.elementCache = {...this.elementCache, ...elements};
 
-    return {variableName, variableType, strategy, selector, elements: elementList};
+    return {
+      variableName,
+      variableType,
+      strategy,
+      selector,
+      elements: elementList,
+      executionTime,
+    };
   }
 
   async fetchElement ({strategy, selector}) {

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -334,6 +334,7 @@ export default function inspector (state = INITIAL_STATE, action) {
       return {
         ...state,
         locatedElements: null,
+        locatedElementsExecutionTime: null,
         locatorTestElement: null,
         isSearchingForElements: true,
       };
@@ -342,6 +343,7 @@ export default function inspector (state = INITIAL_STATE, action) {
       return {
         ...state,
         locatedElements: action.elements,
+        locatedElementsExecutionTime: action.executionTime,
         isSearchingForElements: false,
       };
 


### PR DESCRIPTION
This PR implements #698.
When searching for an element, the results screen will now also show the elapsed time (arrow not included):

![locator-search-timing](https://github.com/appium/appium-inspector/assets/37242620/9d784bef-7b9a-4cf9-8901-db5fb0f906d5)