### PR TITLE
fix: do not resend highlight for selected element

### DIFF
--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -44,8 +44,8 @@ class LocatedElements extends Component {
             dataSource={locatedElements}
             renderItem={(elementId) =>
               <List.Item type='text'
-                className={locatorTestElement === elementId ? InspectorStyles.searchResultsSelectedItem : ''}
-                onClick={() => setLocatorTestElement(elementId)}
+                {...locatorTestElement === elementId && { className: InspectorStyles.searchResultsSelectedItem }}
+                {...locatorTestElement !== elementId && { onClick: () => {setLocatorTestElement(elementId);} }}
               >
                 {elementId}
               </List.Item>


### PR DESCRIPTION
This fixes the issue where, when searching for elements and selecting any result from the list, if the same result was then selected again, the highlight calculation would be requested again.