### PR TITLE
chore: autoadd dependencies label to renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     ":semanticCommitTypeAll(chore)",
     ":pinAllExceptPeerDependencies"
   ],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
This configures Renovate to automatically add the `dependencies` label for any of its version update PRs.