### PR TITLE
fix: show spinner over source in MJPEG mode + hide pause/start refresh button when not in MJPEG

### DIFF
--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -338,12 +338,12 @@ export default class Inspector extends Component {
       <Tooltip title={t('Back')}>
         <Button id='btnGoBack' icon={<ArrowLeftOutlined/>} onClick={() => applyClientMethod({methodName: 'back'})}/>
       </Tooltip>
-      {!isSourceRefreshOn &&
+      {mjpegScreenshotUrl && !isSourceRefreshOn &&
         <Tooltip title={t('Start Refreshing Source')}>
           <Button id='btnStartRefreshing' icon={<PlayCircleOutlined/>} onClick={toggleRefreshingState}/>
         </Tooltip>
       }
-      {isSourceRefreshOn &&
+      {mjpegScreenshotUrl && isSourceRefreshOn &&
         <Tooltip title={t('Pause Refreshing Source')}>
           <Button id='btnPauseRefreshing' icon={<PauseCircleOutlined/>} onClick={toggleRefreshingState}/>
         </Tooltip>

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -144,12 +144,9 @@ class Screenshot extends Component {
       t,
       scaleRatio,
       selectedTick,
-      selectedInteractionMode,
-      isSourceRefreshOn
+      selectedInteractionMode
     } = this.props;
     const {x, y} = this.state;
-
-    const showSpinner = (isSourceRefreshOn && !!methodCallInProgress);
 
     // If we're tapping or swiping, show the 'crosshair' cursor style
     const screenshotStyle = {};
@@ -171,8 +168,9 @@ class Screenshot extends Component {
 
     const points = this.getGestureCoordinates();
 
-    // Show the screenshot and highlighter rects. Show loading indicator if a method call is in progress.
-    return <Spin size='large' spinning={showSpinner}>
+    // Show the screenshot and highlighter rects.
+    // Show loading indicator if a method call is in progress, unless using MJPEG mode.
+    return <Spin size='large' spinning={!!methodCallInProgress && !mjpegScreenshotUrl}>
       <div className={styles.innerScreenshotContainer}>
         <div ref={(containerEl) => { this.containerEl = containerEl; }}
           style={screenshotStyle}

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Tree } from 'antd';
+import { Tree, Spin } from 'antd';
 import LocatorTestModal from './LocatorTestModal';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
@@ -60,6 +60,9 @@ class Source extends Component {
       expandedPaths,
       selectedElement = {},
       showSourceAttrs,
+      methodCallInProgress,
+      mjpegScreenshotUrl,
+      isSourceRefreshOn,
       t,
     } = this.props;
     const {path} = selectedElement;
@@ -78,19 +81,22 @@ class Source extends Component {
     const treeData = source && recursive(source);
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
-      {/* Must switch to a new antd Tree component when there's changes to treeData  */}
-      {treeData ?
-        <Tree
-          defaultExpandAll={true}
-          onExpand={setExpandedPaths}
-          expandedKeys={expandedPaths}
-          onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
-          selectedKeys={[path]}
-          treeData={treeData} />
-        :
-        <Tree
-          treeData={[]} />
-      }
+      {/* Show loading indicator in MJPEG mode if a method call is in progress and source refresh is on */}
+      <Spin size='large' spinning={!!methodCallInProgress && mjpegScreenshotUrl && isSourceRefreshOn}>
+        {/* Must switch to a new antd Tree component when there's changes to treeData  */}
+        {treeData ?
+          <Tree
+            defaultExpandAll={true}
+            onExpand={setExpandedPaths}
+            expandedKeys={expandedPaths}
+            onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
+            selectedKeys={[path]}
+            treeData={treeData} />
+          :
+          <Tree
+            treeData={[]} />
+        }
+      </Spin>
       {!source && !sourceError &&
         <i>{t('Gathering initial app source…')}</i>
       }


### PR DESCRIPTION
This PR implements #504, similarly to #635.
In addition, the Pause/Start Refreshing Source button in the header is now hidden when not using MJPEG mode, since all it does is enter a state where neither screenshot nor source are changing. The button still remains functional in MJPEG mode.