### PR TITLE
fix: remove copy id button

### DIFF
--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
-import { clipboard } from '../../polyfills';
 import { Input, Row, Button, Badge, List, Space, Spin, Tooltip } from 'antd';
-import { CopyOutlined, AimOutlined, ClearOutlined, SendOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
+import { AimOutlined, ClearOutlined, SendOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
@@ -63,21 +62,13 @@ class LocatedElements extends Component {
           </Row>
           <Row justify='center'>
             <Space direction='horizontal' size='small'>
-              <ButtonGroup>
-                <Tooltip title={t('Copy ID')} placement='bottom'>
-                  <Button
-                    disabled={!locatorTestElement}
-                    icon={<CopyOutlined/>}
-                    onClick={() => clipboard.writeText(locatorTestElement)}/>
-                </Tooltip>
-                <Tooltip title={t('Find and Select in Source')} placement='bottom'>
-                  <Button
-                    disabled={!locatorTestElement}
-                    icon={<MenuUnfoldOutlined/>}
-                    onClick={() => selectLocatedElement(source, searchedForElementBounds, locatorTestElement)}
-                  />
-                </Tooltip>
-              </ButtonGroup>
+              <Tooltip title={t('Find and Select in Source')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  icon={<MenuUnfoldOutlined/>}
+                  onClick={() => selectLocatedElement(source, searchedForElementBounds, locatorTestElement)}
+                />
+              </Tooltip>
               <Tooltip title={t('Tap')} placement='bottom'>
                 <Button
                   disabled={!locatorTestElement}

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -115,7 +115,6 @@
   "Quit Session": "Quit Session",
   "Your session is about to expire": "Your session is about to expire",
   "Enter Keys to Send": "Enter Keys to Send",
-  "Copy ID": "Copy ID",
   "Find and Select in Source": "Find and Select in Source",
   "Clear": "Clear",
   "Send Keys": "Send Keys",


### PR DESCRIPTION
This PR removes the Copy ID button from the locator search results.
As of #842, the found element IDs are presented in a list, rather than a dropdown, which means that it is now possible to directly select the text inside a list item, eliminating the need for a dedicated button.