### PR TITLE
feat: add infobox for disabling package name autocompletion of id locators

### DIFF
--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,10 +1,20 @@
 import React, { Component } from 'react';
-import { Input, Row, Button, Badge, List, Space, Spin, Tooltip } from 'antd';
+import { Alert, Input, Row, Button, Badge, List, Space, Spin, Tooltip } from 'antd';
 import { AimOutlined, ClearOutlined, SendOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
+import { ALERT } from '../AntdTypes';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
 const ButtonGroup = Button.Group;
+
+const showIdAutocompleteInfo = (driver, strategy, value, t) => {
+  const automationName = driver.client.capabilities.automationName;
+  const idLocatorAutocompletionDisabled = driver.client.capabilities.disableIdLocatorAutocompletion;
+  if (automationName && automationName.toLowerCase() === 'uiautomator2' &&
+    strategy === 'id' && !value.includes(':id/') && !idLocatorAutocompletionDisabled) {
+    return <Row><Alert message={t('idAutocompletionCanBeDisabled')} type={ALERT.INFO} showIcon/></Row>;
+  }
+};
 
 class LocatedElements extends Component {
 
@@ -29,17 +39,23 @@ class LocatedElements extends Component {
       locatedElements,
       locatedElementsExecutionTime,
       applyClientMethod,
+      locatorTestStrategy,
+      locatorTestValue,
       setLocatorTestElement,
       locatorTestElement,
       isFindingLocatedElementInSource,
       searchedForElementBounds,
       selectLocatedElement,
       source,
+      driver,
       t,
     } = this.props;
 
     return <>
-      {locatedElements.length === 0 && <Row><i>{t('couldNotFindAnyElements')}</i></Row>}
+      {locatedElements.length === 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+        <Row><i>{t('couldNotFindAnyElements')}</i></Row>
+        {showIdAutocompleteInfo(driver, locatorTestStrategy, locatorTestValue, t)}
+      </Space>}
       {locatedElements.length > 0 && <Spin spinning={isFindingLocatedElementInSource}>
         <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
           <Row justify='space-between'>

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -140,6 +140,7 @@
   "usingSwitchContextRecommended": "Webview context(s) detected; certain elements might only be accessible after switching to a webview context, which must be done in an Appium script. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
   "usingWebviewContext": "Using the Webview inspector in Appium Inspector is less accurate in retrieving and selecting DOM elements in comparison to using the DevTools of Chrome and Safari.",
   "contextSwitcher": "You can switch to a different context here. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
+  "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This session has id autocompletion enabled, which may be the reason why no elements were found. To disable id autocompletion, relaunch this session with the capability 'appium:disableIdLocatorAutocompletion' set to 'true'.",
   "Tap": "Tap",
   "Gathering initial app source…": "Gathering initial app source…",
   "couldNotObtainSource": "Could not obtain source: {{errorMsg}}",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -140,7 +140,7 @@
   "usingSwitchContextRecommended": "Webview context(s) detected; certain elements might only be accessible after switching to a webview context, which must be done in an Appium script. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
   "usingWebviewContext": "Using the Webview inspector in Appium Inspector is less accurate in retrieving and selecting DOM elements in comparison to using the DevTools of Chrome and Safari.",
   "contextSwitcher": "You can switch to a different context here. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
-  "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This session has id autocompletion enabled, which may be the reason why no elements were found. To disable id autocompletion, relaunch this session with the capability 'appium:disableIdLocatorAutocompletion' set to 'true'.",
+  "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This Appium session has package name autocompletion enabled, which may be the reason why no elements were found. To disable this behavior, relaunch this session with the capability 'appium:disableIdLocatorAutocompletion' set to 'true'.",
   "Tap": "Tap",
   "Gathering initial app source…": "Gathering initial app source…",
   "couldNotObtainSource": "Could not obtain source: {{errorMsg}}",


### PR DESCRIPTION
This PR is a highly specific change, but bear with me.

Background: Up until a week ago I was unaware of the `appium:disableIdLocatorAutocompletion` capability. I had been testing an Android app that had Jetpack Compose elements with `testTag`s, and I was wondering why they were listed as `resource-id`s, yet I could not find them through the element search. I didn't delve too deep into this, and just settled on using simple XPaths. Fast forward to this week, and the aforementioned capability has now unlocked the ability to find these elements by id.

To avoid others getting into the above situation, I am suggesting to add an infobox that will appear under very specific circumstances:
* `UiAutomator2` driver is used
* Element search is done using the `id` locator strategy
* The selector used in element search does not have a package name prefix
* `appium:disableIdLocatorAutocompletion` is set to `false` (the default value)
* No results are found

If all of the above points are true, the user will be greeted by this comprehensive message:

![image](https://github.com/appium/appium-inspector/assets/37242620/d3b16e15-b644-44b7-a9fb-157694eb2dfe)

Still, this isn't perfect. It may be a bit misleading in the case where the user attempts to search for a visible element that does have a prefix, but is not part of the current application package (e.g. elements with the `android:id/` prefix). But, I would hope that any element with a package prefix would also have the prefix included in the search...