### PR TITLE
fix: open errormessage link in browser + move copy button to left side

### DIFF
--- a/app/renderer/components/ErrorBoundary/ErrorMessage.css
+++ b/app/renderer/components/ErrorBoundary/ErrorMessage.css
@@ -4,6 +4,5 @@
 
 .copyTraceBtn {
   position: absolute;
-  top: 15px;
-  right: 15px;
+  left: 24px;
 }

--- a/app/renderer/components/ErrorBoundary/ErrorMessage.js
+++ b/app/renderer/components/ErrorBoundary/ErrorMessage.js
@@ -21,7 +21,7 @@ const ErrorMessage = ({ error, copyTrace, t }) => (
           <br />
           {t('Full error trace:')}
           <Tooltip title={t('Copy Error Trace')}>
-            <Button
+            <Button size='small'
               className={styles.copyTraceBtn}
               onClick={copyTrace(error.stack)}
               icon={<CopyOutlined/>} />

--- a/app/renderer/components/ErrorBoundary/ErrorMessage.js
+++ b/app/renderer/components/ErrorBoundary/ErrorMessage.js
@@ -4,6 +4,7 @@ import { CopyOutlined } from '@ant-design/icons';
 import styles from './ErrorMessage.css';
 import { ALERT } from '../AntdTypes';
 import { withTranslation } from '../../util';
+import { shell } from '../../polyfills';
 
 const CREATE_ISSUE_URL = 'https://github.com/appium/appium-inspector/issues/new/choose';
 
@@ -15,7 +16,8 @@ const ErrorMessage = ({ error, copyTrace, t }) => (
       showIcon
       description={
         <>
-          {t('Please report this issue at:')} <a href={CREATE_ISSUE_URL} children={CREATE_ISSUE_URL} />
+          {t('Please report this issue at:')}&nbsp;
+          <a onClick={(e) => e.preventDefault() || shell.openExternal(CREATE_ISSUE_URL)} children={CREATE_ISSUE_URL} />
           <br />
           {t('Full error trace:')}
           <Tooltip title={t('Copy Error Trace')}>


### PR DESCRIPTION
Two small fixes for the refreshed error message:
1) The GitHub link, when clicked in the desktop app, would open in the app itself. All other links open in a new browser tab, so this one was also adjusted accordingly.
2) The copy trace button may overlap the error title, if it is too long. To avoid this, it has been moved to the left side, below the error icon, and vertically closer to the trace text.