### PR TITLE
chore: migrate Session items to React function components

### DIFF
--- a/app/renderer/components/Session/AdvancedServerParams.js
+++ b/app/renderer/components/Session/AdvancedServerParams.js
@@ -1,44 +1,40 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Collapse, Form, Row, Col, Checkbox, Input } from 'antd';
 import styles from './Session.css';
 
-const {Panel} = Collapse;
+const { Panel } = Collapse;
 const FormItem = Form.Item;
 
-export default class AdvancedServerParams extends Component {
+const AdvancedServerParams = ({ server, setServerParam, serverType, t }) => (
+  <Row gutter={8}>
+    <Col className={styles.advancedSettingsContainerCol}>
+      <div className={styles.advancedSettingsContainer}>
+        <Collapse bordered={true}>
+          <Panel header={t('Advanced Settings')}>
+            <Row>
+              {serverType !== 'lambdatest' &&
+              <Col span={7}>
+                <FormItem>
+                  <Checkbox checked={!!server.advanced.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked, 'advanced')}>{t('allowUnauthorizedCerts')}</Checkbox>
+                </FormItem>
+              </Col>}
+              <Col span={5} align='right'>
+                <FormItem>
+                  <Checkbox checked={!!server.advanced.useProxy} onChange={(e) => setServerParam('useProxy', e.target.checked, 'advanced')}>{t('Use Proxy')}</Checkbox>
+                </FormItem>
+              </Col>
+              <Col span={8}>
+                <FormItem>
+                  <Input disabled={!server.advanced.useProxy} onChange={(e) => setServerParam('proxy', e.target.value, 'advanced')}
+                    placeholder={t('Proxy URL')} value={server.advanced.proxy} />
+                </FormItem>
+              </Col>
+            </Row>
+          </Panel>
+        </Collapse>
+      </div>
+    </Col>
+  </Row>
+);
 
-
-  render () {
-    const {server, setServerParam, t, serverType} = this.props;
-
-    return <Row gutter={8}>
-      <Col className={styles.advancedSettingsContainerCol}>
-        <div className={styles.advancedSettingsContainer}>
-          <Collapse bordered={true}>
-            <Panel header={t('Advanced Settings')}>
-              <Row>
-                {serverType !== 'lambdatest' &&
-                <Col span={7}>
-                  <FormItem>
-                    <Checkbox checked={!!server.advanced.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked, 'advanced')}>{t('allowUnauthorizedCerts')}</Checkbox>
-                  </FormItem>
-                </Col>}
-                <Col span={5} align='right'>
-                  <FormItem>
-                    <Checkbox checked={!!server.advanced.useProxy} onChange={(e) => setServerParam('useProxy', e.target.checked, 'advanced')}>{t('Use Proxy')}</Checkbox>
-                  </FormItem>
-                </Col>
-                <Col span={8}>
-                  <FormItem>
-                    <Input disabled={!server.advanced.useProxy} onChange={(e) => setServerParam('proxy', e.target.value, 'advanced')}
-                      placeholder={t('Proxy URL')} value={server.advanced.proxy} />
-                  </FormItem>
-                </Col>
-              </Row>
-            </Panel>
-          </Collapse>
-        </div>
-      </Col>
-    </Row>;
-  }
-}
+export default AdvancedServerParams;

--- a/app/renderer/components/Session/AdvancedServerParams.js
+++ b/app/renderer/components/Session/AdvancedServerParams.js
@@ -2,35 +2,32 @@ import React from 'react';
 import { Collapse, Form, Row, Col, Checkbox, Input } from 'antd';
 import styles from './Session.css';
 
-const { Panel } = Collapse;
-const FormItem = Form.Item;
-
 const AdvancedServerParams = ({ server, setServerParam, serverType, t }) => (
   <Row gutter={8}>
     <Col className={styles.advancedSettingsContainerCol}>
       <div className={styles.advancedSettingsContainer}>
         <Collapse bordered={true}>
-          <Panel header={t('Advanced Settings')}>
+          <Collapse.Panel header={t('Advanced Settings')}>
             <Row>
               {serverType !== 'lambdatest' &&
               <Col span={7}>
-                <FormItem>
+                <Form.Item>
                   <Checkbox checked={!!server.advanced.allowUnauthorized} onChange={(e) => setServerParam('allowUnauthorized', e.target.checked, 'advanced')}>{t('allowUnauthorizedCerts')}</Checkbox>
-                </FormItem>
+                </Form.Item>
               </Col>}
               <Col span={5} align='right'>
-                <FormItem>
+                <Form.Item>
                   <Checkbox checked={!!server.advanced.useProxy} onChange={(e) => setServerParam('useProxy', e.target.checked, 'advanced')}>{t('Use Proxy')}</Checkbox>
-                </FormItem>
+                </Form.Item>
               </Col>
               <Col span={8}>
-                <FormItem>
+                <Form.Item>
                   <Input disabled={!server.advanced.useProxy} onChange={(e) => setServerParam('proxy', e.target.value, 'advanced')}
                     placeholder={t('Proxy URL')} value={server.advanced.proxy} />
-                </FormItem>
+                </Form.Item>
               </Col>
             </Row>
-          </Panel>
+          </Collapse.Panel>
         </Collapse>
       </div>
     </Col>

--- a/app/renderer/components/Session/AttachToSession.js
+++ b/app/renderer/components/Session/AttachToSession.js
@@ -1,83 +1,78 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Card, Select, Button, Row, Col } from 'antd';
 import SessionStyles from './Session.css';
-import {
-  ReloadOutlined
-} from '@ant-design/icons';
-import {ServerTypes} from '../../actions/Session';
+import { ReloadOutlined } from '@ant-design/icons';
+import { ServerTypes } from '../../actions/Session';
 
-const FormItem = Form.Item;
-
-function formatCaps (caps) {
+const formatCaps = (caps) => {
   let importantCaps = [caps.app, caps.platformName, caps.deviceName];
   if (caps.automationName) {
     importantCaps.push(caps.automationName);
   }
   return importantCaps.join(', ').trim();
-}
+};
 
-function formatCapsBrowserstack (caps) {
+const formatCapsBrowserstack = (caps) => {
   let importantCaps = formatCaps(caps).split(', ');
   if (caps.sessionName) {
     importantCaps.push(caps.sessionName);
   }
   return importantCaps.join(', ').trim();
-}
+};
 
-function formatCapsLambdaTest (caps) {
+const formatCapsLambdaTest = (caps) => {
   if (caps.hasOwnProperty.call(caps, 'capabilities')) {
     caps = caps.capabilities;
   }
   const deviceName = caps.desired ? caps.desired.deviceName : caps.deviceName;
   const importantCaps = [deviceName, caps.platformName, caps.platformVersion];
   return importantCaps.join(', ').trim();
-}
+};
 
-export default class AttachToSession extends Component {
-
-  getSessionInfo (session, serverType) {
-    switch (serverType) {
-      case ServerTypes.browserstack:
-        return `${session.id} — ${formatCapsBrowserstack(session.capabilities)}`;
-      case ServerTypes.lambdatest:
-        return `${session.id} - ${formatCapsLambdaTest(session.capabilities)}`;
-      default:
-        return `${session.id} — ${formatCaps(session.capabilities)}`;
-    }
+const getSessionInfo = (session, serverType) => {
+  switch (serverType) {
+    case ServerTypes.browserstack:
+      return `${session.id} — ${formatCapsBrowserstack(session.capabilities)}`;
+    case ServerTypes.lambdatest:
+      return `${session.id} - ${formatCapsLambdaTest(session.capabilities)}`;
+    default:
+      return `${session.id} — ${formatCaps(session.capabilities)}`;
   }
+};
 
-  render () {
-    let {serverType, attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions, t} = this.props;
-    attachSessId = attachSessId || undefined;
-    return (<Form>
-      <FormItem>
-        <Card>
-          <p className={SessionStyles.localDesc}>{t('connectToExistingSessionInstructions')}<br/>{t('selectSessionIDInDropdown')}</p>
-        </Card>
-      </FormItem>
-      <FormItem>
-        <Row>
-          <Col span={23}>
-            <Select showSearch
-              mode='AutoComplete'
-              notFoundContent='None found'
-              placeholder={t('enterYourSessionId')}
-              value={attachSessId}
-              onChange={(value) => setAttachSessId(value)}>
-              {runningAppiumSessions.map((session) => <Select.Option key={session.id} value={session.id}>
-                <div>{this.getSessionInfo(session, serverType)}</div>
-              </Select.Option>)}
-            </Select>
-          </Col>
-          <Col span={1}>
-            <div className={SessionStyles.btnReload}>
-              <Button
-                onClick={getRunningSessions}
-                icon={<ReloadOutlined/>} />
-            </div>
-          </Col>
-        </Row>
-      </FormItem>
-    </Form>);
-  }
-}
+const AttachToSession = ({ serverType, attachSessId, setAttachSessId, runningAppiumSessions, getRunningSessions, t }) => (
+  <Form>
+    <Form.Item>
+      <Card>
+        <p className={SessionStyles.localDesc}>
+          {t('connectToExistingSessionInstructions')}<br/>{t('selectSessionIDInDropdown')}
+        </p>
+      </Card>
+    </Form.Item>
+    <Form.Item>
+      <Row>
+        <Col span={23}>
+          <Select showSearch
+            mode='AutoComplete'
+            notFoundContent='None found'
+            placeholder={t('enterYourSessionId')}
+            value={attachSessId || undefined}
+            onChange={(value) => setAttachSessId(value)}>
+            {runningAppiumSessions.map((session) => <Select.Option key={session.id} value={session.id}>
+              <div>{getSessionInfo(session, serverType)}</div>
+            </Select.Option>)}
+          </Select>
+        </Col>
+        <Col span={1}>
+          <div className={SessionStyles.btnReload}>
+            <Button
+              onClick={getRunningSessions}
+              icon={<ReloadOutlined/>} />
+          </div>
+        </Col>
+      </Row>
+    </Form.Item>
+  </Form>
+);
+
+export default AttachToSession;

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Switch, Input } from 'antd';
 import SessionStyles from './Session.css';
 import { remote, log } from '../../polyfills';
@@ -7,50 +7,50 @@ import { INPUT } from '../AntdTypes';
 import _ from 'lodash';
 import { APPIUM_SESSION_EXTENSION } from '../../../main/helpers';
 
