### PR TITLE
fix: adjust window dimensions and appearance at min window size

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ As mentioned above, the Inspector is basically an Appium client, so for it to fu
 
 Basically, if you can start an Appium session from your typical client library, you should be able to do the same with the Inspector.
 
+### Screen size
+
+The Inspector desktop app has a minimum size of **890 x 710** pixels, whereas the web application works best when using a viewport size of at least **870 x 610** pixels.
+
 ### Connecting to a local server from the browser inspector (CORS)
 
 Web browsers have security features which prevent [cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) in general. The browser version of the Inspector needs to make requests to the Appium server directly from the browser via JavaScript, but these requests are typically not made to the same host (for example, the Inspector is accessed at `appiumpro.com`, whereas your local Appium Server is `localhost:4723`).

--- a/app/main/windows.js
+++ b/app/main/windows.js
@@ -20,10 +20,10 @@ function buildSplashWindow () {
 function buildSessionWindow () {
   const window = new BrowserWindow({
     show: false,
-    width: 1280,
-    height: 800,
-    minWidth: 1000,
-    minHeight: 700,
+    width: 1100,
+    height: 700,
+    minWidth: 870,
+    minHeight: 640,
     titleBarStyle: 'hiddenInset',
     webPreferences: {
       nodeIntegration: true,

--- a/app/main/windows.js
+++ b/app/main/windows.js
@@ -21,9 +21,9 @@ function buildSessionWindow () {
   const window = new BrowserWindow({
     show: false,
     width: 1100,
-    height: 700,
-    minWidth: 870,
-    minHeight: 640,
+    height: 710,
+    minWidth: 890,
+    minHeight: 710,
     titleBarStyle: 'hiddenInset',
     webPreferences: {
       nodeIntegration: true,

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -34,8 +34,8 @@ const {SELECT, SWIPE, TAP} = SCREENSHOT_INTERACTION_MODE;
 
 const ButtonGroup = Button.Group;
 
-const MIN_WIDTH = 1080;
-const MIN_HEIGHT = 570;
+const MIN_WIDTH = 870;
+const MIN_HEIGHT = 640;
 const MAX_SCREENSHOT_WIDTH = 500;
 
 const MJPEG_STREAM_CHECK_INTERVAL = 1000;

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -35,7 +35,7 @@ const {SELECT, SWIPE, TAP} = SCREENSHOT_INTERACTION_MODE;
 const ButtonGroup = Button.Group;
 
 const MIN_WIDTH = 870;
-const MIN_HEIGHT = 640;
+const MIN_HEIGHT = 610;
 const MAX_SCREENSHOT_WIDTH = 500;
 
 const MJPEG_STREAM_CHECK_INTERVAL = 1000;

--- a/app/renderer/components/Session/AdvancedServerParams.js
+++ b/app/renderer/components/Session/AdvancedServerParams.js
@@ -18,17 +18,17 @@ export default class AdvancedServerParams extends Component {
             <Panel header={t('Advanced Settings')}>
               <Row>
                 {serverType !== 'lambdatest' &&
-                <Col span={6}>
+                <Col span={7}>
                   <FormItem>
                     <Checkbox checked={!!server.advanced.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked, 'advanced')}>{t('allowUnauthorizedCerts')}</Checkbox>
                   </FormItem>
                 </Col>}
-                <Col span={4}>
+                <Col span={5} align='right'>
                   <FormItem>
                     <Checkbox checked={!!server.advanced.useProxy} onChange={(e) => setServerParam('useProxy', e.target.checked, 'advanced')}>{t('Use Proxy')}</Checkbox>
                   </FormItem>
                 </Col>
-                <Col span={6}>
+                <Col span={8}>
                   <FormItem>
                     <Input disabled={!server.advanced.useProxy} onChange={(e) => setServerParam('proxy', e.target.value, 'advanced')}
                       placeholder={t('Proxy URL')} value={server.advanced.proxy} />

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -188,7 +188,7 @@
 }
 
 .capsFormCol {
-  min-width: 476px;
+  min-width: 420px;
   height: 100%;
 }
 

--- a/app/renderer/stylesheets/app.global.less
+++ b/app/renderer/stylesheets/app.global.less
@@ -1,6 +1,6 @@
 @import "./common.global.less";
 
 body {
-  min-height: 680px;
-  min-width: 1000px;
+  min-height: 640px;
+  min-width: 870px;
 }

--- a/app/renderer/stylesheets/app.global.less
+++ b/app/renderer/stylesheets/app.global.less
@@ -1,6 +1,6 @@
 @import "./common.global.less";
 
 body {
-  min-height: 640px;
+  min-height: 610px;
   min-width: 870px;
 }


### PR DESCRIPTION
This PR adjusts the default and minimum dimensions for the main window and several components.
The original goal was to try and reduce these dimensions in order to assist with issues like #549, but testing on Windows showed that the minimum height actually needs to be slightly _increased_ to adjust for the title bar (which is likely to affect Linux the same way). The minimum width could still be decreased, and as a result, the new minimum dimensions have been changed to `890 x 710`.

Other notable adjustments:
* Set default window height to match minimum height (may further help with the issue linked above)
* Adjust minimum sizes for a few components (app body, capabilities table, inspector) to fix their appearance at minimum window size
* Slightly increase available width of elements in 'Advanced Settings' to improve appearance at minimum window size