### PR TITLE
chore: switch to React 18 root API

### DIFF
--- a/app/renderer/index.js
+++ b/app/renderer/index.js
@@ -1,26 +1,26 @@
 import React from 'react';
-import { render } from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import Root from './containers/Root';
 import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 import configureStore from './store';
 
 const { store, history } = configureStore();
+const container = document.getElementById('root');
+const root = createRoot(container);
 
-render(
+root.render(
   <ErrorBoundary>
     <Root store={store} history={history} />
-  </ErrorBoundary>,
-  document.getElementById('root')
+  </ErrorBoundary>
 );
 
 if (module.hot) {
   module.hot.accept('./containers/Root', () => {
     const NextRoot = require('./containers/Root').default;
-    render(
+    root.render(
       <AppContainer>
         <NextRoot store={store} history={history} />
-      </AppContainer>,
-      document.getElementById('root')
+      </AppContainer>
     );
   });
 }


### PR DESCRIPTION
This enables the new [React 18 root API](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis), removing the warning that always appears on launch.
However, this does add a new warning when hot module replacement is activated. It can be removed by migrating to React Fast Refresh, but that in turn requires rewriting the app to use React function components, as well as Parcel 2.