### PR TITLE
fix: resolve issue with loading selected element

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -140,12 +140,12 @@ export function selectElement (path) {
     const { selectedElement, sourceXML, expandedPaths } = getState().inspector;
 
     // Expand all of this element's ancestors so that it's visible in the source tree
-    const copiedExpandedPaths = expandedPaths.slice();
+    const copiedExpandedPaths = [...expandedPaths];
     let pathArr = path.split('.').slice(0, path.length - 1);
     while (pathArr.length > 1) {
       pathArr.splice(pathArr.length - 1);
       let path = pathArr.join('.');
-      if (copiedExpandedPaths.indexOf(path) < 0) {
+      if (!copiedExpandedPaths.includes(path)) {
         copiedExpandedPaths.push(path);
       }
     }

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -137,26 +137,24 @@ export function selectElement (path) {
   return async (dispatch, getState) => {
     // Set the selected element in the source tree
     dispatch({type: SELECT_ELEMENT, path});
-    const state = getState().inspector;
-    const {attributes: selectedElementAttributes, xpath: selectedElementXPath} = state.selectedElement;
-    const {sourceXML} = state;
+    const { selectedElement, sourceXML, expandedPaths } = getState().inspector;
 
     // Expand all of this element's ancestors so that it's visible in the source tree
-    let {expandedPaths} = getState().inspector;
+    const copiedExpandedPaths = expandedPaths.slice();
     let pathArr = path.split('.').slice(0, path.length - 1);
     while (pathArr.length > 1) {
       pathArr.splice(pathArr.length - 1);
       let path = pathArr.join('.');
-      if (expandedPaths.indexOf(path) < 0) {
-        expandedPaths.push(path);
+      if (copiedExpandedPaths.indexOf(path) < 0) {
+        copiedExpandedPaths.push(path);
       }
     }
-    dispatch({type: SET_EXPANDED_PATHS, paths: expandedPaths});
+    dispatch({type: SET_EXPANDED_PATHS, paths: copiedExpandedPaths});
 
 
     // Find the optimal selection strategy. If none found, fall back to XPath.
-    const strategyMap = _.toPairs(getLocators(selectedElementAttributes, sourceXML));
-    strategyMap.push(['xpath', selectedElementXPath]);
+    const strategyMap = _.toPairs(getLocators(selectedElement.attributes, sourceXML));
+    strategyMap.push(['xpath', selectedElement.xpath]);
 
     // Debounce find element so that if another element is selected shortly after, cancel the previous search
     await findElement(strategyMap, dispatch, getState, path);

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -140,6 +140,7 @@ export function selectElement (path) {
     const { selectedElement, sourceXML, expandedPaths } = getState().inspector;
 
     // Expand all of this element's ancestors so that it's visible in the source tree
+    // Make a copy of the array to avoid state mutation
     const copiedExpandedPaths = [...expandedPaths];
     let pathArr = path.split('.').slice(0, path.length - 1);
     while (pathArr.length > 1) {


### PR DESCRIPTION
When selecting an element via the highlighted rectangle overlaid over the screenshot, oftentimes there may be an issue where the selected element actions load endlessly, meaning, the element search did not finish.
This was caused by a state mutation of the expanded paths array. By copying this array, the issue is resolved.