-const {dialog} = remote;
-
-export default class CapabilityControl extends Component {
-
-  async getLocalFilePath () {
-    try {
-      const {canceled, filePaths} = await dialog.showOpenDialog({
-        properties: ['openFile'],
-        filters: [
-          {name: 'Appium Session Files', extensions: [APPIUM_SESSION_EXTENSION]}
-        ]
-      });
-      if (!canceled && !_.isEmpty(filePaths)) {
-        return filePaths[0];
-      }
-    } catch (e) {
-      log.error(e);
+async function getLocalFilePath () {
+  try {
+    const {canceled, filePaths} = await remote.dialog.showOpenDialog({
+      properties: ['openFile'],
+      filters: [
+        {name: 'Appium Session Files', extensions: [APPIUM_SESSION_EXTENSION]}
+      ]
+    });
+    if (!canceled && !_.isEmpty(filePaths)) {
+      return filePaths[0];
     }
-  }
-
-  render () {
-    const {cap, onSetCapabilityParam, isEditingDesiredCaps, id, t, onPressEnter} = this.props;
-
-    const buttonAfter = (currentFilePath) => <FileOutlined
-      className={SessionStyles['filepath-button']}
-      onClick={async () => {onSetCapabilityParam(await this.getLocalFilePath() || currentFilePath);}} />;
-
-    switch (cap.type) {
-      case 'text': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} onPressEnter={onPressEnter}
-        className={SessionStyles.capsBoxFont} />;
-      case 'boolean': return <Switch disabled={isEditingDesiredCaps} id={id} checkedChildren={'true'} unCheckedChildren={'false'}
-        placeholder={t('Value')} checked={cap.value} onChange={(value) => onSetCapabilityParam(value)} />;
-      case 'number': return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
-        onChange={(e) => !isNaN(parseInt(e.target.value, 10)) ? onSetCapabilityParam(parseInt(e.target.value, 10)) : onSetCapabilityParam(undefined)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />;
-      case 'object':
-      case 'json_object':
-        return <Input disabled={isEditingDesiredCaps} id={id} type={INPUT.TEXTAREA} rows={4} placeholder={t('Value')} value={cap.value}
-          onChange={(e) => onSetCapabilityParam(e.target.value)} className={SessionStyles.capsBoxFont} />;
-      case 'file': return <div className={SessionStyles.fileControlWrapper}>
-        <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value} addonAfter={buttonAfter(cap.value)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />
-      </div>;
-
-      default:
-        throw `Invalid cap type: ${cap.type}`;
-    }
+  } catch (e) {
+    log.error(e);
   }
 }
+
+const CapabilityControl = ({ cap, onSetCapabilityParam, onPressEnter, isEditingDesiredCaps, id, t }) => {
+  switch (cap.type) {
+    case 'text':
+      return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
+        onChange={(e) => onSetCapabilityParam(e.target.value)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />;
+    case 'boolean':
+      return <Switch disabled={isEditingDesiredCaps} id={id} checkedChildren={'true'} unCheckedChildren={'false'}
+        placeholder={t('Value')} checked={cap.value} onChange={(value) => onSetCapabilityParam(value)} />;
+    case 'number':
+      return <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
+        onChange={(e) => !isNaN(parseInt(e.target.value, 10)) ? onSetCapabilityParam(parseInt(e.target.value, 10)) : onSetCapabilityParam(undefined)}
+        onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont} />;
+    case 'object':
+    case 'json_object':
+      return <Input disabled={isEditingDesiredCaps} id={id} type={INPUT.TEXTAREA} rows={4} placeholder={t('Value')}
+        value={cap.value} onChange={(e) => onSetCapabilityParam(e.target.value)} className={SessionStyles.capsBoxFont} />;
+    case 'file':
+      return <div className={SessionStyles.fileControlWrapper}>
+        <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
+          onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont}
+          addonAfter={
+            <FileOutlined className={SessionStyles['filepath-button']}
+              onClick={async () => onSetCapabilityParam(await getLocalFilePath() || cap.value)} />
+          } />
+      </div>;
+    default:
+      throw `Invalid cap type: ${cap.type}`;
+  }
+};
+
+export default CapabilityControl;

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -7,7 +7,7 @@ import { INPUT } from '../AntdTypes';
 import _ from 'lodash';
 import { APPIUM_SESSION_EXTENSION } from '../../../main/helpers';
 
-async function getLocalFilePath () {
+const getLocalFilePath = async () => {
   try {
     const {canceled, filePaths} = await remote.dialog.showOpenDialog({
       properties: ['openFile'],
@@ -21,7 +21,7 @@ async function getLocalFilePath () {
   } catch (e) {
     log.error(e);
   }
-}
+};
 
 const CapabilityControl = ({ cap, onSetCapabilityParam, onPressEnter, isEditingDesiredCaps, id, t }) => {
   switch (cap.type) {

--- a/app/renderer/components/Session/CapabilityEditor.js
+++ b/app/renderer/components/Session/CapabilityEditor.js
@@ -1,179 +1,157 @@
-import React, { Component } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Button, Checkbox, Input, Modal, Form, Row, Col, Select, Tooltip } from 'antd';
 import FormattedCaps from './FormattedCaps';
 import CapabilityControl from './CapabilityControl';
 import SessionStyles from './Session.css';
-import {
-  DeleteOutlined,
-  PlusOutlined
-} from '@ant-design/icons';
+import { DeleteOutlined, PlusOutlined } from '@ant-design/icons';
 import { ROW } from '../AntdTypes';
 
-const {Item: FormItem} = Form;
-const {Option} = Select;
 const whitespaces = /^\s|\s$/;
 
-function whitespaceMsg (value) {
+const whitespaceMsg = (value) => {
   const leadingSpace = /^\s/.test(value);
   const trailingSpace = /\s$/.test(value);
 
   if (leadingSpace && trailingSpace) {return 'Contains Leading & Trailing Whitespace';}
   if (leadingSpace) {return 'Contains Leading Whitespace';}
   if (trailingSpace) {return 'Contains Trailing Whitespace';}
-}
+};
 
-export default class CapabilityEditor extends Component {
+// Callback when the type of a capability is changed
+const handleSetType = (setCapabilityParam, caps, index, type) => {
+  setCapabilityParam(index, 'type', type);
 
-  constructor (props) {
-    super(props);
-    this.latestCapField = React.createRef();
+  // Translate the current value to the new type
+  let translatedValue = caps[index].value;
+  switch (type) {
+    case 'boolean':
+      if (translatedValue === 'true') {
+        translatedValue = true;
+      } else if (translatedValue === 'false') {
+        translatedValue = false;
+      } else {
+        translatedValue = !!translatedValue;
+      }
+      break;
+    case 'number':
+      translatedValue = parseInt(translatedValue, 10) || 0;
+      break;
+    case 'text':
+    case 'json_object':
+    case 'object':
+      translatedValue = translatedValue + '';
+      break;
+    case 'file':
+      translatedValue = '';
+      break;
+    default:
+      break;
   }
+  setCapabilityParam(index, 'value', translatedValue);
+};
 
-  /**
-   * Callback when the type of a dcap is changed
-   */
-  handleSetType (index, type) {
-    let {setCapabilityParam, caps} = this.props;
-    setCapabilityParam(index, 'type', type);
+const CapabilityEditor = (props) => {
 
-    // Translate the current value to the new type
-    let translatedValue = caps[index].value;
-    switch (type) {
-      case 'text':
-        translatedValue = translatedValue + '';
-        break;
-      case 'boolean':
-        if (translatedValue === 'true') {
-          translatedValue = true;
-        } else if (translatedValue === 'false') {
-          translatedValue = false;
-        } else {
-          translatedValue = !!translatedValue;
-        }
-        break;
-      case 'number':
-        translatedValue = parseInt(translatedValue, 10) || 0;
-        break;
-      case 'json_object':
-      case 'object':
-        translatedValue = translatedValue + '';
-        break;
-      case 'file':
-        translatedValue = '';
-        break;
-      default:
-        break;
+  const {setCapabilityParam, caps, addCapability, removeCapability, saveSession, hideSaveAsModal,
+         saveAsText, showSaveAsModal, setSaveAsText, isEditingDesiredCaps, t,
+         setAddVendorPrefixes, addVendorPrefixes, server, serverType} = props;
+
+  const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
+  const latestCapField = useRef();
+
+  // if we have more than one cap and the most recent cap name is empty, it means we've just
+  // added a new cap field, so focus that input element. But only do this once, so we don't annoy
+  // the user if they decide to unfocus and do something else.
+  useEffect(() => {
+    if (caps.length > 1 && !latestCapField.current.input.value && !latestCapField.current.__didFocus) {
+      latestCapField.current.focus();
+      latestCapField.current.__didFocus = true;
     }
-    setCapabilityParam(index, 'value', translatedValue);
-  }
+  }, [caps.length, latestCapField]);
 
-  componentDidUpdate () {
-    const {caps} = this.props;
-    // if we have more than one cap and the most recent cap name is empty, it means we've just
-    // added a new cap field, so focus that input element. But only do this once, so we don't annoy
-    // the user if they decide to unfocus and do something else.
-    if (
-      caps.length > 1 &&
-      !this.latestCapField.current.input.value &&
-      !this.latestCapField.current.__didFocus
-    ) {
-      this.latestCapField.current.focus();
-      this.latestCapField.current.__didFocus = true;
-    }
-  }
-
-  render () {
-    const {setCapabilityParam, caps, addCapability, removeCapability, saveSession, hideSaveAsModal,
-           saveAsText, showSaveAsModal, setSaveAsText, isEditingDesiredCaps, t,
-           setAddVendorPrefixes, addVendorPrefixes, server, serverType} = this.props;
-    const numCaps = caps.length;
-    const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
-
-    return <>
-      <Row type={ROW.FLEX} align="top" justify="start" className={SessionStyles.capsFormRow}>
-        <Col order={1} span={12} className={`${SessionStyles.capsFormCol} ${isEditingDesiredCaps ? SessionStyles.capsFormDisabled : ''}`}>
-          <Form
-            className={SessionStyles.newSessionForm}
-          >
-
-            {caps.map((cap, index) => <Row gutter={8} key={index}>
+  return (
+    <Row type={ROW.FLEX} align="top" justify="start" className={SessionStyles.capsFormRow}>
+      <Col order={1} span={12} className={SessionStyles.capsFormCol}>
+        <Form className={SessionStyles.newSessionForm}>
+          {caps.map((cap, index) => (
+            <Row gutter={8} key={index}>
               <Col span={7}>
-                <FormItem>
+                <Form.Item>
                   <Tooltip title={whitespaceMsg(cap.name)} open={whitespaces.test(cap.name)}>
                     <Input disabled={isEditingDesiredCaps} id={`desiredCapabilityName_${index}`} placeholder={t('Name')}
                       value={cap.name} onChange={(e) => setCapabilityParam(index, 'name', e.target.value)}
-                      ref={index === numCaps - 1 ? this.latestCapField : ''}
-                      className={SessionStyles.capsBoxFont}
-                    />
+                      ref={index === caps.length - 1 ? latestCapField : ''}
+                      className={SessionStyles.capsBoxFont} />
                   </Tooltip>
-                </FormItem>
+                </Form.Item>
               </Col>
               <Col span={8}>
-                <FormItem>
-                  <Select disabled={isEditingDesiredCaps} onChange={(val) => this.handleSetType(index, val)} defaultValue={cap.type}>
-                    <Option value='text'>{t('text')}</Option>
-                    <Option value='boolean'>{t('boolean')}</Option>
-                    <Option value='number'>{t('number')}</Option>
-                    <Option value='object'>{t('JSON object')}</Option>
-                    <Option value='file'>{t('filepath')}</Option>
+                <Form.Item>
+                  <Select disabled={isEditingDesiredCaps} defaultValue={cap.type}
+                    onChange={(val) => handleSetType(setCapabilityParam, caps, index, val)}>
+                    <Select.Option value='text'>{t('text')}</Select.Option>
+                    <Select.Option value='boolean'>{t('boolean')}</Select.Option>
+                    <Select.Option value='number'>{t('number')}</Select.Option>
+                    <Select.Option value='object'>{t('JSON object')}</Select.Option>
+                    <Select.Option value='file'>{t('filepath')}</Select.Option>
                   </Select>
-                </FormItem>
+                </Form.Item>
               </Col>
               <Col span={7}>
-                <FormItem>
+                <Form.Item>
                   <Tooltip title={whitespaceMsg(cap.value)} open={whitespaces.test(cap.value)}>
-                    <CapabilityControl {...this.props} cap={cap} id={`desiredCapabilityValue_${index}`}
+                    <CapabilityControl {...props} cap={cap} id={`desiredCapabilityValue_${index}`}
                       onSetCapabilityParam={(value) => setCapabilityParam(index, 'value', value)}
-                      onPressEnter={(index === numCaps - 1) ? addCapability : () => {}}
-                    />
+                      onPressEnter={(index === caps.length - 1) ? addCapability : () => {}} />
                   </Tooltip>
-                </FormItem>
+                </Form.Item>
               </Col>
               <Col span={2}>
                 <div className={SessionStyles.btnDeleteCap}>
-                  <FormItem>
+                  <Form.Item>
                     <Button {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
                       icon={<DeleteOutlined/>}
-                      onClick={() => removeCapability(index)}/>
-                  </FormItem>
+                      onClick={() => removeCapability(index)} />
+                  </Form.Item>
                 </div>
               </Col>
-            </Row>)}
-            <Row>
-              <Col span={22}>
-                <FormItem>
-                  <Checkbox
-                    onChange={(e) => setAddVendorPrefixes(e.target.checked)}
-                    checked={addVendorPrefixes}
-                  >
-                    {t('autoAddPrefixes')}
-                  </Checkbox>
-                </FormItem>
-              </Col>
-              <Col span={2}>
-                <FormItem>
-                  <Button
-                    disabled={isEditingDesiredCaps} id='btnAddDesiredCapability'
-                    icon={<PlusOutlined/>}
-                    onClick={addCapability}
-                    className={SessionStyles['add-desired-capability-button']} />
-                </FormItem>
-              </Col>
             </Row>
-          </Form>
-        </Col>
-        <Col order={2} span={12} className={SessionStyles.capsFormattedCol}>
-          <FormattedCaps {...this.props} />
-          <Modal open={showSaveAsModal}
-            title={t('Save Capability Set As')}
-            okText='Save'
-            cancelText='Cancel'
-            onCancel={hideSaveAsModal}
-            onOk={onSaveAsOk}>
-            <Input onChange={(e) => setSaveAsText(e.target.value)} addonBefore={t('Name')} value={saveAsText} onPressEnter={onSaveAsOk}/>
-          </Modal>
-        </Col>
-      </Row>
-    </>;
-  }
-}
+          ))}
+          <Row>
+            <Col span={22}>
+              <Form.Item>
+                <Checkbox checked={addVendorPrefixes}
+                  onChange={(e) => setAddVendorPrefixes(e.target.checked)}>
+                  {t('autoAddPrefixes')}
+                </Checkbox>
+              </Form.Item>
+            </Col>
+            <Col span={2}>
+              <Form.Item>
+                <Button
+                  disabled={isEditingDesiredCaps} id='btnAddDesiredCapability'
+                  icon={<PlusOutlined/>}
+                  onClick={addCapability}
+                  className={SessionStyles['add-desired-capability-button']} />
+              </Form.Item>
+            </Col>
+          </Row>
+        </Form>
+      </Col>
+      <Col order={2} span={12} className={SessionStyles.capsFormattedCol}>
+        <FormattedCaps {...props} />
+        <Modal open={showSaveAsModal}
+          title={t('Save Capability Set As')}
+          okText='Save'
+          cancelText='Cancel'
+          onCancel={hideSaveAsModal}
+          onOk={onSaveAsOk}>
+          <Input onChange={(e) => setSaveAsText(e.target.value)} addonBefore={t('Name')}
+            value={saveAsText} onPressEnter={onSaveAsOk} />
+        </Modal>
+      </Col>
+    </Row>
+  );
+};
+
+export default CapabilityEditor;

--- a/app/renderer/components/Session/CapabilityEditor.js
+++ b/app/renderer/components/Session/CapabilityEditor.js
@@ -51,10 +51,9 @@ const handleSetType = (setCapabilityParam, caps, index, type) => {
 };
 
 const CapabilityEditor = (props) => {
-
-  const {setCapabilityParam, caps, addCapability, removeCapability, saveSession, hideSaveAsModal,
-         saveAsText, showSaveAsModal, setSaveAsText, isEditingDesiredCaps, t,
-         setAddVendorPrefixes, addVendorPrefixes, server, serverType} = props;
+  const { setCapabilityParam, caps, addCapability, removeCapability, saveSession, hideSaveAsModal,
+          saveAsText, showSaveAsModal, setSaveAsText, isEditingDesiredCaps, t,
+          setAddVendorPrefixes, addVendorPrefixes, server, serverType } = props;
 
   const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
   const latestCapField = useRef();

--- a/app/renderer/components/Session/CloudProviderSelector.js
+++ b/app/renderer/components/Session/CloudProviderSelector.js
@@ -7,16 +7,6 @@ import { BUTTON } from '../AntdTypes';
 
 export default class CloudProviderSelector extends Component {
 
-  componentDidMount () {
-    const {setLocalServerParams, getSavedSessions, setSavedServerParams, getRunningSessions} = this.props;
-    (async () => {
-      await getSavedSessions();
-      await setSavedServerParams();
-      await setLocalServerParams();
-      getRunningSessions();
-    })();
-  }
-
   toggleVisibleProvider (providerName) {
     const {addVisibleProvider, removeVisibleProvider, visibleProviders = []} = this.props;
     if (visibleProviders.includes(providerName)) {

--- a/app/renderer/components/Session/CloudProviderSelector.js
+++ b/app/renderer/components/Session/CloudProviderSelector.js
@@ -6,14 +6,13 @@ import SessionStyles from './Session.css';
 import { BUTTON } from '../AntdTypes';
 
 const CloudProviderSelector = (props) => {
-
-  const { visibleProviders = [], addVisibleProvider, removeVisibleProvider,
-          isAddingCloudProvider, stopAddCloudProvider, t } = props;
+  const { visibleProviders = [], isAddingCloudProvider, stopAddCloudProvider, t } = props;
 
   const footer = <Button key="back" type={BUTTON.PRIMARY} onClick={stopAddCloudProvider}>{t('Done')}</Button>;
   const providersGrid = _.chunk(_.keys(CloudProviders), 2); // Converts list of providers into list of pairs of providers
 
   const toggleVisibleProvider = (providerName) => {
+    const { addVisibleProvider, removeVisibleProvider } = props;
     if (visibleProviders.includes(providerName)) {
       removeVisibleProvider(providerName);
     } else {

--- a/app/renderer/components/Session/CloudProviderSelector.js
+++ b/app/renderer/components/Session/CloudProviderSelector.js
@@ -1,49 +1,50 @@
-import React, { Component } from 'react';
+import React from 'react';
 import _ from 'lodash';
 import { Modal, Row, Col, Button } from 'antd';
 import CloudProviders from './CloudProviders';
 import SessionStyles from './Session.css';
 import { BUTTON } from '../AntdTypes';
 
-export default class CloudProviderSelector extends Component {
+const CloudProviderSelector = (props) => {
 
-  toggleVisibleProvider (providerName) {
-    const {addVisibleProvider, removeVisibleProvider, visibleProviders = []} = this.props;
+  const { visibleProviders = [], addVisibleProvider, removeVisibleProvider,
+          isAddingCloudProvider, stopAddCloudProvider, t } = props;
+
+  const footer = <Button key="back" type={BUTTON.PRIMARY} onClick={stopAddCloudProvider}>{t('Done')}</Button>;
+  const providersGrid = _.chunk(_.keys(CloudProviders), 2); // Converts list of providers into list of pairs of providers
+
+  const toggleVisibleProvider = (providerName) => {
     if (visibleProviders.includes(providerName)) {
       removeVisibleProvider(providerName);
     } else {
       addVisibleProvider(providerName);
     }
-  }
+  };
 
-  render () {
-    const {t, isAddingCloudProvider, stopAddCloudProvider, visibleProviders = []} = this.props;
-    const providersGrid = _.chunk(_.keys(CloudProviders), 2); // Converts list of providers into list of pairs of providers
-    const footer = [<Button key="back" type={BUTTON.PRIMARY} onClick={stopAddCloudProvider}>{t('Done')}</Button>];
+  return <Modal key="modal"
+    className={SessionStyles.cloudProviderModal}
+    open={isAddingCloudProvider}
+    onCancel={stopAddCloudProvider}
+    footer={footer}
+    title={t('Select Cloud Providers')}>
+    {[
+      ..._.map(providersGrid, (row, key) => <Row gutter={16} key={key}>{
+        [
+          ..._(row).map((providerName) => {
+            const providerIsVisible = visibleProviders.includes(providerName);
+            const style = {};
+            if (providerIsVisible) {
+              style.borderColor = '#40a9ff';
+            }
+            const provider = CloudProviders[providerName];
+            return provider && <Col span={12} key={providerName}>
+              <Button role="checkbox" style={style} onClick={() => toggleVisibleProvider(providerName)}><img src={provider.logo} /></Button>
+            </Col>;
+          })
+        ]
+      }</Row>)
+    ]}
+  </Modal>;
+};
 
-    return <Modal key="modal"
-      className={SessionStyles.cloudProviderModal}
-      open={isAddingCloudProvider}
-      onCancel={stopAddCloudProvider}
-      footer={footer}
-      title={t('Select Cloud Providers')}>
-      {[
-        ..._.map(providersGrid, (row, key) => <Row gutter={16} key={key}>{
-          [
-            ..._(row).map((providerName) => {
-              const providerIsVisible = visibleProviders.includes(providerName);
-              const style = {};
-              if (providerIsVisible) {
-                style.borderColor = '#40a9ff';
-              }
-              const provider = CloudProviders[providerName];
-              return provider && <Col span={12} key={providerName}>
-                <Button role="checkbox" style={style} onClick={() => this.toggleVisibleProvider(providerName)}><img src={provider.logo} /></Button>
-              </Col>;
-            })
-          ]
-        }</Row>)
-      ]}
-    </Modal>;
-  }
-}
+export default CloudProviderSelector;

--- a/app/renderer/components/Session/CloudProviderSelector.js
+++ b/app/renderer/components/Session/CloudProviderSelector.js
@@ -16,11 +16,6 @@ export default class CloudProviderSelector extends Component {
     }
   }
 
-  handleCloseModal () {
-    const {stopAddCloudProvider} = this.props;
-    stopAddCloudProvider();
-  }
-
   render () {
     const {t, isAddingCloudProvider, stopAddCloudProvider, visibleProviders = []} = this.props;
     const providersGrid = _.chunk(_.keys(CloudProviders), 2); // Converts list of providers into list of pairs of providers

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -7,13 +7,13 @@ import { CloseOutlined, SaveOutlined, EditOutlined } from '@ant-design/icons';
 import { ALERT } from '../AntdTypes';
 
 const FormattedCaps = (props) => {
-
-  const {caps, title, desiredCapsName, setDesiredCapsName, isEditingDesiredCapsName,
-         startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName,
-         isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor,
-         saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps, isValidCapsJson, invalidCapsJsonReason, t} = props;
+  const { caps, title, desiredCapsName, isEditingDesiredCapsName,
+          isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor,
+          saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps,
+          isValidCapsJson, invalidCapsJsonReason, t } = props;
 
   const setCapsTitle = () => {
+    const { setDesiredCapsName } = props;
     if (!title) {
       return 'JSON Representation';
     } else if (!isEditingDesiredCapsName) {
@@ -28,6 +28,7 @@ const FormattedCaps = (props) => {
   };
 
   const setCapsTitleButtons = () => {
+    const { startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName } = props;
     if (!title) {
       return null;
     } else if (!isEditingDesiredCapsName) {

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -1,19 +1,19 @@
-import React, { Component } from 'react';
+import React from 'react';
 import formatJSON from 'format-json';
 import SessionStyles from './Session.css';
 import { Card, Button, Alert, Tooltip } from 'antd';
 import { getCapsObject } from '../../actions/Session.js';
-import {
-  CloseOutlined,
-  SaveOutlined,
-  EditOutlined
-} from '@ant-design/icons';
+import { CloseOutlined, SaveOutlined, EditOutlined } from '@ant-design/icons';
 import { ALERT } from '../AntdTypes';
 
-export default class FormattedCaps extends Component {
+export const FormattedCaps = (props) => {
 
-  setCapsTitle (title, isEditingDesiredCapsName) {
-    const {setDesiredCapsName, desiredCapsName} = this.props;
+  const {caps, title, desiredCapsName, setDesiredCapsName, isEditingDesiredCapsName,
+         startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName,
+         isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor,
+         saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps, isValidCapsJson, invalidCapsJsonReason, t} = props;
+
+  const setCapsTitle = () => {
     if (!title) {
       return 'JSON Representation';
     } else if (!isEditingDesiredCapsName) {
@@ -25,10 +25,9 @@ export default class FormattedCaps extends Component {
         className={SessionStyles.capsEditorTitle}
       />;
     }
-  }
+  };
 
-  setCapsTitleButtons (title, isEditingDesiredCapsName, t) {
-    const {startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName} = this.props;
+  const setCapsTitleButtons = () => {
     if (!title) {
       return null;
     } else if (!isEditingDesiredCapsName) {
@@ -55,48 +54,42 @@ export default class FormattedCaps extends Component {
           className={SessionStyles.capsNameEditorButton} />
       </Tooltip></div>;
     }
-  }
+  };
 
-  getFormattedJSON (caps) {
-    return formatJSON.plain(getCapsObject(caps));
-  }
+  return caps && <Card
+    className={SessionStyles.formattedCaps}
+    title={setCapsTitle()}
+    extra={setCapsTitleButtons()}
+  >
+    <div className={SessionStyles.capsEditorControls}>
+      {isEditingDesiredCaps && <Tooltip title={t('Cancel')}>
+        <Button
+          onClick={abortDesiredCapsEditor}
+          icon={<CloseOutlined/>}
+          className={SessionStyles.capsEditorButton} />
+      </Tooltip> }
+      {isEditingDesiredCaps && <Tooltip title={t('Save')}>
+        <Button
+          onClick={saveRawDesiredCaps}
+          icon={<SaveOutlined/>}
+          className={SessionStyles.capsEditorButton} />
+      </Tooltip>}
+      {!isEditingDesiredCaps && <Tooltip title={t('Edit Raw JSON')} placement="topRight" >
+        <Button
+          onClick={startDesiredCapsEditor}
+          icon={<EditOutlined/>} />
+      </Tooltip> }
+    </div>
+    {isEditingDesiredCaps && <div className={SessionStyles.capsEditor}>
+      <textarea onChange={(e) => setRawDesiredCaps(e.target.value)} value={rawDesiredCaps}
+        className={`${SessionStyles.capsEditorBody} ${isValidCapsJson ? SessionStyles.capsEditorBodyFull : SessionStyles.capsEditorBodyResized}`}
+      />
+      {!isValidCapsJson && <Alert message={invalidCapsJsonReason} type={ALERT.ERROR} />}
+    </div>}
+    {!isEditingDesiredCaps && <div className={SessionStyles.formattedCapsBody}>
+      <pre>{formatJSON.plain(getCapsObject(caps))}</pre>
+    </div>}
+  </Card>;
+};
 
-  render () {
-    const {caps, title, isEditingDesiredCapsName, isEditingDesiredCaps, startDesiredCapsEditor, abortDesiredCapsEditor,
-           saveRawDesiredCaps, setRawDesiredCaps, rawDesiredCaps, isValidCapsJson, invalidCapsJsonReason, t} = this.props;
-    return caps && <Card
-      className={SessionStyles.formattedCaps}
-      title={this.setCapsTitle(title, isEditingDesiredCapsName)}
-      extra={this.setCapsTitleButtons(title, isEditingDesiredCapsName, t)}
-    >
-      <div className={SessionStyles.capsEditorControls}>
-        {isEditingDesiredCaps && <Tooltip title={t('Cancel')}>
-          <Button
-            onClick={abortDesiredCapsEditor}
-            icon={<CloseOutlined/>}
-            className={SessionStyles.capsEditorButton} />
-        </Tooltip> }
-        {isEditingDesiredCaps && <Tooltip title={t('Save')}>
-          <Button
-            onClick={saveRawDesiredCaps}
-            icon={<SaveOutlined/>}
-            className={SessionStyles.capsEditorButton} />
-        </Tooltip>}
-        {!isEditingDesiredCaps && <Tooltip title={t('Edit Raw JSON')} placement="topRight" >
-          <Button
-            onClick={startDesiredCapsEditor}
-            icon={<EditOutlined/>} />
-        </Tooltip> }
-      </div>
-      {isEditingDesiredCaps && <div className={SessionStyles.capsEditor}>
-        <textarea onChange={(e) => setRawDesiredCaps(e.target.value)} value={rawDesiredCaps}
-          className={`${SessionStyles.capsEditorBody} ${isValidCapsJson ? SessionStyles.capsEditorBodyFull : SessionStyles.capsEditorBodyResized}`}
-        />
-        {!isValidCapsJson && <Alert message={invalidCapsJsonReason} type={ALERT.ERROR} />}
-      </div>}
-      {!isEditingDesiredCaps && <div className={SessionStyles.formattedCapsBody}>
-        <pre>{this.getFormattedJSON(caps)}</pre>
-      </div>}
-    </Card>;
-  }
-}
+export default FormattedCaps;

--- a/app/renderer/components/Session/FormattedCaps.js
+++ b/app/renderer/components/Session/FormattedCaps.js
@@ -6,7 +6,7 @@ import { getCapsObject } from '../../actions/Session.js';
 import { CloseOutlined, SaveOutlined, EditOutlined } from '@ant-design/icons';
 import { ALERT } from '../AntdTypes';
 
-export const FormattedCaps = (props) => {
+const FormattedCaps = (props) => {
 
   const {caps, title, desiredCapsName, setDesiredCapsName, isEditingDesiredCapsName,
          startDesiredCapsNameEditor, abortDesiredCapsNameEditor, saveDesiredCapsName,

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -29,11 +29,12 @@ const sessionFromUUID = (savedSessions, uuid) => {
 };
 
 const SavedSessions = (props) => {
-
-  const { savedSessions, deleteSavedSession, capsUUID, switchTabs, setCapsAndServer, server, serverType,
-          isEditingDesiredCapsName, abortDesiredCapsNameEditor, isEditingDesiredCaps, abortDesiredCapsEditor } = props;
+  const { savedSessions, capsUUID, switchTabs } = props;
 
   const handleCapsAndServer = (uuid) => {
+    const { setCapsAndServer, server, serverType,
+            isEditingDesiredCapsName, abortDesiredCapsNameEditor,
+            isEditingDesiredCaps, abortDesiredCapsEditor } = props;
     const session = sessionFromUUID(savedSessions, uuid);
 
     // Disable any editors before changing the selected caps
@@ -44,7 +45,7 @@ const SavedSessions = (props) => {
       abortDesiredCapsEditor();
     }
 
-    // Incase user has CAPS saved from older version of Inspector which
+    // In case user has CAPS saved from older version of Inspector which
     // doesn't contain server and serverType within the session object
     setCapsAndServer(
       session.server || server,
@@ -56,6 +57,7 @@ const SavedSessions = (props) => {
   };
 
   const handleDelete = (uuid) => {
+    const { deleteSavedSession } = props;
     if (window.confirm('Are you sure?')) {
       deleteSavedSession(uuid);
     }

--- a/app/renderer/components/Session/SavedSessions.js
+++ b/app/renderer/components/Session/SavedSessions.js
@@ -1,41 +1,40 @@
-import React, { Component } from 'react';
+import React from 'react';
 import moment from 'moment';
 import { Button, Row, Col, Table } from 'antd';
 import FormattedCaps from './FormattedCaps';
 import SessionStyles from './Session.css';
-import {
-  EditOutlined,
-  DeleteOutlined
-} from '@ant-design/icons';
+import { EditOutlined, DeleteOutlined } from '@ant-design/icons';
 
 const DATE_COLUMN_WIDTH = '25%';
 const ACTIONS_COLUMN_WIDTH = '106px';
 
-export default class SavedSessions extends Component {
-
-  constructor (props) {
-    super(props);
-    this.onRow = this.onRow.bind(this);
-    this.getRowClassName = this.getRowClassName.bind(this);
+const dataSource = (savedSessions) => {
+  if (!savedSessions) {
+    return [];
   }
+  return savedSessions.map((session) => ({
+    key: session.uuid,
+    name: (session.name || '(Unnamed)'),
+    date: moment(session.date).format('YYYY-MM-DD')
+  }));
+};
 
-  onRow (record) {
-    return {
-      onClick: () => {
-        this.handleCapsAndServer(record.key);
-      }
-    };
+const sessionFromUUID = (savedSessions, uuid) => {
+  for (let session of savedSessions) {
+    if (session.uuid === uuid) {
+      return session;
+    }
   }
+  throw new Error(`Couldn't find session with uuid ${uuid}`);
+};
 
-  getRowClassName (record) {
-    const {capsUUID} = this.props;
-    return capsUUID === record.key ? SessionStyles.selected : '';
-  }
+const SavedSessions = (props) => {
 
-  handleCapsAndServer (uuid) {
-    const {setCapsAndServer, server, serverType, isEditingDesiredCapsName, abortDesiredCapsNameEditor,
-           isEditingDesiredCaps, abortDesiredCapsEditor} = this.props;
-    const session = this.sessionFromUUID(uuid);
+  const { savedSessions, deleteSavedSession, capsUUID, switchTabs, setCapsAndServer, server, serverType,
+          isEditingDesiredCapsName, abortDesiredCapsNameEditor, isEditingDesiredCaps, abortDesiredCapsEditor } = props;
+
+  const handleCapsAndServer = (uuid) => {
+    const session = sessionFromUUID(savedSessions, uuid);
 
     // Disable any editors before changing the selected caps
     if (isEditingDesiredCapsName) {
@@ -47,80 +46,63 @@ export default class SavedSessions extends Component {
 
     // Incase user has CAPS saved from older version of Inspector which
     // doesn't contain server and serverType within the session object
-    setCapsAndServer(session.server || server, session.serverType || serverType, session.caps, session.uuid, session.name);
-  }
+    setCapsAndServer(
+      session.server || server,
+      session.serverType || serverType,
+      session.caps,
+      session.uuid,
+      session.name
+    );
+  };
 
-  handleDelete (uuid) {
-    return () => {
-      if (window.confirm('Are you sure?')) {
-        this.props.deleteSavedSession(uuid);
-      }
-    };
-  }
-
-  sessionFromUUID (uuid) {
-    const {savedSessions} = this.props;
-    for (let session of savedSessions) {
-      if (session.uuid === uuid) {
-        return session;
-      }
+  const handleDelete = (uuid) => {
+    if (window.confirm('Are you sure?')) {
+      deleteSavedSession(uuid);
     }
-    throw new Error(`Couldn't find session with uuid ${uuid}`);
-  }
+  };
 
-  render () {
-    const {savedSessions, capsUUID, switchTabs} = this.props;
+  const columns = [{
+    title: 'Capability Set',
+    dataIndex: 'name',
+    key: 'name'
+  }, {
+    title: 'Created',
+    dataIndex: 'date',
+    key: 'date',
+    width: DATE_COLUMN_WIDTH
+  }, {
+    title: 'Actions',
+    key: 'action',
+    width: ACTIONS_COLUMN_WIDTH,
+    render: (_, record) => <div>
+      <Button
+        icon={<EditOutlined/>}
+        onClick={() => {handleCapsAndServer(record.key); switchTabs('new');}}
+        className={SessionStyles.editSession}
+      />
+      <Button
+        icon={<DeleteOutlined/>}
+        onClick={() => handleDelete(record.key)}/>
+    </div>
+  }];
 
-    const columns = [{
-      title: 'Capability Set',
-      dataIndex: 'name',
-      key: 'name'
-    }, {
-      title: 'Created',
-      dataIndex: 'date',
-      key: 'date',
-      width: DATE_COLUMN_WIDTH
-    }, {
-      title: 'Actions',
-      key: 'action',
-      width: ACTIONS_COLUMN_WIDTH,
-      render: (text, record) => <div>
-        <Button
-          icon={<EditOutlined/>}
-          onClick={() => {this.handleCapsAndServer(record.key); switchTabs('new');}}
-          className={SessionStyles.editSession}
-        />
-        <Button
-          icon={<DeleteOutlined/>}
-          onClick={this.handleDelete(record.key)}/>
-      </div>
-    }];
-
-    let dataSource = [];
-    if (savedSessions) {
-      dataSource = savedSessions.map((session) => ({
-        key: session.uuid,
-        name: (session.name || '(Unnamed)'),
-        date: moment(session.date).format('YYYY-MM-DD')
-      }));
-    }
-
-    return (<Row className={SessionStyles.savedSessions}>
+  return (
+    <Row className={SessionStyles.savedSessions}>
       <Col span={12}>
         <Table
           pagination={false}
           sticky={true}
-          dataSource={dataSource}
+          dataSource={dataSource(savedSessions)}
           columns={columns}
-          onRow={this.onRow}
-          rowClassName={this.getRowClassName}
-        />
+          onRow={(row) => ({onClick: () => handleCapsAndServer(row.key)})}
+          rowClassName={(row) => (capsUUID === row.key ? SessionStyles.selected : '')} />
       </Col>
       <Col span={12} className={SessionStyles.capsFormattedCol}>
-        <FormattedCaps {...this.props}
-          title={capsUUID ? this.sessionFromUUID(capsUUID).name : null}
-        />
+        <FormattedCaps {...props}
+          title={capsUUID ? sessionFromUUID(savedSessions, capsUUID).name : null} />
       </Col>
-    </Row>);
-  }
-}
+    </Row>
+  );
+};
+
+export default SavedSessions;

--- a/app/renderer/components/Session/ServerTabBitbar.js
+++ b/app/renderer/components/Session/ServerTabBitbar.js
@@ -1,26 +1,25 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
-
-export default class ServerTabBitbar extends Component {
-
-  render () {
-    const { server, setServerParam, t } = this.props;
-
-    const bitbarApiKeyPlaceholder = process.env.BITBAR_API_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'BITBAR_API_KEY'}) : t('yourApiKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={24}>
-          <FormItem>
-            <Input id='bitbarApiKey' type={INPUT.PASSWORD} placeholder={bitbarApiKeyPlaceholder} addonBefore={t('Bitbar API Key')}
-              value={server.bitbar.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const bitbarApiKeyPlaceholder = (t) => {
+  if (process.env.BITBAR_API_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'BITBAR_API_KEY'});
   }
-}
+  return t('yourApiKey');
+};
+
+const ServerTabBitbar = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={24}>
+        <Form.Item>
+          <Input id='bitbarApiKey' type={INPUT.PASSWORD} placeholder={bitbarApiKeyPlaceholder(t)} addonBefore={t('Bitbar API Key')}
+            value={server.bitbar.apiKey} onChange={(e) => setServerParam('apiKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabBitbar;

--- a/app/renderer/components/Session/ServerTabBrowserstack.js
+++ b/app/renderer/components/Session/ServerTabBrowserstack.js
@@ -1,36 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
-
-export default class ServerTabBrowserstack extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const browserstackUsernamePlaceholder = process.env.BROWSERSTACK_USERNAME ?
-      t('usingDataFoundIn', {environmentVariable: 'BROWSERSTACK_USERNAME'}) : t('yourUsername');
-
-    const browserstackAccessKeyPlaceholder = process.env.BROWSERSTACK_ACCESS_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'BROWSERSTACK_ACCESS_KEY'}) : t('yourAccessKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input id='browserstackUsername' placeholder={browserstackUsernamePlaceholder} addonBefore={t('BrowserStack Username')} value={server.browserstack.username}
-              onChange={(e) => setServerParam('username', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input id='browserstackPassword' type={INPUT.PASSWORD} placeholder={browserstackAccessKeyPlaceholder} addonBefore={t('BrowserStack Access Key')}
-              value={server.browserstack.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const browserstackUsernamePlaceholder = (t) => {
+  if (process.env.BROWSERSTACK_USERNAME) {
+    return t('usingDataFoundIn', {environmentVariable: 'BROWSERSTACK_USERNAME'});
   }
-}
+  return t('yourUsername');
+};
+
+const browserstackAccessKeyPlaceholder = (t) => {
+  if (process.env.BROWSERSTACK_ACCESS_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'BROWSERSTACK_ACCESS_KEY'});
+  }
+  return t('yourAccessKey');
+};
+
+const ServerTabBrowserstack = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='browserstackUsername' placeholder={browserstackUsernamePlaceholder(t)} addonBefore={t('BrowserStack Username')} value={server.browserstack.username}
+            onChange={(e) => setServerParam('username', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='browserstackPassword' type={INPUT.PASSWORD} placeholder={browserstackAccessKeyPlaceholder(t)} addonBefore={t('BrowserStack Access Key')}
+            value={server.browserstack.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabBrowserstack;

--- a/app/renderer/components/Session/ServerTabCustom.js
+++ b/app/renderer/components/Session/ServerTabCustom.js
@@ -1,41 +1,35 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input, Checkbox } from 'antd';
 import { DEFAULT_SERVER_PATH, DEFAULT_SERVER_HOST, DEFAULT_SERVER_PORT } from '../../actions/Session';
 
-const FormItem = Form.Item;
+const ServerTabCustom = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={9}>
+        <Form.Item>
+          <Input id='customServerHost' placeholder={DEFAULT_SERVER_HOST} addonBefore={t('Remote Host')} value={server.remote.hostname}
+            onChange={(e) => setServerParam('hostname', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={4}>
+        <Form.Item>
+          <Input id='customServerPort' placeholder={DEFAULT_SERVER_PORT} addonBefore={t('Remote Port')} value={server.remote.port}
+            onChange={(e) => setServerParam('port', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={9}>
+        <Form.Item>
+          <Input id='customServerPath' placeholder={DEFAULT_SERVER_PATH} addonBefore={t('Remote Path')} value={server.remote.path}
+            onChange={(e) => setServerParam('path', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={2}>
+        <Form.Item>
+          <Checkbox id='customServerSSL' checked={!!server.remote.ssl} value={server.remote.ssl} onChange={(e) => setServerParam('ssl', e.target.checked)}>{t('SSL')}</Checkbox>
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
 
-export default class ServerTabCustom extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={9}>
-          <FormItem>
-            <Input id='customServerHost' placeholder={DEFAULT_SERVER_HOST} addonBefore={t('Remote Host')} value={server.remote.hostname}
-              onChange={(e) => setServerParam('hostname', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={4}>
-          <FormItem>
-            <Input id='customServerPort' placeholder={DEFAULT_SERVER_PORT} addonBefore={t('Remote Port')} value={server.remote.port}
-              onChange={(e) => setServerParam('port', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={9}>
-          <FormItem>
-            <Input id='customServerPath' placeholder={DEFAULT_SERVER_PATH} addonBefore={t('Remote Path')} value={server.remote.path}
-              onChange={(e) => setServerParam('path', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={2}>
-          <FormItem>
-            <Checkbox id='customServerSSL' checked={!!server.remote.ssl} value={server.remote.ssl} onChange={(e) => setServerParam('ssl', e.target.checked)}>{t('SSL')}</Checkbox>
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
-  }
-}
+export default ServerTabCustom;

--- a/app/renderer/components/Session/ServerTabExperitest.js
+++ b/app/renderer/components/Session/ServerTabExperitest.js
@@ -1,34 +1,29 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input } from 'antd';
 import SessionStyles from './Session.css';
 
-const FormItem = Form.Item;
+const accessKeyPlaceholder = 'accessKey';
+const placeholderUrl = 'https://example.experitest.com';
 
-export default class ServerTabExperitest extends Component {
+const ServerTabExperitest = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input className={SessionStyles.customServerInputLeft} id='ExperitestServerUrl' placeholder={placeholderUrl}
+            addonBefore={t('experitestUrl')} value={server.experitest.url}
+            onChange={(evt) => setServerParam('url', evt.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input className={SessionStyles.customServerInputLeft} id='ExperitestServerAccessKey' placeholder={accessKeyPlaceholder}
+            addonBefore={t('experitestAccessKey')} value={server.experitest.accessKey}
+            onChange={(evt) => setServerParam('accessKey', evt.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
 
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-    const accessKeyPlaceholder = 'accessKey';
-    const placeholderUrl = 'https://example.experitest.com';
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input className={SessionStyles.customServerInputLeft} id='ExperitestServerUrl' placeholder={placeholderUrl}
-              addonBefore={t('experitestUrl')} value={server.experitest.url}
-              onChange={(evt) => setServerParam('url', evt.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input className={SessionStyles.customServerInputLeft} id='ExperitestServerAccessKey' placeholder={accessKeyPlaceholder}
-              addonBefore={t('experitestAccessKey')} value={server.experitest.accessKey}
-              onChange={(evt) => setServerParam('accessKey', evt.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
-  }
-}
+export default ServerTabExperitest;

--- a/app/renderer/components/Session/ServerTabHeadspin.js
+++ b/app/renderer/components/Session/ServerTabHeadspin.js
@@ -1,26 +1,22 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input } from 'antd';
 import SessionStyles from './Session.css';
 
-const FormItem = Form.Item;
+const headspinUrl = 'https://xxxx.headspin.io:4723/v0/your-api-token/wd/hub';
 
-export default class ServerTabHeadspin extends Component {
+const ServerTabHeadspin = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={24}>
+        <Form.Item>
+          <Input className={SessionStyles.customServerInputLeft} id='headspinServerHost' placeholder={headspinUrl} addonBefore={t('serverTabHeasdpinWebDriverURL')}
+            value={server.headspin.webDriverUrl} onChange={(e) => setServerParam('webDriverUrl', e.target.value)} />
+          <p className={SessionStyles.localDesc}>{t('sessionHeadspinWebDriverURLDescription')}</p>
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
 
-  render () {
+export default ServerTabHeadspin;
 
-    const {server, setServerParam, t} = this.props;
-
-    const headspinUrl = 'https://xxxx.headspin.io:4723/v0/your-api-token/wd/hub';
-    return <Form>
-      <Row gutter={8}>
-        <Col span={24}>
-          <FormItem>
-            <Input className={SessionStyles.customServerInputLeft} id='headspinServerHost' placeholder={headspinUrl} addonBefore={t('serverTabHeasdpinWebDriverURL')}
-              value={server.headspin.webDriverUrl} onChange={(e) => setServerParam('webDriverUrl', e.target.value)} />
-            <p className={SessionStyles.localDesc}>{t('sessionHeadspinWebDriverURLDescription')}</p>
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
-  }
-}

--- a/app/renderer/components/Session/ServerTabKobiton.js
+++ b/app/renderer/components/Session/ServerTabKobiton.js
@@ -1,33 +1,37 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
-
-export default class ServerTabKobiton extends Component {
-
-  render () {
-    const {server, setServerParam, t} = this.props;
-    const kobitonUsernamePlaceholder = process.env.KOBITON_USERNAME ?
-      t('usingDataFoundIn', {environmentVariable: 'KOBITON_USERNAME'}) : t('yourUsername');
-
-    const kobitonAccessKeyPlaceholder = process.env.KOBITON_ACCESS_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'KOBITON_ACCESS_KEY'}) : t('yourAccessKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input id='kobitonUsername' placeholder={kobitonUsernamePlaceholder} addonBefore={t('Your Kobiton Username')} value={server.kobiton.username}
-              onChange={(e) => setServerParam('username', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input id='kobitonAccessKey' type={INPUT.PASSWORD} placeholder={kobitonAccessKeyPlaceholder} addonBefore={t('Kobiton Access Key')} value={server.kobiton.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const kobitonUsernamePlaceholder = (t) => {
+  if (process.env.KOBITON_USERNAME) {
+    return t('usingDataFoundIn', {environmentVariable: 'KOBITON_USERNAME'});
   }
-}
+  return t('yourUsername');
+};
+
+const kobitonAccessKeyPlaceholder = (t) => {
+  if (process.env.KOBITON_ACCESS_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'KOBITON_ACCESS_KEY'});
+  }
+  return t('yourAccessKey');
+};
+
+const ServerTabKobiton = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='kobitonUsername' placeholder={kobitonUsernamePlaceholder(t)} addonBefore={t('Your Kobiton Username')} value={server.kobiton.username}
+            onChange={(e) => setServerParam('username', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='kobitonAccessKey' type={INPUT.PASSWORD} placeholder={kobitonAccessKeyPlaceholder(t)} addonBefore={t('Kobiton Access Key')} value={server.kobiton.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabKobiton;

--- a/app/renderer/components/Session/ServerTabLambdatest.js
+++ b/app/renderer/components/Session/ServerTabLambdatest.js
@@ -1,36 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
-
-export default class ServerTabLambdatest extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const lambdatestUsernamePlaceholder = process.env.LAMBDATEST_USERNAME ?
-      t('usingDataFoundIn', {environmentVariable: 'LAMBDATEST_USERNAME'}) : t('yourUsername');
-
-    const lambdatestAccessKeyPlaceholder = process.env.LAMBDATEST_ACCESS_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'LAMBDATEST_ACCESS_KEY'}) : t('yourAccessKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input id='lambdatestUsername' placeholder={lambdatestUsernamePlaceholder} addonBefore={t('LambdaTest Username')} value={server.lambdatest.username}
-              onChange={(e) => setServerParam('username', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input id='lambdatestPassword' type={INPUT.PASSWORD} placeholder={lambdatestAccessKeyPlaceholder} addonBefore={t('LambdaTest Access Key')}
-              value={server.lambdatest.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const lambdatestUsernamePlaceholder = (t) => {
+  if (process.env.LAMBDATEST_USERNAME) {
+    return t('usingDataFoundIn', {environmentVariable: 'LAMBDATEST_USERNAME'});
   }
-}
+  return t('yourUsername');
+};
+
+const lambdatestAccessKeyPlaceholder = (t) => {
+  if (process.env.LAMBDATEST_ACCESS_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'LAMBDATEST_ACCESS_KEY'});
+  }
+  return t('yourAccessKey');
+};
+
+const ServerTabLambdatest = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='lambdatestUsername' placeholder={lambdatestUsernamePlaceholder(t)} addonBefore={t('LambdaTest Username')} value={server.lambdatest.username}
+            onChange={(e) => setServerParam('username', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='lambdatestPassword' type={INPUT.PASSWORD} placeholder={lambdatestAccessKeyPlaceholder(t)} addonBefore={t('LambdaTest Access Key')}
+            value={server.lambdatest.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabLambdatest;

--- a/app/renderer/components/Session/ServerTabPcloudy.js
+++ b/app/renderer/components/Session/ServerTabPcloudy.js
@@ -1,40 +1,35 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input } from 'antd';
 import SessionStyles from './Session.css';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
+const pcloudyUsernamePlaceholder = 'username@pcloudy.com';
+const pcloudyHostPlaceholder = 'cloud.pcloudy.com';
+const pcloudyAccessKeyExample = 'kjdgtdwn65fdasd78uy6y';
 
-export default class ServerTabPcloudy extends Component {
+const ServerTabPcloudy = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={8}>
+        <Form.Item>
+          <Input className={SessionStyles.customServerInputLeft} id='PcloudyServerHost' placeholder={pcloudyHostPlaceholder} addonBefore={t('Pcloudy Host')}
+            value={server.pcloudy.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={8}>
+        <Form.Item>
+          <Input id='username' type={INPUT.TEXT} placeholder={pcloudyUsernamePlaceholder} addonBefore={t('Pcloudy User Name')}
+            value={server.pcloudy.username} onChange={(e) => setServerParam('username', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={8}>
+        <Form.Item>
+          <Input id='accessKey' type={INPUT.PASSWORD} placeholder={pcloudyAccessKeyExample} addonBefore={t('Pcloudy API Key')}
+            value={server.pcloudy.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
 
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const pcloudyUsernamePlaceholder = 'username@pcloudy.com';
-    const pcloudyHostPlaceholder = 'cloud.pcloudy.com';
-    const pcloudyAccessKeyExample = 'kjdgtdwn65fdasd78uy6y';
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={8}>
-          <FormItem>
-            <Input className={SessionStyles.customServerInputLeft} id='PcloudyServerHost' placeholder={pcloudyHostPlaceholder} addonBefore={t('Pcloudy Host')}
-              value={server.pcloudy.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={8}>
-          <FormItem>
-            <Input id='username' type={INPUT.TEXT} placeholder={pcloudyUsernamePlaceholder} addonBefore={t('Pcloudy User Name')} value={server.pcloudy.username} onChange={(e) => setServerParam('username', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={8}>
-          <FormItem>
-            <Input id='accessKey' type={INPUT.PASSWORD} placeholder={pcloudyAccessKeyExample} addonBefore={t('Pcloudy API Key')}
-              value={server.pcloudy.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
-  }
-}
+export default ServerTabPcloudy;

--- a/app/renderer/components/Session/ServerTabPerfecto.js
+++ b/app/renderer/components/Session/ServerTabPerfecto.js
@@ -1,47 +1,46 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input, Checkbox } from 'antd';
 import SessionStyles from './Session.css';
 
-const FormItem = Form.Item;
+const cloudPerfectoUrl = 'cloud.Perfectomobile.com';
 
-export default class ServerTabPerfecto extends Component {
+const portPlaceholder = (server) => server.perfecto.ssl ? '443' : '80';
 
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const cloudPerfectoUrl = 'cloud.Perfectomobile.com';
-
-    const perfectoTokenPlaceholder = process.env.PERFECTO_TOKEN ?
-      t('usingDataFoundIn', {environmentVariable: 'PERFECTO_TOKEN'}) : t('Add your token');
-
-    const portPlaceholder = server.perfecto.ssl ? '443' : '80';
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={9}>
-          <FormItem>
-            <Input className={SessionStyles.customServerInputLeft} id='PerfectoServerHost' placeholder={cloudPerfectoUrl} addonBefore={t('Perfecto Host')}
-              value={server.perfecto.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={4}>
-          <FormItem>
-            <Input id='PerfectoPort' placeholder={portPlaceholder} addonBefore={t('Perfecto Port')} value={server.perfecto.port}
-              onChange={(e) => setServerParam('port', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={9}>
-          <FormItem>
-            <Input id='token' placeholder={perfectoTokenPlaceholder} addonBefore={t('Perfecto Token')} value={server.perfecto.token} onChange={(e) => setServerParam('token', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={2}>
-          <FormItem>
-            <Checkbox checked={!!server.perfecto.ssl} onChange={(e) => setServerParam('ssl', e.target.checked)}> {'SSL'}</Checkbox>
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const perfectoTokenPlaceholder = (t) => {
+  if (process.env.PERFECTO_TOKEN) {
+    return t('usingDataFoundIn', {environmentVariable: 'PERFECTO_TOKEN'});
   }
-}
+  return t('Add your token');
+};
+
+const ServerTabPerfecto = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={9}>
+        <Form.Item>
+          <Input className={SessionStyles.customServerInputLeft} id='PerfectoServerHost' placeholder={cloudPerfectoUrl} addonBefore={t('Perfecto Host')}
+            value={server.perfecto.hostname} onChange={(e) => setServerParam('hostname', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={4}>
+        <Form.Item>
+          <Input id='PerfectoPort' placeholder={portPlaceholder(server)} addonBefore={t('Perfecto Port')} value={server.perfecto.port}
+            onChange={(e) => setServerParam('port', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={9}>
+        <Form.Item>
+          <Input id='token' placeholder={perfectoTokenPlaceholder(t)} addonBefore={t('Perfecto Token')} value={server.perfecto.token}
+            onChange={(e) => setServerParam('token', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={2}>
+        <Form.Item>
+          <Checkbox checked={!!server.perfecto.ssl} onChange={(e) => setServerParam('ssl', e.target.checked)}> {'SSL'}</Checkbox>
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabPerfecto;

--- a/app/renderer/components/Session/ServerTabRemoteTestKit.js
+++ b/app/renderer/components/Session/ServerTabRemoteTestKit.js
@@ -1,24 +1,18 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
+const ServerTabRemoteTestkit = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={24}>
+        <Form.Item>
+          <Input id='remoteTestKitAccessToken' type={INPUT.PASSWORD} addonBefore={t('RemoteTestKit AccessToken')} value={server.remotetestkit.token}
+            onChange={(e) => setServerParam('token', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
 
-export default class ServerTabRemoteTestkit extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={24}>
-          <FormItem>
-            <Input id='remoteTestKitAccessToken' type={INPUT.PASSWORD} addonBefore={t('RemoteTestKit AccessToken')} value={server.remotetestkit.token}
-              onChange={(e) => setServerParam('token', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
-  }
-}
+export default ServerTabRemoteTestkit;

--- a/app/renderer/components/Session/ServerTabRobotQA.js
+++ b/app/renderer/components/Session/ServerTabRobotQA.js
@@ -1,23 +1,24 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 
-const FormItem = Form.Item;
-export default class ServerTabRobotQA extends Component {
-  render () {
-
-    const { server, setServerParam, t } = this.props;
-
-    const placeholder = process.env.ROBOTQA_TOKEN ?
-      t('usingDataFoundIn', { environmentVariable: 'ROBOTQA_TOKEN' }) : t('Add your token');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={24}>
-          <FormItem>
-            <Input id='robotQAToken' placeholder={placeholder} addonBefore={t('RobotQA Token')} value={server.roboticmobi.token} onChange={(e) => setServerParam('token', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const robotQATokenPlaceholder = (t) => {
+  if (process.env.ROBOTQA_TOKEN) {
+    return t('usingDataFoundIn', {environmentVariable: 'ROBOTQA_TOKEN'});
   }
-}
+  return t('Add your token');
+};
+
+const ServerTabRobotQA = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={24}>
+        <Form.Item>
+          <Input id='robotQAToken' placeholder={robotQATokenPlaceholder(t)} addonBefore={t('RobotQA Token')}
+            value={server.roboticmobi.token} onChange={(e) => setServerParam('token', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabRobotQA;

--- a/app/renderer/components/Session/ServerTabSauce.js
+++ b/app/renderer/components/Session/ServerTabSauce.js
@@ -1,63 +1,70 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Row, Col, Input, Checkbox, Radio, Tooltip } from 'antd';
 import SessionStyles from './Session.css';
 import { INPUT } from '../AntdTypes';
-const FormItem = Form.Item;
 
-export default class ServerTabSauce extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const sauceUsernamePlaceholder = process.env.SAUCE_USERNAME ?
-      t('usingDataFoundIn', {environmentVariable: 'SAUCE_USERNAME'}) : t('yourUsername');
-
-    const sauceAccessKeyPlaceholder = process.env.SAUCE_ACCESS_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'SAUCE_ACCESS_KEY'}) : t('yourAccessKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input id='sauceUsername' placeholder={sauceUsernamePlaceholder} addonBefore={t('Sauce Username')} value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input id='saucePassword' type={INPUT.PASSWORD} placeholder={sauceAccessKeyPlaceholder}
-              addonBefore={t('Sauce Access Key')} value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-      <Row gutter={8}>
-        <Col span={8}>
-          <FormItem>
-            <div className={['ant-input-group-addon', SessionStyles.addonDataCenter].join(' ') }>{t('SauceLabs Data Center')}</div>
-            <Radio.Group className={[SessionStyles.inputDataCenter, SessionStyles.addonDataCenterRadioContainer].join(' ')} buttonStyle="solid" defaultValue='us-west-1' id='sauceObjectDataCenter' value={server.sauce.dataCenter} onChange={(e) => setServerParam('dataCenter', e.target.value)}>
-              <Tooltip placement="top" title={t('UP')}>
-                <Radio value='us-west-1'>{t('US')}</Radio>
-              </Tooltip>
-              <Radio value='eu-central-1'>{t('EU')}</Radio>
-            </Radio.Group>
-          </FormItem>
-        </Col>
-        <Col span={8} align="right">
-          <FormItem>
-            <Checkbox checked={!!server.sauce.useSCProxy} onChange={(e) => setServerParam('useSCProxy', e.target.checked)}> {t('proxyThroughSC')}</Checkbox>
-          </FormItem>
-        </Col>
-        <Col span={5}>
-          <FormItem>
-            <Input addonBefore={t('Host')} placeholder={t('localhost')} disabled={!server.sauce.useSCProxy} value={server.sauce.scHost} onChange={(e) => setServerParam('scHost', e.target.value)}/>
-          </FormItem>
-        </Col>
-        <Col span={3}>
-          <FormItem>
-            <Input addonBefore={t('Port')} placeholder={4445} disabled={!server.sauce.useSCProxy} value={server.sauce.scPort} onChange={(e) => setServerParam('scPort', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const sauceUsernamePlaceholder = (t) => {
+  if (process.env.SAUCE_USERNAME) {
+    return t('usingDataFoundIn', {environmentVariable: 'SAUCE_USERNAME'});
   }
-}
+  return t('yourUsername');
+};
+
+const sauceAccessKeyPlaceholder = (t) => {
+  if (process.env.SAUCE_ACCESS_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'SAUCE_ACCESS_KEY'});
+  }
+  return t('yourAccessKey');
+};
+
+const ServerTabSauce = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='sauceUsername' placeholder={sauceUsernamePlaceholder(t)} addonBefore={t('Sauce Username')}
+            value={server.sauce.username} onChange={(e) => setServerParam('username', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='saucePassword' type={INPUT.PASSWORD} placeholder={sauceAccessKeyPlaceholder(t)} addonBefore={t('Sauce Access Key')}
+            value={server.sauce.accessKey} onChange={(e) => setServerParam('accessKey', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+    <Row gutter={8}>
+      <Col span={8}>
+        <Form.Item>
+          <div className={['ant-input-group-addon', SessionStyles.addonDataCenter].join(' ') }>{t('SauceLabs Data Center')}</div>
+          <Radio.Group className={[SessionStyles.inputDataCenter, SessionStyles.addonDataCenterRadioContainer].join(' ')}
+            buttonStyle="solid" defaultValue='us-west-1' id='sauceObjectDataCenter' value={server.sauce.dataCenter} onChange={(e) => setServerParam('dataCenter', e.target.value)}>
+            <Tooltip placement="top" title={t('UP')}>
+              <Radio value='us-west-1'>{t('US')}</Radio>
+            </Tooltip>
+            <Radio value='eu-central-1'>{t('EU')}</Radio>
+          </Radio.Group>
+        </Form.Item>
+      </Col>
+      <Col span={8} align="right">
+        <Form.Item>
+          <Checkbox checked={!!server.sauce.useSCProxy} onChange={(e) => setServerParam('useSCProxy', e.target.checked)}> {t('proxyThroughSC')}</Checkbox>
+        </Form.Item>
+      </Col>
+      <Col span={5}>
+        <Form.Item>
+          <Input addonBefore={t('Host')} placeholder={t('localhost')} disabled={!server.sauce.useSCProxy}
+            value={server.sauce.scHost} onChange={(e) => setServerParam('scHost', e.target.value)}/>
+        </Form.Item>
+      </Col>
+      <Col span={3}>
+        <Form.Item>
+          <Input addonBefore={t('Port')} placeholder={4445} disabled={!server.sauce.useSCProxy}
+            value={server.sauce.scPort} onChange={(e) => setServerParam('scPort', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabSauce;

--- a/app/renderer/components/Session/ServerTabTestingbot.js
+++ b/app/renderer/components/Session/ServerTabTestingbot.js
@@ -1,34 +1,38 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Form, Input, Row, Col } from 'antd';
 import { INPUT } from '../AntdTypes';
 
-const FormItem = Form.Item;
-
-export default class ServerTabTestingbot extends Component {
-
-  render () {
-
-    const {server, setServerParam, t} = this.props;
-
-    const testingbotKeyPlaceholder = process.env.TB_KEY ?
-      t('usingDataFoundIn', {environmentVariable: 'TB_KEY'}) : t('yourUsername');
-
-    const testingbotSecretPlaceholder = process.env.TB_SECRET ?
-      t('usingDataFoundIn', {environmentVariable: 'TB_SECRET'}) : t('yourAccessKey');
-
-    return <Form>
-      <Row gutter={8}>
-        <Col span={12}>
-          <FormItem>
-            <Input id='testingbotKey' placeholder={testingbotKeyPlaceholder} addonBefore={t('TestingBot Key')} value={server.testingbot.key} onChange={(e) => setServerParam('key', e.target.value)} />
-          </FormItem>
-        </Col>
-        <Col span={12}>
-          <FormItem>
-            <Input id='testingbotSecret' type={INPUT.PASSWORD} placeholder={testingbotSecretPlaceholder} addonBefore={t('TestingBot Secret')} value={server.testingbot.secret} onChange={(e) => setServerParam('secret', e.target.value)} />
-          </FormItem>
-        </Col>
-      </Row>
-    </Form>;
+const testingbotKeyPlaceholder = (t) => {
+  if (process.env.TB_KEY) {
+    return t('usingDataFoundIn', {environmentVariable: 'TB_KEY'});
   }
-}
+  return t('yourUsername');
+};
+
+const testingbotSecretPlaceholder = (t) => {
+  if (process.env.TB_SECRET) {
+    return t('usingDataFoundIn', {environmentVariable: 'TB_SECRET'});
+  }
+  return t('yourAccessKey');
+};
+
+const ServerTabTestingbot = ({ server, setServerParam, t }) => (
+  <Form>
+    <Row gutter={8}>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='testingbotKey' placeholder={testingbotKeyPlaceholder(t)} addonBefore={t('TestingBot Key')}
+            value={server.testingbot.key} onChange={(e) => setServerParam('key', e.target.value)} />
+        </Form.Item>
+      </Col>
+      <Col span={12}>
+        <Form.Item>
+          <Input id='testingbotSecret' type={INPUT.PASSWORD} placeholder={testingbotSecretPlaceholder(t)} addonBefore={t('TestingBot Secret')}
+            value={server.testingbot.secret} onChange={(e) => setServerParam('secret', e.target.value)} />
+        </Form.Item>
+      </Col>
+    </Row>
+  </Form>
+);
+
+export default ServerTabTestingbot;

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -52,11 +52,6 @@ export default class Session extends Component {
     await changeServerType(tab);
   }
 
-  removeCloudProvider (providerName) {
-    const {removeVisibleProvider} = this.props;
-    removeVisibleProvider(providerName);
-  }
-
   render () {
     const {savedSessions, tabKey, switchTabs,
            serverType, server,

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -1,5 +1,5 @@
 import { shell, ipcRenderer } from '../../polyfills';
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import _ from 'lodash';
 import CapabilityEditor from './CapabilityEditor';
 import SavedSessions from './SavedSessions';
@@ -14,12 +14,27 @@ import { LinkOutlined } from '@ant-design/icons';
 import { BUTTON } from '../AntdTypes';
 
 const ADD_CLOUD_PROVIDER = 'addCloudProvider';
+const CAPS_DOCS_LINK = 'https://appium.io/docs/en/latest/guides/caps/';
 
-export default class Session extends Component {
+const Session = (props) => {
+  const { tabKey, switchTabs, serverType, server, visibleProviders = [],
+          caps, capsUUID, capsName, isCapsDirty, isEditingDesiredCaps, requestSaveAsModal,
+          saveSession, newSession, savedSessions, newSessionLoading, attachSessId, t } = props;
 
-  componentDidMount () {
-    const {setLocalServerParams, getSavedSessions, setSavedServerParams, setStateFromAppiumFile,
-           setVisibleProviders, getRunningSessions, bindWindowClose, initFromQueryString, saveFile, switchTabs} = this.props;
+  const isAttaching = tabKey === 'attach';
+
+  const handleSelectServerTab = async (tab) => {
+    const { changeServerType, addCloudProvider } = props;
+    if (tab === ADD_CLOUD_PROVIDER) {
+      addCloudProvider();
+      return;
+    }
+    await changeServerType(tab);
+  };
+
+  useEffect(() => {
+    const { setLocalServerParams, getSavedSessions, setSavedServerParams, setStateFromAppiumFile,
+            setVisibleProviders, getRunningSessions, bindWindowClose, initFromQueryString, saveFile } = props;
     (async () => {
       try {
         bindWindowClose();
@@ -31,94 +46,67 @@ export default class Session extends Component {
         getRunningSessions();
         await initFromQueryString();
         await setStateFromAppiumFile();
-        ipcRenderer.on('open-file', (evt, filePath) => {
-          setStateFromAppiumFile(filePath);
-        });
-        ipcRenderer.on('save-file', (evt, filePath) => {
-          saveFile(filePath);
-        });
+        ipcRenderer.on('open-file', (_, filePath) => setStateFromAppiumFile(filePath));
+        ipcRenderer.on('save-file', (_, filePath) => saveFile(filePath));
       } catch (e) {
         console.error(e); // eslint-disable-line no-console
       }
     })();
-  }
+  }, []);
 
-  async handleSelectServerTab (tab) {
-    const {changeServerType, addCloudProvider} = this.props;
-    if (tab === ADD_CLOUD_PROVIDER) {
-      addCloudProvider();
-      return;
-    }
-    await changeServerType(tab);
-  }
-
-  render () {
-    const {savedSessions, tabKey, switchTabs,
-           serverType, server,
-           requestSaveAsModal, newSession, caps, capsUUID, capsName, saveSession,
-           visibleProviders = [],
-           isCapsDirty, isEditingDesiredCaps, newSessionLoading, attachSessId, t} = this.props;
-
-    const isAttaching = tabKey === 'attach';
-
-    return [
-      <Spin spinning={!!newSessionLoading} key="main">
-        <div className={SessionStyles.sessionContainer}>
-          <div id='serverTypeTabs' className={SessionStyles.serverTab}>
-            <Tabs activeKey={serverType} onChange={(tab) => this.handleSelectServerTab(tab)} className={SessionStyles.serverTabs} items={[{
-              label: t('Appium Server'), key: 'remote', children:
-                <ServerTabCustom {...this.props} />
-            },
+  return [
+    <Spin spinning={!!newSessionLoading} key="main">
+      <div className={SessionStyles.sessionContainer}>
+        <div id='serverTypeTabs' className={SessionStyles.serverTab}>
+          <Tabs activeKey={serverType} onChange={(tab) => handleSelectServerTab(tab)} className={SessionStyles.serverTabs} items={[
+            {label: t('Appium Server'), key: 'remote', children: <ServerTabCustom {...props} />},
             ..._(visibleProviders).map((providerName) => {
               const provider = CloudProviders[providerName];
               if (!provider) {
                 return true;
               }
-
-              return {label: <div>{provider.tabhead()}</div>, key: providerName, children: provider.tab(this.props)};
+              return {label: <div>{provider.tabhead()}</div>, key: providerName, children: provider.tab(props)};
             }),
             {label: <span className='addCloudProviderTab'>{ t('Select Cloud Providers') }</span>, key: ADD_CLOUD_PROVIDER}
-            ]}/>
-            <AdvancedServerParams {...this.props} />
-          </div>
-
-          <Tabs activeKey={tabKey} onChange={switchTabs} className={SessionStyles.scrollingTabCont} items={[{
-            label: t('Desired Capabilities'), key: 'new', className: SessionStyles.scrollingTab, children:
-              <CapabilityEditor {...this.props} />
-          }, {
-            label: (<span>{t('Saved Capability Sets')} <Badge count={savedSessions.length} offset={[0, -3]}/></span>),
-            key: 'saved', className: SessionStyles.scrollingTab, disabled: savedSessions.length === 0, children:
-              <SavedSessions {...this.props} />
-          }, {
-            label: t('Attach to Session'), key: 'attach', className: SessionStyles.scrollingTab, children:
-              <AttachToSession {...this.props} />
-          }]}/>
-
-          <div className={SessionStyles.sessionFooter}>
-            <div className={SessionStyles.desiredCapsLink}>
-              <a href="#" onClick={(e) => e.preventDefault() || shell.openExternal('https://appium.io/docs/en/latest/guides/caps/')}>
-                <LinkOutlined />&nbsp;
-                {t('desiredCapabilitiesDocumentation')}
-              </a>
-            </div>
-            { (!isAttaching && capsUUID) && <Button
-              onClick={() => saveSession(server, serverType, caps, {name: capsName, uuid: capsUUID})}
-              disabled={!isCapsDirty || isEditingDesiredCaps}>{t('Save')}</Button> }
-            {!isAttaching && <Button
-              onClick={requestSaveAsModal} disabled={isEditingDesiredCaps}>{t('saveAs')}</Button>}
-            {!isAttaching && <Button type={BUTTON.PRIMARY} id='btnStartSession'
-              onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>{t('startSession')}</Button>
-            }
-            {isAttaching &&
-              <Button type={BUTTON.PRIMARY} disabled={!attachSessId} onClick={() => newSession(null, attachSessId)}>
-                {t('attachToSession')}
-              </Button>
-            }
-          </div>
-
+          ]}/>
+          <AdvancedServerParams {...props} />
         </div>
-      </Spin>,
-      <CloudProviderSelector {...this.props} key='CloudProviderSelector' />
-    ];
-  }
-}
+
+        <Tabs activeKey={tabKey} onChange={switchTabs} className={SessionStyles.scrollingTabCont} items={[
+          {label: t('Desired Capabilities'),
+           key: 'new', className: SessionStyles.scrollingTab, children: <CapabilityEditor {...props} />},
+          {label: (<span>{t('Saved Capability Sets')} <Badge count={savedSessions.length} offset={[0, -3]}/></span>),
+           key: 'saved', className: SessionStyles.scrollingTab, disabled: savedSessions.length === 0, children: <SavedSessions {...props} />},
+          {label: t('Attach to Session'),
+           key: 'attach', className: SessionStyles.scrollingTab, children: <AttachToSession {...props} />}
+        ]}/>
+
+        <div className={SessionStyles.sessionFooter}>
+          <div className={SessionStyles.desiredCapsLink}>
+            <a href="#" onClick={(e) => e.preventDefault() || shell.openExternal(CAPS_DOCS_LINK)}>
+              <LinkOutlined />&nbsp;
+              {t('desiredCapabilitiesDocumentation')}
+            </a>
+          </div>
+          {(!isAttaching && capsUUID) && <Button
+            onClick={() => saveSession(server, serverType, caps, {name: capsName, uuid: capsUUID})}
+            disabled={!isCapsDirty || isEditingDesiredCaps}>{t('Save')}
+          </Button>}
+          {!isAttaching && <Button
+            onClick={requestSaveAsModal} disabled={isEditingDesiredCaps}>{t('saveAs')}
+          </Button>}
+          {!isAttaching && <Button type={BUTTON.PRIMARY} id='btnStartSession'
+            onClick={() => newSession(caps)} className={SessionStyles['start-session-button']}>{t('startSession')}
+          </Button>}
+          {isAttaching && <Button type={BUTTON.PRIMARY} disabled={!attachSessId}
+            onClick={() => newSession(null, attachSessId)}>{t('attachToSession')}
+          </Button>}
+        </div>
+
+      </div>
+    </Spin>,
+    <CloudProviderSelector {...props} key='CloudProviderSelector' />
+  ];
+};
+
+export default Session;


### PR DESCRIPTION
This PR is a partial implementation of #879, covering all the components in the Session route.
Most of the components were relatively straightforward to migrate: only 2 needed lifecycle methods, and only 1 needed an instance variable. Though I have a hunch that the Inspector route will be more complicated...

I've also removed a few unnecessary/unused methods:
* `componentDidMount` in `CloudProviderSelector` - needlessly duplicates some calls in the equivalent `Session` method
* `handleCloseModal` in `CloudProviderSelector` - `<Modal onCancel=` already handles this case
* `removeCloudProvider` in `Session` - unused and already handled in `CloudProviderSelector`