### PR TITLE
chore: remove unused/deprecated eslint ignore flags

### DIFF
--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -17,7 +17,6 @@ render(
 
 if (module.hot) {
   module.hot.accept('./containers/Root', () => {
-    // eslint-disable-next-line global-require
     const NextRoot = require('./containers/Root').default;
     render(
       <AppContainer>

--- a/app/renderer/polyfills/browser.js
+++ b/app/renderer/polyfills/browser.js
@@ -37,7 +37,7 @@ class BrowserSettings {
   }
 }
 
-const log = console; // eslint-disable-line no-console
+const log = console;
 const settings = new BrowserSettings();
 const {clipboard, shell, remote, ipcRenderer} = browser;
 const i18NextBackend = require('i18next-chained-backend').default;

--- a/app/renderer/store/configureStore.development.js
+++ b/app/renderer/store/configureStore.development.js
@@ -39,14 +39,12 @@ const configureStore = (initialState) => {
     ...routerActions
   };
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
-  /* eslint-disable no-underscore-dangle */
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
     ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
       // Options: http://extension.remotedev.io/docs/API/Arguments.html
       actionCreators
     })
     : compose;
-  /* eslint-enable no-underscore-dangle */
 
   // Apply Middleware & Compose Enhancers
   enhancers.push(applyMiddleware(...middleware));
@@ -58,7 +56,6 @@ const configureStore = (initialState) => {
   if (module.hot) {
     module.hot.accept(
       '../reducers',
-      // eslint-disable-next-line global-require
       () => store.replaceReducer(require('../reducers').default)
     );
   }

--- a/app/renderer/store/configureStore.js
+++ b/app/renderer/store/configureStore.js
@@ -11,7 +11,7 @@ export const { configureStore } = selectedConfigureStore;
 export const { history } = selectedConfigureStore;
 
 if (process.env.NODE_ENV === 'production') {
-  module.exports = require('./configureStore.production'); // eslint-disable-line global-require
+  module.exports = require('./configureStore.production');
 } else {
-  module.exports = require('./configureStore.development'); // eslint-disable-line global-require
+  module.exports = require('./configureStore.development');
 }


### PR DESCRIPTION
A few ESLint ignore flags can be removed. The `global-require` flag has been deprecated since ESLint 7, and the others do not result in any warnings upon their removal.