### PR TITLE
style: align selected element actions design to search results

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -19,7 +19,6 @@ export const SET_SELECTED_ELEMENT_ID = 'SET_SELECTED_ELEMENT_ID';
 export const SET_INTERACTIONS_NOT_AVAILABLE = 'SET_INTERACTIONS_NOT_AVAILABLE';
 export const METHOD_CALL_REQUESTED = 'METHOD_CALL_REQUESTED';
 export const METHOD_CALL_DONE = 'METHOD_CALL_DONE';
-export const SET_FIELD_VALUE = 'SET_FIELD_VALUE';
 export const SET_EXPANDED_PATHS = 'SET_EXPANDED_PATHS';
 export const SELECT_HOVERED_ELEMENT = 'SELECT_HOVERED_ELEMENT';
 export const UNSELECT_HOVERED_ELEMENT = 'UNSELECT_HOVERED_ELEMENT';
@@ -30,8 +29,6 @@ export const SELECT_CENTROID = 'SELECT_CENTROID';
 export const UNSELECT_CENTROID = 'UNSELECT_CENTROID';
 export const SET_SHOW_CENTROIDS = 'SET_SHOW_CENTROIDS';
 
-export const SHOW_SEND_KEYS_MODAL = 'SHOW_SEND_KEYS_MODAL';
-export const HIDE_SEND_KEYS_MODAL = 'HIDE_SEND_KEYS_MODAL';
 export const QUIT_SESSION_REQUESTED = 'QUIT_SESSION_REQUESTED';
 export const QUIT_SESSION_DONE = 'QUIT_SESSION_DONE';
 export const SET_SESSION_TIME = 'SET_SESSION_TIME';
