### PR TITLE
fix: enable manual text input for filepath capability + remove filtering by extension

### DIFF
--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -5,16 +5,10 @@ import { remote, log } from '../../polyfills';
 import { FileOutlined } from '@ant-design/icons';
 import { INPUT } from '../AntdTypes';
 import _ from 'lodash';
-import { APPIUM_SESSION_EXTENSION } from '../../../main/helpers';
 
 const getLocalFilePath = async () => {
   try {
-    const {canceled, filePaths} = await remote.dialog.showOpenDialog({
-      properties: ['openFile'],
-      filters: [
-        {name: 'Appium Session Files', extensions: [APPIUM_SESSION_EXTENSION]}
-      ]
-    });
+    const {canceled, filePaths} = await remote.dialog.showOpenDialog({properties: ['openFile']});
     if (!canceled && !_.isEmpty(filePaths)) {
       return filePaths[0];
     }

--- a/app/renderer/components/Session/CapabilityControl.js
+++ b/app/renderer/components/Session/CapabilityControl.js
@@ -42,7 +42,7 @@ const CapabilityControl = ({ cap, onSetCapabilityParam, onPressEnter, isEditingD
     case 'file':
       return <div className={SessionStyles.fileControlWrapper}>
         <Input disabled={isEditingDesiredCaps} id={id} placeholder={t('Value')} value={cap.value}
-          onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont}
+          onChange={(e) => onSetCapabilityParam(e.target.value)} onPressEnter={onPressEnter} className={SessionStyles.capsBoxFont}
           addonAfter={
             <FileOutlined className={SessionStyles['filepath-button']}
               onClick={async () => onSetCapabilityParam(await getLocalFilePath() || cap.value)} />


### PR DESCRIPTION
This fixes 2 things for the filepath capability in the capability editor:
1) It is now possible to manually type a string in the value field. Until now, it was only possible to use the open file button.
2) The extension filter for `.appiumsession` files has been removed. There are many reasons to use other extensions here, such as for the `appium:app` capability.