### PR TITLE
fix: resolve issue where source loading/error text was not shown

### DIFF
--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -96,13 +96,9 @@ class Source extends Component {
           <Tree
             treeData={[]} />
         }
+        {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
+        {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
       </Spin>
-      {!source && !sourceError &&
-        <i>{t('Gathering initial app source…')}</i>
-      }
-      {
-        sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})
-      }
       <LocatorTestModal {...this.props} />
       <SiriCommandModal {...this.props} />
     </div>;

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -81,6 +81,8 @@ class Source extends Component {
     const treeData = source && recursive(source);
 
     return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
+      {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
+      {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
       {/* Show loading indicator in MJPEG mode if a method call is in progress and source refresh is on */}
       <Spin size='large' spinning={!!methodCallInProgress && mjpegScreenshotUrl && isSourceRefreshOn}>
         {/* Must switch to a new antd Tree component when there's changes to treeData  */}
@@ -96,8 +98,6 @@ class Source extends Component {
           <Tree
             treeData={[]} />
         }
-        {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
-        {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
       </Spin>
       <LocatorTestModal {...this.props} />
       <SiriCommandModal {...this.props} />


### PR DESCRIPTION
This fixes an issue where the placeholder text for loading source ("Gathering initial app source...") was not shown. It was therefore likely to affect the source error text too.
It seems this is caused by some interaction with the antd Spin component, where text after it is not shown. Moving text before the Spin makes it show up as expected.