@@ -273,27 +270,6 @@ export function applyClientMethod (params) {
 export function addAssignedVarCache (varName) {
   return (dispatch) => {
     dispatch({type: ADD_ASSIGNED_VAR_CACHE, varName});
-  };
-}
-
-export function showSendKeysModal () {
-  return (dispatch) => {
-    dispatch({type: SHOW_SEND_KEYS_MODAL});
-  };
-}
-
-export function hideSendKeysModal () {
-  return (dispatch) => {
-    dispatch({type: HIDE_SEND_KEYS_MODAL});
-  };
-}
-
-/**
- * Set a value of an arbitrarily named field
- */
-export function setFieldValue (name, value) {
-  return (dispatch) => {
-    dispatch({type: SET_FIELD_VALUE, name, value});
   };
 }
 

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -368,6 +368,12 @@
 
 .elementActions {
     margin-bottom: 20px;
+    gap: 8px;
+}
+
+.elementKeyInputActions {
+    max-width: 300px;
+    flex: 1;
 }
 
 .inspector-main #selectedElementContainer {
@@ -391,6 +397,7 @@
 .selected-element-card :global(.ant-card-body) {
     flex: 1;
     overflow: auto;
+    margin-right: -12px;
 }
 
 .selectedElemNotInteractableAlertRow {
@@ -452,7 +459,8 @@
     width: 350px;
 }
 
-.searchResultsKeyInput {
+.searchResultsKeyInput,
+.elementKeyInput {
     height: 32px;
     width: calc(100% - 64px);
 }

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -9,8 +9,8 @@ import {
   LoadingOutlined,
   CopyOutlined,
   AimOutlined,
-  EditOutlined,
-  UndoOutlined,
+  SendOutlined,
+  ClearOutlined,
   HourglassOutlined,
 } from '@ant-design/icons';
 import { ROW, ALERT } from '../AntdTypes';
@@ -80,7 +80,6 @@ class SelectedElement extends Component {
       sendKeys,
       selectedElement,
       sendKeysModalVisible,
-      showSendKeysModal,
       hideSendKeysModal,
       selectedElementId: elementId,
       sourceXML,
@@ -214,50 +213,56 @@ class SelectedElement extends Component {
           <Alert type={ALERT.INFO} message={t('interactionsNotAvailable')} showIcon />
         </Col>
       </Row>}
-      <Row justify="center" type={ROW.FLEX} align="middle" gutter={10} className={styles.elementActions}>
-        <Col>
-          <ButtonGroup>
-            <Tooltip title={t('Tap')}>
-              <Button
-                disabled={isDisabled}
-                icon={tapIcon}
-                id='btnTapElement'
-                onClick={() => applyClientMethod({methodName: 'click', elementId})}
-              />
-            </Tooltip>
-            <Tooltip title={t('Send Keys')}>
-              <Button
-                disabled={isDisabled}
-                id='btnSendKeysToElement'
-                icon={<EditOutlined/>}
-                onClick={() => showSendKeysModal()}
-              />
-            </Tooltip>
-            <Tooltip title={t('Clear')}>
-              <Button
-                disabled={isDisabled}
-                id='btnClearElement'
-                icon={<UndoOutlined/>}
-                onClick={() => applyClientMethod({methodName: 'clear', elementId})}
-              />
-            </Tooltip>
-            <Tooltip title={t('Copy Attributes to Clipboard')}>
-              <Button
-                disabled={isDisabled}
-                id='btnCopyAttributes'
-                icon={<CopyOutlined/>}
-                onClick={() => clipboard.writeText(JSON.stringify(dataSource))}/>
-            </Tooltip>
-            <Tooltip title={t('Get Timing')}>
-              <Button
-                disabled={isDisabled}
-                id='btnGetTiming'
-                icon={<HourglassOutlined/>}
-                onClick={() => getFindElementsTimes(findDataSource)}
-              />
-            </Tooltip>
-          </ButtonGroup>
-        </Col>
+      <Row justify="center" type={ROW.FLEX} align="middle" className={styles.elementActions}>
+        <Tooltip title={t('Tap')}>
+          <Button
+            disabled={isDisabled}
+            icon={tapIcon}
+            id='btnTapElement'
+            onClick={() => applyClientMethod({methodName: 'click', elementId})}
+          />
+        </Tooltip>
+        <ButtonGroup className={styles.elementKeyInputActions}>
+          <Input className={styles.elementKeyInput}
+            disabled={isDisabled}
+            placeholder={t('Enter Keys to Send')}
+            allowClear={true}
+            onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}
+          />
+          <Tooltip title={t('Send Keys')}>
+            <Button
+              disabled={isDisabled}
+              id='btnSendKeysToElement'
+              icon={<SendOutlined/>}
+              onClick={() => applyClientMethod({methodName: 'sendKeys', elementId, args: [this.state.sendKeys || '']})}
+            />
+          </Tooltip>
+          <Tooltip title={t('Clear')}>
+            <Button
+              disabled={isDisabled}
+              id='btnClearElement'
+              icon={<ClearOutlined/>}
+              onClick={() => applyClientMethod({methodName: 'clear', elementId})}
+            />
+          </Tooltip>
+        </ButtonGroup>
+        <ButtonGroup>
+          <Tooltip title={t('Copy Attributes to Clipboard')}>
+            <Button
+              disabled={isDisabled}
+              id='btnCopyAttributes'
+              icon={<CopyOutlined/>}
+              onClick={() => clipboard.writeText(JSON.stringify(dataSource))}/>
+          </Tooltip>
+          <Tooltip title={t('Get Timing')}>
+            <Button
+              disabled={isDisabled}
+              id='btnGetTiming'
+              icon={<HourglassOutlined/>}
+              onClick={() => getFindElementsTimes(findDataSource)}
+            />
+          </Tooltip>
+        </ButtonGroup>
       </Row>
       {findDataSource.length > 0 &&
         <Row>

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import _ from 'lodash';
 import {getLocators} from './shared';
 import styles from './Inspector.css';
-import { Button, Row, Col, Input, Modal, Table, Alert, Tooltip, Select, Spin } from 'antd';
+import { Button, Row, Col, Input, Table, Alert, Tooltip, Select, Spin } from 'antd';
 import { withTranslation } from '../../util';
 import {clipboard, shell} from '../../polyfills';
 import {
@@ -40,14 +40,7 @@ class SelectedElement extends Component {
 
   constructor (props) {
     super(props);
-    this.handleSendKeys = this.handleSendKeys.bind(this);
     this.contextSelect = this.contextSelect.bind(this);
-  }
-
-  handleSendKeys () {
-    const {sendKeys, applyClientMethod, hideSendKeysModal, selectedElementId: elementId} = this.props;
-    applyClientMethod({methodName: 'sendKeys', elementId, args: [sendKeys]});
-    hideSendKeysModal();
   }
 
   contextSelect () {
@@ -73,14 +66,10 @@ class SelectedElement extends Component {
       applyClientMethod,
       contexts,
       currentContext,
-      setFieldValue,
       getFindElementsTimes,
       findElementsExecutionTimes,
       isFindingElementsTimes,
-      sendKeys,
       selectedElement,
-      sendKeysModalVisible,
-      hideSendKeysModal,
       selectedElementId: elementId,
       sourceXML,
       elementInteractionsNotAvailable,
@@ -322,19 +311,6 @@ class SelectedElement extends Component {
             pagination={false} />
         </Row>
       }
-      <Modal title={t('Send Keys')}
-        open={sendKeysModalVisible}
-        okText={t('Send Keys')}
-        cancelText={t('Cancel')}
-        onCancel={hideSendKeysModal}
-        onOk={this.handleSendKeys}
-      >
-        <Input
-          placeholder={t('Enter Keys to Send')}
-          value={sendKeys}
-          onChange={(e) => setFieldValue('sendKeys', e.target.value)}
-        />
-      </Modal>
     </div>;
   }
 }

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -2,8 +2,7 @@ import { omit } from 'lodash';
 import { SET_SOURCE_AND_SCREENSHOT, QUIT_SESSION_REQUESTED, QUIT_SESSION_DONE,
          SESSION_DONE, SELECT_ELEMENT, UNSELECT_ELEMENT, SELECT_HOVERED_ELEMENT, SET_SELECTED_ELEMENT_ID, SET_INTERACTIONS_NOT_AVAILABLE,
          UNSELECT_HOVERED_ELEMENT, METHOD_CALL_REQUESTED, METHOD_CALL_DONE,
-         SET_FIELD_VALUE, SET_EXPANDED_PATHS, SHOW_SEND_KEYS_MODAL,
-         HIDE_SEND_KEYS_MODAL, START_RECORDING, PAUSE_RECORDING, CLEAR_RECORDING,
+         SET_EXPANDED_PATHS, START_RECORDING, PAUSE_RECORDING, CLEAR_RECORDING,
          SET_ACTION_FRAMEWORK, RECORD_ACTION, CLOSE_RECORDER, SET_SHOW_BOILERPLATE, SET_SESSION_DETAILS,
          SHOW_LOCATOR_TEST_MODAL, HIDE_LOCATOR_TEST_MODAL, SHOW_SIRI_COMMAND_MODAL, HIDE_SIRI_COMMAND_MODAL, SET_LOCATOR_TEST_STRATEGY, SET_LOCATOR_TEST_VALUE,
          SEARCHING_FOR_ELEMENTS, SEARCHING_FOR_ELEMENTS_COMPLETED, SET_LOCATOR_TEST_ELEMENT, CLEAR_SEARCH_RESULTS,
@@ -192,33 +191,11 @@ export default function inspector (state = INITIAL_STATE, action) {
         methodCallInProgress: false,
       };
 
-    case SET_FIELD_VALUE:
-      return {
-        ...state,
-        [action.name]: action.value,
-      };
-
     case SET_EXPANDED_PATHS:
       return {
         ...state,
         expandedPaths: action.paths,
         findElementsExecutionTimes: [],
-      };
-
-    case SHOW_SEND_KEYS_MODAL:
-      return {
-        ...state,
-        sendKeysModalVisible: true
-      };
-
-    case HIDE_SEND_KEYS_MODAL:
-      return {
-        ...state,
-        sendKeysModalVisible: false,
-        action: {
-          ...state.action,
-          sendKeys: null,
-        }
       };
 
     case START_RECORDING:


### PR DESCRIPTION
This PR aligns the design of selected element actions to that of the locator search results:
* Replace send keys modal with inline input field
  * The field is flexible and will adjust to the width of the whole inspector window
* Adjust button grouping
* Change icon of clear button

![selected-elem-actions-min-width](https://github.com/appium/appium-inspector/assets/37242620/1b5ed283-e326-459f-8d1d-2ea05f4714a2)
![selected-elem-actions-max-width](https://github.com/appium/appium-inspector/assets/37242620/ca7c719a-020d-4be8-acbf-3b45e06f8076)
