### PR TITLE
fix: resolve issue with saving gestures

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -850,8 +850,8 @@ export function setAwaitingMjpegStream (isAwaiting) {
 }
 
 export function saveGesture (params) {
-  return async (dispatch, getState) => {
-    const savedGestures = getState().inspector.savedGestures;
+  return async (dispatch) => {
+    let savedGestures = await getSetting(SET_SAVED_GESTURES) || [];
     if (!params.id) {
       params.id = UUID();
       params.date = Date.now();


### PR DESCRIPTION
This fixes a problem where it was not possible to save new gestures. The fix implementation is taken from the code for saving new sessions.
Not actually sure when this issue was introduced, since I already had several saved gestures from an older version.