### PR TITLE
feat: fix element search error + add infobox if automationName is missing

### DIFF
--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
-import { Input, Radio, Row } from 'antd';
+import { Alert, Input, Space, Radio, Row } from 'antd';
+import { ALERT } from '../AntdTypes';
 import InspectorStyles from './Inspector.css';
 import { withTranslation } from '../../util';
 
@@ -33,6 +34,12 @@ const locatorStrategies = (driver) => {
   return strategies;
 };
 
+const showMissingAutomationNameInfo = (driver, t) => {
+  if (!driver.client.capabilities.automationName) {
+    return <Alert message={t('missingAutomationNameForStrategies')} type={ALERT.INFO} showIcon/>;
+  }
+};
+
 class ElementLocator extends Component {
 
   onSubmit () {
@@ -62,34 +69,36 @@ class ElementLocator extends Component {
     } = this.props;
 
     return <>
-      {t('locatorStrategy')}
-      <Row justify="center">
-        <Radio.Group buttonStyle="solid"
-          className={InspectorStyles.locatorStrategyGroup}
-          onChange={(e) => setLocatorTestStrategy(e.target.value)}
-          defaultValue={locatorTestStrategy}
-        >
-          <Row justify="center">
-            {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
-              <Radio.Button
-                className={InspectorStyles.locatorStrategyBtn}
-                value={strategyValue}
-                key={strategyValue}
-              >
-                {strategyName}
-              </Radio.Button>
-            ))}
-          </Row>
-        </Radio.Group>
-      </Row>
-      {t('selector')}
-      <Input.TextArea
-        className={InspectorStyles.locatorSelectorTextArea}
-        onChange={(e) => setLocatorTestValue(e.target.value)}
-        value={locatorTestValue}
-        allowClear={true}
-        rows={3}
-      />
+      <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+        {t('locatorStrategy')}
+        <Row justify="center">
+          <Radio.Group buttonStyle="solid"
+            onChange={(e) => setLocatorTestStrategy(e.target.value)}
+            defaultValue={locatorTestStrategy}
+          >
+            <Row justify="center">
+              {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
+                <Radio.Button
+                  className={InspectorStyles.locatorStrategyBtn}
+                  value={strategyValue}
+                  key={strategyValue}
+                >
+                  {strategyName}
+                </Radio.Button>
+              ))}
+            </Row>
+          </Radio.Group>
+        </Row>
+        {showMissingAutomationNameInfo(driver, t)}
+        {t('selector')}
+        <Input.TextArea
+          className={InspectorStyles.locatorSelectorTextArea}
+          onChange={(e) => setLocatorTestValue(e.target.value)}
+          value={locatorTestValue}
+          allowClear={true}
+          rows={3}
+        />
+      </Space>
     </>;
   }
 }

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -15,9 +15,10 @@ const STRAT_DATAMATCHER = ['-android datamatcher', 'DataMatcher'];
 const STRAT_VIEWTAG = ['-android viewtag', 'View Tag'];
 
 const locatorStrategies = (driver) => {
-  const automationName = driver.client.capabilities.automationName.toLowerCase();
+  const automationName = driver.client.capabilities.automationName;
   let strategies = [STRAT_ID, STRAT_XPATH, STRAT_NAME, STRAT_CLASS_NAME, STRAT_ACCESSIBILITY_ID];
-  switch (automationName) {
+  if (!automationName) { return strategies; }
+  switch (automationName.toLowerCase()) {
     case 'xcuitest':
     case 'mac2':
       strategies.push(STRAT_PREDICATE, STRAT_CLASS_CHAIN);

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -470,10 +470,6 @@
     margin-left: 0.5em;
 }
 
-.locatorStrategyGroup {
-    margin-bottom: 12px;
-}
-
 .locatorStrategyBtn {
     margin-top: -1px;
     min-width: 25%;

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -141,6 +141,7 @@
   "usingWebviewContext": "Using the Webview inspector in Appium Inspector is less accurate in retrieving and selecting DOM elements in comparison to using the DevTools of Chrome and Safari.",
   "contextSwitcher": "You can switch to a different context here. See http://appium.io/docs/en/writing-running-appium/web/hybrid/ for more information",
   "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This Appium session has package name autocompletion enabled, which may be the reason why no elements were found. To disable this behavior, relaunch this session with the capability 'appium:disableIdLocatorAutocompletion' set to 'true'.",
+  "missingAutomationNameForStrategies": "Additional locator strategies may be available. To view them, add the capability 'appium:automationName' when launching the session. Note that this capability is mandatory in Appium 2.",
   "Tap": "Tap",
   "Gathering initial app source…": "Gathering initial app source…",
   "couldNotObtainSource": "Could not obtain source: {{errorMsg}}",


### PR DESCRIPTION
This PR should only affect Appium 1.x users.
It fixes an application error if element search is opened in a session with `appium:automationName` not specified. Only the default locator strategies will be shown in that case.

In order to help users unhide any platform-specific capabilities, I have added a new infobox that only appears if `appium:automationName` is missing:
![image](https://github.com/appium/appium-inspector/assets/37242620/71f7d548-83f3-487d-b39e-01ba88bd2061)
