### PR TITLE
chore: remove unneeded params in this.setState

### DIFF
--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -193,7 +193,6 @@ export default class HighlighterRects extends Component {
       const x = offsetX * scaleRatio;
       const y = offsetY * scaleRatio;
       this.setState({
-        ...this.state,
         x: Math.round(x),
         y: Math.round(y),
       });
@@ -202,7 +201,6 @@ export default class HighlighterRects extends Component {
 
   handleMouseOut () {
     this.setState({
-      ...this.state,
       x: null,
       y: null,
     });

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -81,7 +81,7 @@ class LocatedElements extends Component {
                   disabled={!locatorTestElement}
                   placeholder={t('Enter Keys to Send')}
                   allowClear={true}
-                  onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}/>
+                  onChange={(e) => this.setState({sendKeys: e.target.value})}/>
                 <Tooltip title={t('Send Keys')} placement='bottom'>
                   <Button
                     disabled={!locatorTestElement}

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -67,7 +67,6 @@ class Screenshot extends Component {
       const x = offsetX * scaleRatio;
       const y = offsetY * scaleRatio;
       this.setState({
-        ...this.state,
         x: Math.round(x),
         y: Math.round(y),
       });
@@ -76,7 +75,6 @@ class Screenshot extends Component {
 
   handleMouseOut () {
     this.setState({
-      ...this.state,
       x: null,
       y: null,
     });

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -216,7 +216,7 @@ class SelectedElement extends Component {
             disabled={isDisabled}
             placeholder={t('Enter Keys to Send')}
             allowClear={true}
-            onChange={(e) => this.setState({...this.state, sendKeys: e.target.value})}
+            onChange={(e) => this.setState({sendKeys: e.target.value})}
           />
           <Tooltip title={t('Send Keys')}>
             <Button


### PR DESCRIPTION
`this.setState` does not overwrite the parameters that are not specified, so they can be omitted from the method call. This approach is already used in most other calls of `this.setState`.