### PR TITLE
chore: migrate most Inspector items to React function components

### DIFF
--- a/app/renderer/components/Inspector/Commands.js
+++ b/app/renderer/components/Inspector/Commands.js
@@ -1,24 +1,25 @@
-import React, { Component } from 'react';
+import React from 'react';
 import _ from 'lodash';
 import { Row, Col, Button, Select, Modal, Input, Switch, notification, } from 'antd';
 import { COMMAND_DEFINITIONS, COMMAND_ARG_TYPES } from './shared';
 import InspectorStyles from './Inspector.css';
 import { INPUT } from '../AntdTypes';
 
-export default class Commands extends Component {
+const Commands = (props) => {
+  const { selectCommandGroup, selectCommandSubGroup, selectedCommandGroup, selectedCommandSubGroup,
+          pendingCommand, cancelPendingCommand, setCommandArg, applyClientMethod, t } = props;
 
-  startPerformingCommand (commandName, command) {
-    const { startEnteringCommandArgs, applyClientMethod } = this.props;
+  const startPerformingCommand = (commandName, command) => {
+    const { startEnteringCommandArgs } = props;
     if (_.isEmpty(command.args)) {
       applyClientMethod({methodName: command.methodName, args: [], skipRefresh: !command.refresh, ignoreResult: false});
     } else {
       startEnteringCommandArgs(commandName, command);
     }
-  }
+  };
 
-  executeCommand () {
-    const { pendingCommand, cancelPendingCommand, applyClientMethod, t } = this.props;
-    let {args, command} = pendingCommand;
+  const executeCommand = () => {
+    let { args, command } = pendingCommand;
 
     // Special case for 'rotateDevice'
     if (command.methodName === 'rotateDevice') {
@@ -60,58 +61,55 @@ export default class Commands extends Component {
 
     applyClientMethod({methodName: command.methodName, args, skipRefresh: !command.refresh, ignoreResult: false});
     cancelPendingCommand();
-  }
+  };
 
-  render () {
-    const {
-      t, selectCommandGroup, selectCommandSubGroup, selectedCommandGroup, selectedCommandSubGroup, pendingCommand,
-      cancelPendingCommand, setCommandArg } = this.props;
-    return <div className={InspectorStyles['commands-container']}>
-      <Row gutter={16} className={InspectorStyles['arg-row']}>
-        <Col span={24}>
-          <Select onChange={(commandGroupName) => selectCommandGroup(commandGroupName)} placeholder={t('Select Command Group')}>
-            { _.keys(COMMAND_DEFINITIONS).map((commandGroup) => <Select.Option key={commandGroup}>{t(commandGroup)}</Select.Option>) }
-          </Select>
-        </Col>
-      </Row>
-      {selectedCommandGroup && <Row>
-        <Col span={24}>
-          <Select onChange={(commandGroupName) => selectCommandSubGroup(commandGroupName)} placeholder={t('Select Sub Group')}>
-            { _.keys(COMMAND_DEFINITIONS[selectedCommandGroup]).map((commandGroup) => <Select.Option key={commandGroup}>{t(commandGroup)}</Select.Option>) }
-          </Select>
-        </Col>
-      </Row>}
-      <Row>
-        {selectedCommandSubGroup && _.toPairs(COMMAND_DEFINITIONS[selectedCommandGroup][selectedCommandSubGroup]).map(([commandName, command], index) => <Col key={index} span={8}>
-          <div className={InspectorStyles['btn-container']}>
-            <Button onClick={() => this.startPerformingCommand(commandName, command)}>{t(commandName)}</Button>
-          </div>
-        </Col>)}
-      </Row>
-      {!!pendingCommand && <Modal
-        title={t(pendingCommand.commandName)}
-        okText={t('Execute Command')}
-        cancelText={t('Cancel')}
-        open={!!pendingCommand}
-        onOk={() => this.executeCommand()}
-        onCancel={() => cancelPendingCommand()}>
-        {
-          !_.isEmpty(pendingCommand.command.args) && _.map(pendingCommand.command.args, ([argName, argType], index) => <Row key={index} gutter={16}>
-            <Col span={24} className={InspectorStyles['arg-container']}>
-              {
-                argType === COMMAND_ARG_TYPES.NUMBER && <Input
-                  type={INPUT.NUMBER}
-                  value={pendingCommand.args[index]}
-                  addonBefore={t(argName)}
-                  onChange={(e) => setCommandArg(index, _.toNumber(e.target.value))}
-                />
-              }
-              {argType === COMMAND_ARG_TYPES.BOOLEAN && <div>{t(argName)} <Switch checked={pendingCommand.args[index]} onChange={(v) => setCommandArg(index, v)} /></div>}
-              {argType === COMMAND_ARG_TYPES.STRING && <Input addonBefore={t(argName)} onChange={(e) => setCommandArg(index, e.target.value)}/>}
-            </Col>
-          </Row>)
-        }
-      </Modal>}
-    </div>;
-  }
-}
+  return <div className={InspectorStyles['commands-container']}>
+    <Row gutter={16} className={InspectorStyles['arg-row']}>
+      <Col span={24}>
+        <Select onChange={(commandGroupName) => selectCommandGroup(commandGroupName)} placeholder={t('Select Command Group')}>
+          { _.keys(COMMAND_DEFINITIONS).map((commandGroup) => <Select.Option key={commandGroup}>{t(commandGroup)}</Select.Option>) }
+        </Select>
+      </Col>
+    </Row>
+    {selectedCommandGroup && <Row>
+      <Col span={24}>
+        <Select onChange={(commandGroupName) => selectCommandSubGroup(commandGroupName)} placeholder={t('Select Sub Group')}>
+          { _.keys(COMMAND_DEFINITIONS[selectedCommandGroup]).map((commandGroup) => <Select.Option key={commandGroup}>{t(commandGroup)}</Select.Option>) }
+        </Select>
+      </Col>
+    </Row>}
+    <Row>
+      {selectedCommandSubGroup && _.toPairs(COMMAND_DEFINITIONS[selectedCommandGroup][selectedCommandSubGroup]).map(([commandName, command], index) => <Col key={index} span={8}>
+        <div className={InspectorStyles['btn-container']}>
+          <Button onClick={() => startPerformingCommand(commandName, command)}>{t(commandName)}</Button>
+        </div>
+      </Col>)}
+    </Row>
+    {!!pendingCommand && <Modal
+      title={t(pendingCommand.commandName)}
+      okText={t('Execute Command')}
+      cancelText={t('Cancel')}
+      open={!!pendingCommand}
+      onOk={() => executeCommand()}
+      onCancel={() => cancelPendingCommand()}>
+      {
+        !_.isEmpty(pendingCommand.command.args) && _.map(pendingCommand.command.args, ([argName, argType], index) => <Row key={index} gutter={16}>
+          <Col span={24} className={InspectorStyles['arg-container']}>
+            {
+              argType === COMMAND_ARG_TYPES.NUMBER && <Input
+                type={INPUT.NUMBER}
+                value={pendingCommand.args[index]}
+                addonBefore={t(argName)}
+                onChange={(e) => setCommandArg(index, _.toNumber(e.target.value))}
+              />
+            }
+            {argType === COMMAND_ARG_TYPES.BOOLEAN && <div>{t(argName)} <Switch checked={pendingCommand.args[index]} onChange={(v) => setCommandArg(index, v)} /></div>}
+            {argType === COMMAND_ARG_TYPES.STRING && <Input addonBefore={t(argName)} onChange={(e) => setCommandArg(index, e.target.value)}/>}
+          </Col>
+        </Row>)
+      }
+    </Modal>}
+  </div>;
+};
+
+export default Commands;

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -42,22 +42,6 @@ const showMissingAutomationNameInfo = (driver, t) => {
 
 class ElementLocator extends Component {
 
-  onSubmit () {
-    const {locatedElements, locatorTestStrategy, locatorTestValue, searchForElement, clearSearchResults, hideLocatorTestModal} = this.props;
-    if (locatedElements) {
-      hideLocatorTestModal();
-      clearSearchResults();
-    } else {
-      searchForElement(locatorTestStrategy, locatorTestValue);
-    }
-  }
-
-  onCancel () {
-    const {hideLocatorTestModal, clearSearchResults} = this.props;
-    hideLocatorTestModal();
-    clearSearchResults();
-  }
-
   render () {
     const {
       setLocatorTestValue,

--- a/app/renderer/components/Inspector/ElementLocator.js
+++ b/app/renderer/components/Inspector/ElementLocator.js
@@ -1,8 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Alert, Input, Space, Radio, Row } from 'antd';
 import { ALERT } from '../AntdTypes';
 import InspectorStyles from './Inspector.css';
-import { withTranslation } from '../../util';
 
 const STRAT_ID = ['id', 'Id'];
 const STRAT_XPATH = ['xpath', 'XPath'];
@@ -40,51 +39,40 @@ const showMissingAutomationNameInfo = (driver, t) => {
   }
 };
 
-class ElementLocator extends Component {
+const ElementLocator = (props) => {
+  const { setLocatorTestValue, locatorTestValue, setLocatorTestStrategy, locatorTestStrategy, driver, t } = props;
 
-  render () {
-    const {
-      setLocatorTestValue,
-      locatorTestValue,
-      setLocatorTestStrategy,
-      locatorTestStrategy,
-      driver,
-      t,
-    } = this.props;
+  return (
+    <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+      {t('locatorStrategy')}
+      <Row justify="center">
+        <Radio.Group buttonStyle="solid"
+          onChange={(e) => setLocatorTestStrategy(e.target.value)}
+          defaultValue={locatorTestStrategy}
+        >
+          <Row justify="center">
+            {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
+              <Radio.Button
+                className={InspectorStyles.locatorStrategyBtn}
+                value={strategyValue}
+                key={strategyValue}
+              >
+                {strategyName}
+              </Radio.Button>
+            ))}
+          </Row>
+        </Radio.Group>
+      </Row>
+      {showMissingAutomationNameInfo(driver, t)}
+      {t('selector')}
+      <Input.TextArea
+        className={InspectorStyles.locatorSelectorTextArea}
+        onChange={(e) => setLocatorTestValue(e.target.value)}
+        value={locatorTestValue}
+        allowClear={true}
+        rows={3} />
+    </Space>
+  );
+};
 
-    return <>
-      <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
-        {t('locatorStrategy')}
-        <Row justify="center">
-          <Radio.Group buttonStyle="solid"
-            onChange={(e) => setLocatorTestStrategy(e.target.value)}
-            defaultValue={locatorTestStrategy}
-          >
-            <Row justify="center">
-              {locatorStrategies(driver).map(([strategyValue, strategyName]) => (
-                <Radio.Button
-                  className={InspectorStyles.locatorStrategyBtn}
-                  value={strategyValue}
-                  key={strategyValue}
-                >
-                  {strategyName}
-                </Radio.Button>
-              ))}
-            </Row>
-          </Radio.Group>
-        </Row>
-        {showMissingAutomationNameInfo(driver, t)}
-        {t('selector')}
-        <Input.TextArea
-          className={InspectorStyles.locatorSelectorTextArea}
-          onChange={(e) => setLocatorTestValue(e.target.value)}
-          value={locatorTestValue}
-          allowClear={true}
-          rows={3}
-        />
-      </Space>
-    </>;
-  }
-}
-
-export default withTranslation(ElementLocator);
+export default ElementLocator;

--- a/app/renderer/components/Inspector/HeaderButtons.js
+++ b/app/renderer/components/Inspector/HeaderButtons.js
@@ -1,7 +1,6 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Button, Tooltip, Space } from 'antd';
 import InspectorStyles from './Inspector.css';
-import { withTranslation } from '../../util';
 import { HiOutlineMicrophone, HiOutlineHome } from 'react-icons/hi';
 import { BiSquare, BiCircle } from 'react-icons/bi';
 import { IoChevronBackOutline } from 'react-icons/io5';
@@ -19,94 +18,99 @@ import {
   GlobalOutlined
 } from '@ant-design/icons';
 
-const ButtonGroup = Button.Group;
+const HeaderButtons = (props) => {
+  const { selectAppMode, appMode, mjpegScreenshotUrl, isSourceRefreshOn, toggleRefreshingState,
+          isRecording, startRecording, pauseRecording, showLocatorTestModal, showSiriCommandModal,
+          applyClientMethod, quitSession, driver, t } = props;
 
-class HeaderButtons extends Component {
-
-  render () {
-    const {
-      selectAppMode, appMode, mjpegScreenshotUrl, isSourceRefreshOn, toggleRefreshingState,
-      isRecording, startRecording, pauseRecording, showLocatorTestModal, showSiriCommandModal,
-      applyClientMethod, quitSession, driver, t
-    } = this.props;
-
-    const deviceControls = <ButtonGroup>
-      {driver && driver.client.isIOS && <>
-        <Tooltip title={t('Press Home Button')}>
-          <Button id='btnPressHomeButton' icon={<HiOutlineHome className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'executeScript', args: ['mobile:pressButton', [{name: 'home'}]]})}/>
-        </Tooltip>
-        <Tooltip title={t('Execute Siri Command')}>
-          <Button id='siriCommand' icon={<HiOutlineMicrophone className={InspectorStyles['custom-button-icon']}/>} onClick={showSiriCommandModal} />
-        </Tooltip>
-      </>}
-      {driver && driver.client.isAndroid && <>
-        <Tooltip title={t('Press Back Button')}>
-          <Button id='btnPressHomeButton' icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [4]})}/>
-        </Tooltip>
-        <Tooltip title={t('Press Home Button')}>
-          <Button id='btnPressHomeButton' icon={<BiCircle className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [3]})}/>
-        </Tooltip>
-        <Tooltip title={t('Press App Switch Button')}>
-          <Button id='btnPressHomeButton' icon={<BiSquare className={InspectorStyles['custom-button-icon']}/>} onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [187]})}/>
-        </Tooltip>
-      </>}
-    </ButtonGroup>;
-
-    const appModeControls = <ButtonGroup value={appMode}>
-      <Tooltip title={t('Native App Mode')}>
-        <Button icon={<AppstoreOutlined/>} onClick={() => {selectAppMode(APP_MODE.NATIVE);}}
-          type={appMode === APP_MODE.NATIVE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-        />
+  const deviceControls = <Button.Group>
+    {driver && driver.client.isIOS && <>
+      <Tooltip title={t('Press Home Button')}>
+        <Button id='btnPressHomeButton'
+          icon={<HiOutlineHome className={InspectorStyles['custom-button-icon']}/>}
+          onClick={() =>
+            applyClientMethod({ methodName: 'executeScript', args: ['mobile:pressButton', [{name: 'home'}]]})
+          } />
       </Tooltip>
-      <Tooltip title={t('Web/Hybrid App Mode')}>
-        <Button icon={<GlobalOutlined/>} onClick={() => {selectAppMode(APP_MODE.WEB_HYBRID);}}
-          type={appMode === APP_MODE.WEB_HYBRID ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-        />
+      <Tooltip title={t('Execute Siri Command')}>
+        <Button id='siriCommand'
+          icon={<HiOutlineMicrophone className={InspectorStyles['custom-button-icon']}/>}
+          onClick={showSiriCommandModal} />
       </Tooltip>
-    </ButtonGroup>;
+    </>}
+    {driver && driver.client.isAndroid && <>
+      <Tooltip title={t('Press Back Button')}>
+        <Button id='btnPressHomeButton'
+          icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']}/>}
+          onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [4]})} />
+      </Tooltip>
+      <Tooltip title={t('Press Home Button')}>
+        <Button id='btnPressHomeButton'
+          icon={<BiCircle className={InspectorStyles['custom-button-icon']}/>}
+          onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [3]})} />
+      </Tooltip>
+      <Tooltip title={t('Press App Switch Button')}>
+        <Button id='btnPressHomeButton'
+          icon={<BiSquare className={InspectorStyles['custom-button-icon']}/>}
+          onClick={() => applyClientMethod({ methodName: 'pressKeyCode', args: [187]})} />
+      </Tooltip>
+    </>}
+  </Button.Group>;
 
-    const generalControls = <ButtonGroup>
-      {mjpegScreenshotUrl && !isSourceRefreshOn &&
+  const appModeControls = <Button.Group value={appMode}>
+    <Tooltip title={t('Native App Mode')}>
+      <Button icon={<AppstoreOutlined/>} onClick={() => {selectAppMode(APP_MODE.NATIVE);}}
+        type={appMode === APP_MODE.NATIVE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+      />
+    </Tooltip>
+    <Tooltip title={t('Web/Hybrid App Mode')}>
+      <Button icon={<GlobalOutlined/>} onClick={() => {selectAppMode(APP_MODE.WEB_HYBRID);}}
+        type={appMode === APP_MODE.WEB_HYBRID ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+      />
+    </Tooltip>
+  </Button.Group>;
+
+  const generalControls = <Button.Group>
+    {mjpegScreenshotUrl && !isSourceRefreshOn &&
         <Tooltip title={t('Start Refreshing Source')}>
           <Button id='btnStartRefreshing' icon={<PlayCircleOutlined/>} onClick={toggleRefreshingState}/>
         </Tooltip>
-      }
-      {mjpegScreenshotUrl && isSourceRefreshOn &&
-        <Tooltip title={t('Pause Refreshing Source')}>
-          <Button id='btnPauseRefreshing' icon={<PauseCircleOutlined/>} onClick={toggleRefreshingState}/>
-        </Tooltip>
-      }
-      <Tooltip title={t('refreshSource')}>
-        <Button id='btnReload' icon={<ReloadOutlined/>} onClick={() => applyClientMethod({methodName: 'getPageSource'})}/>
+    }
+    {mjpegScreenshotUrl && isSourceRefreshOn &&
+      <Tooltip title={t('Pause Refreshing Source')}>
+        <Button id='btnPauseRefreshing' icon={<PauseCircleOutlined/>} onClick={toggleRefreshingState}/>
       </Tooltip>
-      <Tooltip title={t('Search for element')}>
-        <Button id='searchForElement' icon={<SearchOutlined/>} onClick={showLocatorTestModal} />
+    }
+    <Tooltip title={t('refreshSource')}>
+      <Button id='btnReload' icon={<ReloadOutlined/>} onClick={() => applyClientMethod({methodName: 'getPageSource'})}/>
+    </Tooltip>
+    <Tooltip title={t('Search for element')}>
+      <Button id='searchForElement' icon={<SearchOutlined/>} onClick={showLocatorTestModal} />
+    </Tooltip>
+    {!isRecording &&
+      <Tooltip title={t('Start Recording')}>
+        <Button id='btnStartRecording' icon={<EyeOutlined/>} onClick={startRecording}/>
       </Tooltip>
-      {!isRecording &&
-        <Tooltip title={t('Start Recording')}>
-          <Button id='btnStartRecording' icon={<EyeOutlined/>} onClick={startRecording}/>
-        </Tooltip>
-      }
-      {isRecording &&
-        <Tooltip title={t('Pause Recording')}>
-          <Button id='btnPause' icon={<PauseOutlined/>} type={BUTTON.DANGER} onClick={pauseRecording}/>
-        </Tooltip>
-      }
-    </ButtonGroup>;
+    }
+    {isRecording &&
+      <Tooltip title={t('Pause Recording')}>
+        <Button id='btnPause' icon={<PauseOutlined/>} type={BUTTON.DANGER} onClick={pauseRecording}/>
+      </Tooltip>
+    }
+  </Button.Group>;
 
-    const quitSessionButton = <Tooltip title={t('quitSessionAndClose')}>
-      <Button id='btnClose' icon={<CloseOutlined/>} onClick={() => quitSession()}/>
-    </Tooltip>;
+  const quitSessionButton = <Tooltip title={t('quitSessionAndClose')}>
+    <Button id='btnClose' icon={<CloseOutlined/>} onClick={() => quitSession()}/>
+  </Tooltip>;
 
-    return <div className={InspectorStyles['inspector-toolbar']}>
-      <Space size='middle'>
-        {deviceControls}
-        {appModeControls}
-        {generalControls}
-        {quitSessionButton}
-      </Space>
-    </div>;
-  }
-}
+  return <div className={InspectorStyles['inspector-toolbar']}>
+    <Space size='middle'>
+      {deviceControls}
+      {appModeControls}
+      {generalControls}
+      {quitSessionButton}
+    </Space>
+  </div>;
+};
 
-export default withTranslation(HeaderButtons);
+export default HeaderButtons;

--- a/app/renderer/components/Inspector/HighlighterCentroid.js
+++ b/app/renderer/components/Inspector/HighlighterCentroid.js
@@ -1,8 +1,8 @@
-import React, { Component } from 'react';
+import React from 'react';
 import InspectorCSS from './Inspector.css';
 import { RENDER_CENTROID_AS } from './shared';
 
-const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
+const { CENTROID, OVERLAP, EXPAND } = RENDER_CENTROID_AS;
 const CENTROID_STYLES = {
   VISIBLE: 'visible',
   HIDDEN: 'hidden',
@@ -12,42 +12,41 @@ const CENTROID_STYLES = {
 
 // Generate new coordinates along a circlular trajectory
 // for overlapping elements only
-function getCentroidPos (type, angle, coord) {
-  return type === OVERLAP ?
-    `calc((${angle} * 2.6vh) + ${coord}px)`
-    :
-    coord;
-}
+const getCentroidPos = (type, angle, coord) => {
+  if (type === OVERLAP) {
+    return `calc((${angle} * 2.6vh) + ${coord}px)`;
+  }
+  return coord;
+};
 
 /**
  * Shows all element centroids
  */
-export default class HighlighterCentroid extends Component {
+const HighlighterCentroid = (props) => {
+  const { selectedElementPath, hoveredElement = {}, element, elementProperties,
+          centroidType, hoveredCentroid, selectedCentroid } = props;
+  const { centerX, centerY, angleX, angleY, keyCode, path, container } = elementProperties;
 
-  onMouseEnter (path) {
-    const {selectHoveredElement, selectHoveredCentroid,
-           centroidType} = this.props;
+  const onMouseEnter = (path) => {
+    const { selectHoveredElement, selectHoveredCentroid } = props;
     if (centroidType === EXPAND) {
       selectHoveredCentroid(path);
     } else {
       selectHoveredElement(path);
     }
-  }
+  };
 
-  onMouseLeave () {
-    const {unselectHoveredElement, unselectHoveredCentroid,
-           centroidType} = this.props;
+  const onMouseLeave = () => {
+    const { unselectHoveredElement, unselectHoveredCentroid } = props;
     if (centroidType === EXPAND) {
       unselectHoveredCentroid();
     } else {
       unselectHoveredElement();
     }
-  }
+  };
 
-  onClickCentroid (path) {
-    const {selectElement, unselectElement,
-           selectCentroid, unselectCentroid, centroidType,
-           selectedCentroid, selectedElementPath} = this.props;
+  const onClickCentroid = (path) => {
+    const { selectElement, unselectElement, selectCentroid, unselectCentroid } = props;
     if (centroidType === EXPAND) {
       if (path === selectedCentroid) {
         unselectCentroid();
@@ -61,67 +60,62 @@ export default class HighlighterCentroid extends Component {
         selectElement(path);
       }
     }
+  };
+
+  const centroidClasses = [InspectorCSS['centroid-box']];
+  centroidClasses.push(InspectorCSS[centroidType]);
+
+  // Highlight centroids that represent elements
+  if (centroidType !== EXPAND) {
+    if (hoveredElement.path === path) {
+      centroidClasses.push(InspectorCSS['hovered-element-box']);
+    }
+    if (selectedElementPath === path) {
+      centroidClasses.push(InspectorCSS['inspected-element-box']);
+    }
   }
 
-  render () {
-    const {selectedElementPath, hoveredElement = {}, element, elementProperties,
-           centroidType, hoveredCentroid, selectedCentroid} = this.props;
-    const {path: hoveredPath} = hoveredElement;
-    const {centerX, centerY, angleX, angleY,
-           keyCode, path, container} = elementProperties;
-    const centroidClasses = [InspectorCSS['centroid-box']];
-    centroidClasses.push(InspectorCSS[centroidType]);
-
-    // Highlght centroids that represent elements
-    if (centroidType !== EXPAND) {
-      if (hoveredPath === path) {
-        centroidClasses.push(InspectorCSS['hovered-element-box']);
-      }
-      if (selectedElementPath === path) {
-        centroidClasses.push(InspectorCSS['inspected-element-box']);
-      }
+  // Highlight +/- centroids
+  if (centroidType !== CENTROID) {
+    if (hoveredCentroid === keyCode) {
+      centroidClasses.push(InspectorCSS['hovered-element-box']);
     }
-
-    // Highlight +/- centroids
-    if (centroidType !== CENTROID) {
-      if (hoveredCentroid === keyCode) {
-        centroidClasses.push(InspectorCSS['hovered-element-box']);
-      }
-      if (selectedCentroid === keyCode && !element) {
-        centroidClasses.push(InspectorCSS['inspected-element-box']);
-      }
+    if (selectedCentroid === keyCode && !element) {
+      centroidClasses.push(InspectorCSS['inspected-element-box']);
     }
-
-    const overlapDivStyle = {
-      visibility:
-        keyCode === selectedCentroid ?
-          CENTROID_STYLES.VISIBLE : CENTROID_STYLES.HIDDEN,
-    };
-
-    const centroidDivStyle = {
-      left: getCentroidPos(centroidType, angleX, centerX),
-      top: getCentroidPos(centroidType, angleY, centerY),
-      borderRadius:
-        element && !container ?
-          CENTROID_STYLES.NON_CONTAINER : CENTROID_STYLES.CONTAINER,
-      ...(centroidType === OVERLAP ? overlapDivStyle : {})
-    };
-
-    const placeHolder = centroidType === EXPAND ?
-      <div className={InspectorCSS['plus-minus']}>
-        {keyCode === selectedCentroid ? '-' : '+'}
-      </div>
-      :
-      <div></div>;
-
-    return <div
-      className={centroidClasses.join(' ').trim()}
-      onMouseOver={() => this.onMouseEnter(path)}
-      onMouseOut={() => this.onMouseLeave()}
-      onClick={() => this.onClickCentroid(path)}
-      key={path}
-      style={centroidDivStyle}>
-      {placeHolder}
-    </div>;
   }
-}
+
+  const overlapDivStyle = {
+    visibility:
+      keyCode === selectedCentroid ?
+        CENTROID_STYLES.VISIBLE : CENTROID_STYLES.HIDDEN,
+  };
+
+  const centroidDivStyle = {
+    left: getCentroidPos(centroidType, angleX, centerX),
+    top: getCentroidPos(centroidType, angleY, centerY),
+    borderRadius:
+      element && !container ?
+        CENTROID_STYLES.NON_CONTAINER : CENTROID_STYLES.CONTAINER,
+    ...(centroidType === OVERLAP ? overlapDivStyle : {})
+  };
+
+  const placeHolder = centroidType === EXPAND ?
+    <div className={InspectorCSS['plus-minus']}>
+      {keyCode === selectedCentroid ? '-' : '+'}
+    </div>
+    :
+    <div></div>;
+
+  return <div
+    className={centroidClasses.join(' ').trim()}
+    onMouseOver={() => onMouseEnter(path)}
+    onMouseOut={() => onMouseLeave()}
+    onClick={() => onClickCentroid(path)}
+    key={path}
+    style={centroidDivStyle}>
+    {placeHolder}
+  </div>;
+};
+
+export default HighlighterCentroid;

--- a/app/renderer/components/Inspector/HighlighterRect.js
+++ b/app/renderer/components/Inspector/HighlighterRect.js
@@ -1,48 +1,48 @@
-import React, { Component } from 'react';
+import React from 'react';
 import InspectorCSS from './Inspector.css';
 
 /**
  * Absolute positioned divs that overlay the app screenshot and highlight the bounding
  * boxes of the elements in the app
  */
-export default class HighlighterRect extends Component {
+const HighlighterRect = (props) => {
+  const { selectedElement = {}, selectHoveredElement, unselectHoveredElement, hoveredElement = {},
+          selectElement, unselectElement, element, scaleRatio, xOffset, elLocation, elSize, dimensions } = props;
+  const { path: hoveredPath } = hoveredElement;
+  const { path: selectedPath } = selectedElement;
 
-  render () {
-    const {selectedElement = {}, selectHoveredElement, unselectHoveredElement, hoveredElement = {}, selectElement, unselectElement, element,
-           scaleRatio, xOffset, elLocation, elSize, dimensions} = this.props;
-    const {path: hoveredPath} = hoveredElement;
-    const {path: selectedPath} = selectedElement;
+  let width, height, left, top, highlighterClasses, key;
+  highlighterClasses = [InspectorCSS['highlighter-box']];
 
-    let width, height, left, top, highlighterClasses, key;
-    highlighterClasses = [InspectorCSS['highlighter-box']];
+  if (element) {
+    ({width, height, left, top} = dimensions);
 
-    if (element) {
-      ({width, height, left, top} = dimensions);
-
-      // Add class + special classes to hovered and selected elements
-      if (hoveredPath === element.path) {
-        highlighterClasses.push(InspectorCSS['hovered-element-box']);
-      }
-      if (selectedPath === element.path) {
-        highlighterClasses.push(InspectorCSS['inspected-element-box']);
-      }
-      key = element.path;
-    } else if (elLocation && elSize) {
-      width = elSize.width / scaleRatio;
-      height = elSize.height / scaleRatio;
-      top = elLocation.y / scaleRatio;
-      left = elLocation.x / scaleRatio + xOffset;
-      // Unique keys are assigned to elements by their x & y coordinates
-      key = `searchedForElement{x: ${elLocation.x}, y: ${elLocation.y}}`;
+    // Add class + special classes to hovered and selected elements
+    if (hoveredPath === element.path) {
+      highlighterClasses.push(InspectorCSS['hovered-element-box']);
+    }
+    if (selectedPath === element.path) {
       highlighterClasses.push(InspectorCSS['inspected-element-box']);
     }
-    return <div className={highlighterClasses.join(' ').trim()}
-      onMouseOver={() => selectHoveredElement(key)}
-      onMouseOut={unselectHoveredElement}
-      onClick={() => key === selectedPath ? unselectElement() : selectElement(key)}
-      key={key}
-      style={{left: (left || 0), top: (top || 0), width: (width || 0), height: (height || 0)}}>
-      <div></div>
-    </div>;
+    key = element.path;
+  } else if (elLocation && elSize) {
+    width = elSize.width / scaleRatio;
+    height = elSize.height / scaleRatio;
+    top = elLocation.y / scaleRatio;
+    left = elLocation.x / scaleRatio + xOffset;
+    // Unique keys are assigned to elements by their x & y coordinates
+    key = `searchedForElement{x: ${elLocation.x}, y: ${elLocation.y}}`;
+    highlighterClasses.push(InspectorCSS['inspected-element-box']);
   }
-}
+
+  return <div className={highlighterClasses.join(' ').trim()}
+    onMouseOver={() => selectHoveredElement(key)}
+    onMouseOut={unselectHoveredElement}
+    onClick={() => key === selectedPath ? unselectElement() : selectElement(key)}
+    key={key}
+    style={{left: (left || 0), top: (top || 0), width: (width || 0), height: (height || 0)}}>
+    <div></div>
+  </div>;
+};
+
+export default HighlighterRect;

--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -1,22 +1,24 @@
-import React, { Component } from 'react';
+import React from 'react';
 import HighlighterRect from './HighlighterRect';
 import HighlighterCentroid from './HighlighterCentroid';
-import B from 'bluebird';
-import { SCREENSHOT_INTERACTION_MODE, parseCoordinates,
-         RENDER_CENTROID_AS, POINTER_TYPES, DEFAULT_TAP,
-         DEFAULT_SWIPE } from './shared';
+import { parseCoordinates, RENDER_CENTROID_AS } from './shared';
 
-const {POINTER_UP, POINTER_DOWN, PAUSE, POINTER_MOVE} = POINTER_TYPES;
-const {TAP, SWIPE, SELECT} = SCREENSHOT_INTERACTION_MODE;
-const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
+const { CENTROID, OVERLAP, EXPAND } = RENDER_CENTROID_AS;
 
 /**
  * Shows screenshot of running application and divs that highlight the elements' bounding boxes
  */
-export default class HighlighterRects extends Component {
+const HighlighterRects = (props) => {
+  const { source, containerEl, searchedForElementBounds, scaleRatio, showCentroids,
+          isLocatorTestModalVisible, isSiriCommandModalVisible } = props;
 
-  getElements (source) {
-    const elementsByOverlap = this.buildElementsWithProps(source, null, [], {});
+  const highlighterRects = [];
+  const highlighterCentroids = [];
+  let highlighterXOffset = 0;
+  let screenshotEl = null;
+
+  const getElements = (source) => {
+    const elementsByOverlap = buildElementsWithProps(source, null, [], {});
     let elements = [];
 
     // Adjust overlapping elements
@@ -46,27 +48,23 @@ export default class HighlighterRects extends Component {
           }
         };
         elements = [...elements, element,
-          ...this.updateOverlapsAngles(elementsByOverlap[key], key)];
+          ...updateOverlapsAngles(elementsByOverlap[key], key)];
       } else {
         elements.push(elementsByOverlap[key][0]);
       }
     }
 
     return elements;
-  }
+  };
 
   // This func creates a new object for each element and determines its properties
   // 'elements' is an array that stores all prev elements
   // 'overlaps' is an object which organzies elements by their positions
-  buildElementsWithProps (source, prevElement, elements, overlaps) {
-    if (!source) {
-      return {};
-    }
-    const {scaleRatio} = this.props;
-    const {x1, y1, x2, y2} = parseCoordinates(source);
-    const xOffset = this.highlighterXOffset || 0;
-    const centerPoint = (v1, v2) =>
-      Math.round(v1 + ((v2 - v1) / 2)) / scaleRatio;
+  const buildElementsWithProps = (source, prevElement, elements, overlaps) => {
+    if (!source) { return {}; }
+    const { x1, y1, x2, y2 } = parseCoordinates(source);
+    const xOffset = highlighterXOffset || 0;
+    const centerPoint = (v1, v2) => Math.round(v1 + ((v2 - v1) / 2)) / scaleRatio;
     const obj = {
       type: CENTROID,
       element: source,
@@ -87,7 +85,7 @@ export default class HighlighterRects extends Component {
       }
     };
     const coordinates = `${obj.properties.centerX}.${obj.properties.centerY}`;
-    obj.properties.container = this.isElementContainer(obj, elements);
+    obj.properties.container = isElementContainer(obj, elements);
 
     elements.push(obj);
 
@@ -101,33 +99,32 @@ export default class HighlighterRects extends Component {
 
     if (source.children) {
       for (const childEl of source.children) {
-        this.buildElementsWithProps(childEl, source, elements, overlaps);
+        buildElementsWithProps(childEl, source, elements, overlaps);
       }
     }
 
     return overlaps;
-  }
+  };
 
-  isElementContainer (element1, elements) {
+  const isElementContainer = (element1, elements) => {
     for (const element2 of elements) {
       if (element2.element !== element1.element
-        && this.isElementOverElement(element1.properties, element2.properties)
-        && !this.isAncestor(element1.parent, element2.element, elements)) {
+        && isElementOverElement(element1.properties, element2.properties)
+        && !isAncestor(element1.parent, element2.element, elements)) {
         return true;
       }
     }
     return false;
-  }
+  };
 
-  isElementOverElement (element1, element2) {
-    return element1.left <= element2.left
-        && element1.width >= element2.width
-        && element1.top >= element2.top
-        && element1.height >= element2.height;
-  }
+  const isElementOverElement = (element1, element2) =>
+    element1.left <= element2.left
+      && element1.width >= element2.width
+      && element1.top >= element2.top
+      && element1.height >= element2.height;
 
   // Traverse through parent elements until we reach maybeAncestor
-  isAncestor (curElement, maybeAncestor, elements) {
+  const isAncestor = (curElement, maybeAncestor, elements) => {
     if (elements.length > 0) {
       while (curElement !== null) {
         if (curElement === maybeAncestor) { return true; }
@@ -138,10 +135,10 @@ export default class HighlighterRects extends Component {
       }
     }
     return false;
-  }
+  };
 
   // Generate angles for circular positioning for overlaping elements
-  updateOverlapsAngles (elements, key) {
+  const updateOverlapsAngles = (elements, key) => {
     const steps = elements.length;
     for (let step = 0; step < steps; step++) {
       const [el, elProps] = [elements[step], elements[step].properties];
@@ -151,139 +148,70 @@ export default class HighlighterRects extends Component {
       elProps.angleY = Math.sin(2 * Math.PI * (step / steps));
     }
     return elements;
-  }
+  };
 
-  async handleScreenshotClick () {
-    const {screenshotInteractionMode, applyClientMethod,
-           swipeStart, swipeEnd, setSwipeStart, setSwipeEnd} = this.props;
-    const {x, y} = this.state;
-    const {POINTER_NAME, DURATION_1, DURATION_2, BUTTON} = DEFAULT_TAP;
-
-    if (screenshotInteractionMode === TAP) {
-      applyClientMethod({
-        methodName: TAP,
-        args: [
-          {
-            [POINTER_NAME]: [
-              {type: POINTER_MOVE, duration: DURATION_1, x, y},
-              {type: POINTER_DOWN, button: BUTTON},
-              {type: PAUSE, duration: DURATION_2},
-              {type: POINTER_UP, button: BUTTON}
-            ],
-          }
-        ],
-      });
-    } else if (screenshotInteractionMode === SWIPE) {
-      if (!swipeStart) {
-        setSwipeStart(x, y);
-      } else if (!swipeEnd) {
-        setSwipeEnd(x, y);
-        await B.delay(500); // Wait a second to do the swipe so user can see the SVG line
-        await this.handleDoSwipe();
-      }
-    }
-  }
-
-  handleMouseMove (e) {
-    const {screenshotInteractionMode, scaleRatio} = this.props;
-
-    if (screenshotInteractionMode !== SELECT) {
-      const offsetX = e.nativeEvent.offsetX;
-      const offsetY = e.nativeEvent.offsetY;
-      const x = offsetX * scaleRatio;
-      const y = offsetY * scaleRatio;
-      this.setState({
-        x: Math.round(x),
-        y: Math.round(y),
-      });
-    }
-  }
-
-  handleMouseOut () {
-    this.setState({
-      x: null,
-      y: null,
-    });
-  }
-
-  async handleDoSwipe () {
-    const {swipeStart, swipeEnd, clearSwipeAction, applyClientMethod} = this.props;
-    const {POINTER_NAME, DURATION_1, DURATION_2, BUTTON, ORIGIN} = DEFAULT_SWIPE;
-    await applyClientMethod({
-      methodName: SWIPE,
-      args: {[POINTER_NAME]: [
-        {type: POINTER_MOVE, duration: DURATION_1, x: swipeStart.x, y: swipeStart.y},
-        {type: POINTER_DOWN, button: BUTTON},
-        {type: POINTER_MOVE, duration: DURATION_2, origin: ORIGIN, x: swipeEnd.x, y: swipeEnd.y},
-        {type: POINTER_UP, button: BUTTON}
-      ]},
-    });
-    clearSwipeAction();
-  }
-
-  render () {
-    const {source, screenshotInteractionMode, containerEl, searchedForElementBounds,
-           isLocatorTestModalVisible, isSiriCommandModalVisible, scaleRatio, showCentroids} = this.props;
-
-    // Array of all element objects with properties to draw rectangles and/or centroids
-    const elements = this.getElements(source);
-
-    const highlighterRects = [];
-    const highlighterCentroids = [];
-    let highlighterXOffset = 0;
-    let screenshotEl = null;
-
-    if (containerEl) {
-      screenshotEl = containerEl.querySelector('img');
-      highlighterXOffset = screenshotEl.getBoundingClientRect().left -
-                           containerEl.getBoundingClientRect().left;
-    }
-
-    // Displays element rectangles only
-    let renderElements = (source) => {
-      for (const elem of source) {
-        highlighterRects.push(<HighlighterRect {...this.props}
+  // Displays element rectangles only
+  const renderElements = (source) => {
+    for (const elem of source) {
+      highlighterRects.push(
+        <HighlighterRect {...props}
           dimensions={elem.properties}
           element={elem.element}
           scaleRatio={scaleRatio}
           key={elem.properties.path}
-          xOffset={highlighterXOffset}
-        />);
-      }
-    };
+          xOffset={highlighterXOffset} />
+      );
+    }
+  };
 
-    // Displays centroids only
-    let renderCentroids = (centroids) => {
-      for (const elem of centroids) {
-        highlighterCentroids.push(<HighlighterCentroid {...this.props}
+  // Displays centroids only
+  const renderCentroids = (centroids) => {
+    for (const elem of centroids) {
+      highlighterCentroids.push(
+        <HighlighterCentroid {...props}
           centroidType={elem.type}
           elementProperties={elem.properties}
           element={elem.element}
-          key={elem.properties.path}
-        />);
-      }
-    };
-
-    // If the user selected an element that they searched for, highlight that element
-    if (searchedForElementBounds && isLocatorTestModalVisible) {
-      const {location: elLocation, size} = searchedForElementBounds;
-      highlighterRects.push(<HighlighterRect elSize={size} elLocation={elLocation} scaleRatio={scaleRatio} xOffset={highlighterXOffset} />);
+          key={elem.properties.path} />
+      );
     }
+  };
 
-    // If we're tapping or swiping, show the 'crosshair' cursor style
-    const screenshotStyle = {};
-    if ([TAP, SWIPE].includes(screenshotInteractionMode)) {
-      screenshotStyle.cursor = 'crosshair';
-    }
+  // Array of all element objects with properties to draw rectangles and/or centroids
+  const elements = getElements(source);
 
-    // Don't show highlighter rects when Search Elements modal is open
-    if (!isLocatorTestModalVisible && !isSiriCommandModalVisible) {
-      renderElements(elements);
-      if (showCentroids) {
-        renderCentroids(elements);
-      }
-    }
-
-    return <div>{ highlighterRects }{ highlighterCentroids }</div>;
+  if (containerEl) {
+    screenshotEl = containerEl.querySelector('img');
+    highlighterXOffset = screenshotEl.getBoundingClientRect().left -
+                         containerEl.getBoundingClientRect().left;
   }
-}
+
+  // If the user selected an element that they searched for, highlight that element
+  if (searchedForElementBounds && isLocatorTestModalVisible) {
+    const {location: elLocation, size} = searchedForElementBounds;
+    highlighterRects.push(
+      <HighlighterRect
+        elSize={size}
+        elLocation={elLocation}
+        scaleRatio={scaleRatio}
+        xOffset={highlighterXOffset} />
+    );
+  }
+
+  // Don't show highlighter rects when Search Elements modal is open
+  if (!isLocatorTestModalVisible && !isSiriCommandModalVisible) {
+    renderElements(elements);
+    if (showCentroids) {
+      renderCentroids(elements);
+    }
+  }
+
+  return (
+    <div>
+      {highlighterRects}
+      {highlighterCentroids}
+    </div>
+  );
+};
+
+export default HighlighterRects;

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -1,109 +1,93 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import { Alert, Input, Row, Button, Badge, List, Space, Spin, Tooltip } from 'antd';
 import { AimOutlined, ClearOutlined, SendOutlined, MenuUnfoldOutlined } from '@ant-design/icons';
 import { ALERT } from '../AntdTypes';
 import InspectorStyles from './Inspector.css';
-import { withTranslation } from '../../util';
 
-const ButtonGroup = Button.Group;
+const LocatedElements = (props) => {
+  const { locatedElements, locatedElementsExecutionTime, applyClientMethod, setLocatorTestElement, locatorTestElement,
+          isFindingLocatedElementInSource, searchedForElementBounds, selectLocatedElement, source, driver, t } = props;
 
-const showIdAutocompleteInfo = (driver, strategy, value, t) => {
-  const automationName = driver.client.capabilities.automationName;
-  const idLocatorAutocompletionDisabled = driver.client.capabilities.disableIdLocatorAutocompletion;
-  if (automationName && automationName.toLowerCase() === 'uiautomator2' &&
-    strategy === 'id' && !value.includes(':id/') && !idLocatorAutocompletionDisabled) {
-    return <Row><Alert message={t('idAutocompletionCanBeDisabled')} type={ALERT.INFO} showIcon/></Row>;
-  }
+  const sendKeys = useRef(null);
+
+  const showIdAutocompleteInfo = () => {
+    const { locatorTestStrategy, locatorTestValue } = props;
+    const automationName = driver.client.capabilities.automationName;
+    const idLocatorAutocompletionDisabled = driver.client.capabilities.disableIdLocatorAutocompletion;
+    if (automationName && automationName.toLowerCase() === 'uiautomator2' &&
+      locatorTestStrategy === 'id' && !locatorTestValue.includes(':id/') && !idLocatorAutocompletionDisabled) {
+      return <Row><Alert message={t('idAutocompletionCanBeDisabled')} type={ALERT.INFO} showIcon/></Row>;
+    }
+  };
+
+  return <>
+    {locatedElements.length === 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+      <Row><i>{t('couldNotFindAnyElements')}</i></Row>
+      {showIdAutocompleteInfo()}
+    </Space>}
+    {locatedElements.length > 0 && <Spin spinning={isFindingLocatedElementInSource}>
+      <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
+        <Row justify='space-between'>
+          <span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span>
+          <>{t('Time')}: {locatedElementsExecutionTime}</>
+        </Row>
+        <Row>
+          <List className={InspectorStyles.searchResultsList}
+            size='small'
+            dataSource={locatedElements}
+            renderItem={(elementId) =>
+              <List.Item type='text'
+                {...(locatorTestElement === elementId ? { className: InspectorStyles.searchResultsSelectedItem } : {})}
+                {...(locatorTestElement !== elementId ? { onClick: () => {setLocatorTestElement(elementId);} } : {})}
+              >
+                {elementId}
+              </List.Item>
+            }
+          />
+        </Row>
+        <Row justify='center'>
+          <Space direction='horizontal' size='small'>
+            <Tooltip title={t('Find and Select in Source')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<MenuUnfoldOutlined/>}
+                onClick={() => selectLocatedElement(source, searchedForElementBounds, locatorTestElement)}
+              />
+            </Tooltip>
+            <Tooltip title={t('Tap')} placement='bottom'>
+              <Button
+                disabled={!locatorTestElement}
+                icon={<AimOutlined/>}
+                onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
+              />
+            </Tooltip>
+            <Button.Group className={InspectorStyles.searchResultsActions}>
+              <Input className={InspectorStyles.searchResultsKeyInput}
+                disabled={!locatorTestElement}
+                placeholder={t('Enter Keys to Send')}
+                allowClear={true}
+                onChange={(e) => sendKeys.current = e.target.value}/>
+              <Tooltip title={t('Send Keys')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  icon={<SendOutlined/>}
+                  onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [sendKeys.current || '']})}
+                />
+              </Tooltip>
+              <Tooltip title={t('Clear')} placement='bottom'>
+                <Button
+                  disabled={!locatorTestElement}
+                  id='btnClearElement'
+                  icon={<ClearOutlined/>}
+                  onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
+                />
+              </Tooltip>
+            </Button.Group>
+          </Space>
+        </Row>
+      </Space>
+    </Spin>}
+  </>;
 };
 
-class LocatedElements extends Component {
-
-  render () {
-    const {
-      locatedElements,
-      locatedElementsExecutionTime,
-      applyClientMethod,
-      locatorTestStrategy,
-      locatorTestValue,
-      setLocatorTestElement,
-      locatorTestElement,
-      isFindingLocatedElementInSource,
-      searchedForElementBounds,
-      selectLocatedElement,
-      source,
-      driver,
-      t,
-    } = this.props;
-
-    return <>
-      {locatedElements.length === 0 && <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
-        <Row><i>{t('couldNotFindAnyElements')}</i></Row>
-        {showIdAutocompleteInfo(driver, locatorTestStrategy, locatorTestValue, t)}
-      </Space>}
-      {locatedElements.length > 0 && <Spin spinning={isFindingLocatedElementInSource}>
-        <Space className={InspectorStyles.spaceContainer} direction='vertical' size='small'>
-          <Row justify='space-between'>
-            <span>{t('elementsCount')} <Badge count={locatedElements.length} offset={[0, -2]}/></span>
-            <>{t('Time')}: {locatedElementsExecutionTime}</>
-          </Row>
-          <Row>
-            <List className={InspectorStyles.searchResultsList}
-              size='small'
-              dataSource={locatedElements}
-              renderItem={(elementId) =>
-                <List.Item type='text'
-                  {...(locatorTestElement === elementId ? { className: InspectorStyles.searchResultsSelectedItem } : {})}
-                  {...(locatorTestElement !== elementId ? { onClick: () => {setLocatorTestElement(elementId);} } : {})}
-                >
-                  {elementId}
-                </List.Item>
-              }
-            />
-          </Row>
-          <Row justify='center'>
-            <Space direction='horizontal' size='small'>
-              <Tooltip title={t('Find and Select in Source')} placement='bottom'>
-                <Button
-                  disabled={!locatorTestElement}
-                  icon={<MenuUnfoldOutlined/>}
-                  onClick={() => selectLocatedElement(source, searchedForElementBounds, locatorTestElement)}
-                />
-              </Tooltip>
-              <Tooltip title={t('Tap')} placement='bottom'>
-                <Button
-                  disabled={!locatorTestElement}
-                  icon={<AimOutlined/>}
-                  onClick={() => applyClientMethod({methodName: 'click', elementId: locatorTestElement})}
-                />
-              </Tooltip>
-              <ButtonGroup className={InspectorStyles.searchResultsActions}>
-                <Input className={InspectorStyles.searchResultsKeyInput}
-                  disabled={!locatorTestElement}
-                  placeholder={t('Enter Keys to Send')}
-                  allowClear={true}
-                  onChange={(e) => this.setState({sendKeys: e.target.value})}/>
-                <Tooltip title={t('Send Keys')} placement='bottom'>
-                  <Button
-                    disabled={!locatorTestElement}
-                    icon={<SendOutlined/>}
-                    onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: locatorTestElement, args: [this.state.sendKeys || '']})}
-                  />
-                </Tooltip>
-                <Tooltip title={t('Clear')} placement='bottom'>
-                  <Button
-                    disabled={!locatorTestElement}
-                    id='btnClearElement'
-                    icon={<ClearOutlined/>}
-                    onClick={() => applyClientMethod({methodName: 'clear', elementId: locatorTestElement})}
-                  />
-                </Tooltip>
-              </ButtonGroup>
-            </Space>
-          </Row>
-        </Space>
-      </Spin>}
-    </>;
-  }
-}
-
-export default withTranslation(LocatedElements);
+export default LocatedElements;

--- a/app/renderer/components/Inspector/LocatedElements.js
+++ b/app/renderer/components/Inspector/LocatedElements.js
@@ -18,22 +18,6 @@ const showIdAutocompleteInfo = (driver, strategy, value, t) => {
 
 class LocatedElements extends Component {
 
-  onSubmit () {
-    const {locatedElements, locatorTestStrategy, locatorTestValue, searchForElement, clearSearchResults, hideLocatorTestModal} = this.props;
-    if (locatedElements) {
-      hideLocatorTestModal();
-      clearSearchResults();
-    } else {
-      searchForElement(locatorTestStrategy, locatorTestValue);
-    }
-  }
-
-  onCancel () {
-    const {hideLocatorTestModal, clearSearchResults} = this.props;
-    hideLocatorTestModal();
-    clearSearchResults();
-  }
-
   render () {
     const {
       locatedElements,

--- a/app/renderer/components/Inspector/LocatorTestModal.js
+++ b/app/renderer/components/Inspector/LocatorTestModal.js
@@ -1,63 +1,43 @@
-import React, { Component } from 'react';
-import ReactDOM from 'react-dom';
+import React from 'react';
 import { Modal, Button } from 'antd';
 import LocatedElements from './LocatedElements';
 import ElementLocator from './ElementLocator';
-import { withTranslation } from '../../util';
 
+const LocatorTestModal = (props) => {
+  const { isLocatorTestModalVisible, isSearchingForElements, clearSearchResults, locatedElements, t } = props;
 
-class LocatorTestModal extends Component {
+  const onCancel = () => {
+    const { hideLocatorTestModal } = props;
+    hideLocatorTestModal();
+    clearSearchResults();
+  };
 
-  onSubmit () {
-    const {
-      locatedElements,
-      locatorTestStrategy,
-      locatorTestValue,
-      searchForElement,
-      clearSearchResults,
-      hideLocatorTestModal,
-    } = this.props;
+  const onSubmit = () => {
+    const { locatorTestStrategy, locatorTestValue, searchForElement } = props;
     if (locatedElements) {
-      hideLocatorTestModal();
-      clearSearchResults();
+      onCancel();
     } else {
       searchForElement(locatorTestStrategy, locatorTestValue);
     }
-  }
+  };
 
-  onCancel () {
-    const {hideLocatorTestModal, clearSearchResults} = this.props;
-    hideLocatorTestModal();
-    clearSearchResults();
-  }
+  // Footer displays all the buttons at the bottom of the Modal
+  return <Modal open={isLocatorTestModalVisible}
+    title={t('Search for element')}
+    onCancel={onCancel}
+    footer=
+      {<>
+        {locatedElements &&
+        <Button onClick={(e) => e.preventDefault() || clearSearchResults()}>
+          {t('Back')}
+        </Button>}
+        <Button loading={isSearchingForElements} onClick={onSubmit} type="primary">
+          {locatedElements ? t('Done') : t('Search')}
+        </Button>
+      </>}>
+    {!locatedElements && <ElementLocator {...props} />}
+    {locatedElements && <LocatedElements {...props} />}
+  </Modal>;
+};
 
-  render () {
-    const {
-      clearSearchResults,
-      isLocatorTestModalVisible,
-      isSearchingForElements,
-      locatedElements,
-      t,
-    } = this.props;
-
-    // Footer displays all the buttons at the bottom of the Modal
-    return <Modal open={isLocatorTestModalVisible}
-      title={t('Search for element')}
-      onCancel={this.onCancel.bind(this)}
-      footer=
-        {<>
-          {locatedElements &&
-          <Button onClick={(e) => e.preventDefault() || clearSearchResults()}>
-            {t('Back')}
-          </Button>}
-          <Button loading={isSearchingForElements} onClick={this.onSubmit.bind(this)} type="primary">
-            {locatedElements ? t('Done') : t('Search')}
-          </Button>
-        </>}>
-      {!locatedElements && <ElementLocator {...this.props} />}
-      {locatedElements && <LocatedElements {...this.props} />}
-    </Modal>;
-  }
-}
-
-export default withTranslation(LocatorTestModal);
+export default LocatorTestModal;

--- a/app/renderer/components/Inspector/RecordedActions.js
+++ b/app/renderer/components/Inspector/RecordedActions.js
@@ -1,122 +1,92 @@
 import { clipboard } from '../../polyfills';
-import React, { Component } from 'react';
+import React from 'react';
 import { Card, Select, Tooltip, Button } from 'antd';
 import InspectorStyles from './Inspector.css';
 import frameworks from '../../lib/client-frameworks';
 import { highlight } from 'highlight.js';
-import { withTranslation } from '../../util';
-import {
-  ExportOutlined,
-  CopyOutlined,
-  DeleteOutlined,
-  CloseOutlined,
-  CodeOutlined
-} from '@ant-design/icons';
+import { ExportOutlined, CopyOutlined, DeleteOutlined, CloseOutlined, CodeOutlined } from '@ant-design/icons';
 import { BUTTON } from '../AntdTypes';
 
-const Option = Select.Option;
-const ButtonGroup = Button.Group;
+const RecordedActions = (props) => {
+  const { showBoilerplate, recordedActions, actionFramework, t } = props;
 
-class RecordedActions extends Component {
+  const code = (raw = true) => {
+    const { host, port, path, https, desiredCapabilities } = props.sessionDetails;
 
-  code (raw = true) {
-    let {showBoilerplate, sessionDetails, recordedActions, actionFramework
-    } = this.props;
-    let {host, port, path, https, desiredCapabilities} = sessionDetails;
-
-    let framework = new frameworks[actionFramework](host, port, path,
-      https, desiredCapabilities);
+    let framework = new frameworks[actionFramework](host, port, path, https, desiredCapabilities);
     framework.actions = recordedActions;
-    let rawCode = framework.getCodeString(showBoilerplate);
+    const rawCode = framework.getCodeString(showBoilerplate);
     if (raw) {
       return rawCode;
     }
     return highlight(framework.language, rawCode, true).value;
-  }
+  };
 
-  actionBar () {
-    const {
-      showBoilerplate,
-      recordedActions,
-      setActionFramework,
-      toggleShowBoilerplate,
-      clearRecording,
-      closeRecorder,
-      actionFramework,
-      isRecording,
-      t,
-    } = this.props;
-
-    let frameworkOpts = Object.keys(frameworks).map((f) => <Option value={f} key={f}>
-      {frameworks[f].readableName}
-    </Option>);
+  const actionBar = () => {
+    const { setActionFramework, toggleShowBoilerplate, clearRecording, closeRecorder, isRecording } = props;
 
     return <div>
       {!!recordedActions.length &&
         <Select defaultValue={actionFramework} onChange={setActionFramework}
           className={InspectorStyles['framework-dropdown']} size="small">
-          {frameworkOpts}
+          {Object.keys(frameworks).map((f) =>
+            <Select.Option value={f} key={f}>{frameworks[f].readableName}</Select.Option>
+          )}
         </Select>
       }
       {(!!recordedActions.length || !isRecording) &&
-        <ButtonGroup size="small">
+        <Button.Group size="small">
           {!!recordedActions.length &&
           <Tooltip title={t('Show/Hide Boilerplate Code')}>
             <Button
               onClick={toggleShowBoilerplate}
               icon={<ExportOutlined/>}
-              type={showBoilerplate ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-            />
+              type={showBoilerplate ? BUTTON.PRIMARY : BUTTON.DEFAULT} />
           </Tooltip>
           }
           {!!recordedActions.length &&
           <Tooltip title={t('Copy code to clipboard')}>
             <Button
               icon={<CopyOutlined/>}
-              onClick={() => clipboard.writeText(this.code())}
-            />
+              onClick={() => clipboard.writeText(code())} />
           </Tooltip>
           }
           {!!recordedActions.length &&
           <Tooltip title={t('Clear Actions')}>
             <Button
               icon={<DeleteOutlined/>}
-              onClick={clearRecording}/>
+              onClick={clearRecording} />
           </Tooltip>
           }
           {!isRecording &&
           <Tooltip title={t('Close Recorder')}>
             <Button
               icon={<CloseOutlined/>}
-              onClick={closeRecorder}/>
+              onClick={closeRecorder} />
           </Tooltip>
           }
-        </ButtonGroup>
+        </Button.Group>
       }
     </div>;
-  }
+  };
 
-  render () {
-    const {recordedActions, t} = this.props;
+  const highlightedCode = code(false);
 
-    const highlightedCode = this.code(false);
-
-    return <Card title={<span><CodeOutlined /> {t('Recorder')}</span>}
+  return (
+    <Card title={<span><CodeOutlined /> {t('Recorder')}</span>}
       className={InspectorStyles['recorded-actions']}
-      extra={this.actionBar()}
-    >
+      extra={actionBar()}>
       {!recordedActions.length &&
         <div className={InspectorStyles['no-recorded-actions']}>
           {t('Perform some actions to see code show up here')}
         </div>
       }
       {!!recordedActions.length &&
-        <div
-          className={InspectorStyles['recorded-code']}
+        <div className={InspectorStyles['recorded-code']}
           dangerouslySetInnerHTML={{__html: highlightedCode}} />
       }
-    </Card>;
-  }
-}
+    </Card>
+  );
+};
 
-export default withTranslation(RecordedActions);
+export default RecordedActions;

--- a/app/renderer/components/Inspector/SavedGestures.js
+++ b/app/renderer/components/Inspector/SavedGestures.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Table, Button, Space, Tooltip } from 'antd';
-import { withTranslation } from '../../util';
 import InspectorStyles from './Inspector.css';
 import { EditOutlined, DeleteOutlined, PlusOutlined, PlayCircleOutlined } from '@ant-design/icons';
 import { SCREENSHOT_INTERACTION_MODE, POINTER_TYPES, percentageToPixels } from './shared';
@@ -9,143 +8,125 @@ import moment from 'moment';
 
 const SAVED_ACTIONS_OBJ = {NAME: 'Name', DESCRIPTION: 'Description', CREATED: 'Created', ACTIONS: 'Actions'};
 
-class SavedGestures extends Component {
+const SavedGestures = (props) => {
+  const { savedGestures, showGestureEditor, removeGestureDisplay, t } = props;
 
-  constructor (props) {
-    super(props);
-    this.onRow = this.onRow.bind(this);
-    this.drawnGesture = null;
-  }
+  const drawnGestureRef = useRef(null);
 
-  onRow (record) {
-    return {
-      onClick: () => {
-        const gesture = this.getGestureByID(record.key);
-        if (gesture.id === this.drawnGesture) {
-          this.props.removeGestureDisplay();
-          this.drawnGesture = null;
-        } else {
-          this.onDraw(gesture);
-          this.drawnGesture = gesture.id;
-        }
-      }
-    };
-  }
+  const onRowClick = (rowKey) => {
+    const gesture = getGestureByID(rowKey);
+    if (gesture.id === drawnGestureRef.current) {
+      removeGestureDisplay();
+      drawnGestureRef.current = null;
+    } else {
+      onDraw(gesture);
+      drawnGestureRef.current = gesture.id;
+    }
+  };
 
-  componentDidMount () {
-    const {getSavedGestures} = this.props;
-    getSavedGestures();
-  }
-
-  componentWillUnmount () {
-    this.drawnGesture = null;
-  }
-
-  loadSavedGesture (gesture) {
-    const {removeGestureDisplay, setLoadedGesture, showGestureEditor} = this.props;
+  const loadSavedGesture = (gesture) => {
+    const { setLoadedGesture } = props;
     removeGestureDisplay();
     setLoadedGesture(gesture);
     showGestureEditor();
-  }
+  };
 
-  handleDelete (id) {
-    return () => {
-      if (window.confirm('Are you sure?')) {
-        this.props.deleteSavedGesture(id);
-      }
-    };
-  }
+  const handleDelete = (id) => {
+    const { deleteSavedGesture } = props;
+    if (window.confirm('Are you sure?')) {
+      deleteSavedGesture(id);
+    }
+  };
 
-  getGestureByID (id) {
-    const {savedGestures} = this.props;
+  const getGestureByID = (id) => {
     for (const gesture of savedGestures) {
       if (gesture.id === id) {
         return gesture;
       }
     }
     throw new Error(`Couldn't find session with id ${id}`);
-  }
+  };
 
-  onDraw (gesture) {
-    const {displayGesture} = this.props;
-    const pointers = this.convertCoordinates(gesture.actions);
+  const onDraw = (gesture) => {
+    const { displayGesture } = props;
+    const pointers = convertCoordinates(gesture.actions);
     displayGesture(pointers);
-  }
+  };
 
-  onPlay (gesture) {
-    const {applyClientMethod} = this.props;
-    const pointers = this.convertCoordinates(gesture.actions);
-    const actions = this.formatGesture(pointers);
+  const onPlay = (gesture) => {
+    const { applyClientMethod } = props;
+    const pointers = convertCoordinates(gesture.actions);
+    const actions = formatGesture(pointers);
     applyClientMethod({methodName: SCREENSHOT_INTERACTION_MODE.GESTURE, args: [actions]});
-  }
+  };
 
-  formatGesture (pointers) {
+  const formatGesture = (pointers) => {
     const actions = {};
     for (const pointer of pointers) {
       actions[pointer.name] = pointer.ticks.map((tick) => _.omit(tick, 'id'));
     }
     return actions;
-  }
+  };
 
-  convertCoordinates (pointers) {
-    const {width, height} = this.props.windowSize;
+  const convertCoordinates = (pointers) => {
+    const { windowSize } = props;
     const newPointers = JSON.parse(JSON.stringify(pointers));
     for (const pointer of newPointers) {
       for (const tick of pointer.ticks) {
         if (tick.type === POINTER_TYPES.POINTER_MOVE) {
-          tick.x = percentageToPixels(tick.x, width);
-          tick.y = percentageToPixels(tick.y, height);
+          tick.x = percentageToPixels(tick.x, windowSize.width);
+          tick.y = percentageToPixels(tick.y, windowSize.height);
         }
       }
     }
     return newPointers;
-  }
+  };
 
-  render () {
+  const dataSource = () => {
+    if (!savedGestures) { return []; }
+    return savedGestures.map((gesture) => ({
+      key: gesture.id,
+      Name: (gesture.name || '(Unnamed)'),
+      Created: moment(gesture.date).format('YYYY-MM-DD'),
+      Description: gesture.description || 'No Description',
+    }));
+  };
 
-    const {savedGestures, showGestureEditor, t} = this.props;
+  const columns = (Object.keys(SAVED_ACTIONS_OBJ)).map((key) => {
+    if (SAVED_ACTIONS_OBJ[key] === SAVED_ACTIONS_OBJ.ACTIONS) {
+      return {title: SAVED_ACTIONS_OBJ[key], key: SAVED_ACTIONS_OBJ[key], render: (_, record) => {
+        const gesture = getGestureByID(record.key);
+        return (
+          <div>
+            <Tooltip title={t('Play')}>
+              <Button key='play' type='primary' icon={<PlayCircleOutlined />} onClick={() => onPlay(gesture)}/>
+            </Tooltip>
+            <Button
+              icon={<EditOutlined/>}
+              onClick={() => loadSavedGesture(gesture)}
+            />
+            <Button
+              icon={<DeleteOutlined/>}
+              onClick={() => handleDelete(gesture.id)}/>
+          </div>
+        );
+      }};
+    } else {
+      return {title: SAVED_ACTIONS_OBJ[key], dataIndex: SAVED_ACTIONS_OBJ[key], key: SAVED_ACTIONS_OBJ[key]};
+    }
+  });
 
-    const dataSource = () => {
-      if (savedGestures) {
-        return savedGestures.map((gesture) => ({
-          key: gesture.id,
-          Name: (gesture.name || '(Unnamed)'),
-          Created: moment(gesture.date).format('YYYY-MM-DD'),
-          Description: gesture.description || 'No Description',
-        }));
-      } else {
-        return [];
-      }
-    };
+  useEffect(() => {
+    const { getSavedGestures } = props;
+    getSavedGestures();
+    return () => drawnGestureRef.current = null;
+  }, []);
 
-    const columns = (Object.keys(SAVED_ACTIONS_OBJ)).map((key) => {
-      if (SAVED_ACTIONS_OBJ[key] === SAVED_ACTIONS_OBJ.ACTIONS) {
-        return {title: SAVED_ACTIONS_OBJ[key], key: SAVED_ACTIONS_OBJ[key], render: (_, record) => {
-          const gesture = this.getGestureByID(record.key);
-          return (
-            <div>
-              <Tooltip title={t('Play')}>
-                <Button key='play' type='primary' icon={<PlayCircleOutlined />} onClick={() => this.onPlay(gesture)}/>
-              </Tooltip>
-              <Button
-                icon={<EditOutlined/>}
-                onClick={() => this.loadSavedGesture(gesture)}
-              />
-              <Button
-                icon={<DeleteOutlined/>}
-                onClick={this.handleDelete(gesture.id)}/>
-            </div>
-          );
-        }};
-      } else {
-        return {title: SAVED_ACTIONS_OBJ[key], dataIndex: SAVED_ACTIONS_OBJ[key], key: SAVED_ACTIONS_OBJ[key]};
-      }
-    });
-
-    return <Space className={InspectorStyles.spaceContainer} direction='vertical' size='middle'>
+  return (
+    <Space className={InspectorStyles.spaceContainer} direction='vertical' size='middle'>
       {t('gesturesDescription')}
       <Table
-        onRow={this.onRow}
+        onRow={(row) => ({onClick: () => onRowClick(row.key)})}
         pagination={false}
         dataSource={dataSource()}
         columns={columns}
@@ -154,8 +135,8 @@ class SavedGestures extends Component {
           icon={<PlusOutlined/>}
         />}
       />
-    </Space>;
-  }
-}
+    </Space>
+  );
+};
 
-export default withTranslation(SavedGestures);
+export default SavedGestures;

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -1,35 +1,29 @@
-import React, { Component } from 'react';
+import React, { useRef, useState } from 'react';
 import HighlighterRects from './HighlighterRects';
 import { Spin, Tooltip } from 'antd';
 import B from 'bluebird';
 import styles from './Inspector.css';
 import { SCREENSHOT_INTERACTION_MODE, INTERACTION_MODE, POINTER_TYPES,
          DEFAULT_TAP, DEFAULT_SWIPE } from './shared';
-import { withTranslation } from '../../util';
 
-const {POINTER_UP, POINTER_DOWN, PAUSE, POINTER_MOVE} = POINTER_TYPES;
-const {TAP, SELECT, SWIPE} = SCREENSHOT_INTERACTION_MODE;
+const { POINTER_UP, POINTER_DOWN, PAUSE, POINTER_MOVE } = POINTER_TYPES;
+const { TAP, SELECT, SWIPE } = SCREENSHOT_INTERACTION_MODE;
 const TYPES = {FILLED: 'filled', NEW_DASHED: 'newDashed', WHOLE: 'whole', DASHED: 'dashed'};
 
 /**
  * Shows screenshot of running application and divs that highlight the elements' bounding boxes
  */
-class Screenshot extends Component {
+const Screenshot = (props) => {
+  const { screenshot, mjpegScreenshotUrl, methodCallInProgress, screenshotInteractionMode, swipeStart, swipeEnd,
+          scaleRatio, selectedTick, selectedInteractionMode, applyClientMethod, t } = props;
 
-  constructor (props) {
-    super(props);
-    this.containerEl = null;
-    this.state = {
-      x: null,
-      y: null,
-    };
-  }
+  const containerEl = useRef();
+  const [x, setX] = useState();
+  const [y, setY] = useState();
 
-  async handleScreenshotClick () {
-    const {screenshotInteractionMode, applyClientMethod,
-           swipeStart, swipeEnd, setSwipeStart, setSwipeEnd, selectedTick, tapTickCoordinates} = this.props;
-    const {x, y} = this.state;
-    const {POINTER_NAME, DURATION_1, DURATION_2, BUTTON} = DEFAULT_TAP;
+  const handleScreenshotClick = async () => {
+    const { setSwipeStart, setSwipeEnd, tapTickCoordinates } = props;
+    const { POINTER_NAME, DURATION_1, DURATION_2, BUTTON } = DEFAULT_TAP;
 
     if (screenshotInteractionMode === TAP) {
       applyClientMethod({
@@ -53,130 +47,106 @@ class Screenshot extends Component {
       } else if (!swipeEnd) {
         setSwipeEnd(x, y);
         await B.delay(500); // Wait a second to do the swipe so user can see the SVG line
-        await this.handleDoSwipe();
+        await handleDoSwipe({x, y}); // Pass swipeEnd because otherwise it is not retrieved
       }
     }
-  }
+  };
 
-  handleMouseMove (e) {
-    const {screenshotInteractionMode, scaleRatio} = this.props;
-
-    if (screenshotInteractionMode !== SELECT) {
-      const offsetX = e.nativeEvent.offsetX;
-      const offsetY = e.nativeEvent.offsetY;
-      const x = offsetX * scaleRatio;
-      const y = offsetY * scaleRatio;
-      this.setState({
-        x: Math.round(x),
-        y: Math.round(y),
-      });
-    }
-  }
-
-  handleMouseOut () {
-    this.setState({
-      x: null,
-      y: null,
-    });
-  }
-
-  async handleDoSwipe () {
-    const {swipeStart, swipeEnd, clearSwipeAction, applyClientMethod} = this.props;
-    const {POINTER_NAME, DURATION_1, DURATION_2, BUTTON, ORIGIN} = DEFAULT_SWIPE;
+  const handleDoSwipe = async (swipeEndLocal) => {
+    const { clearSwipeAction } = props;
+    const { POINTER_NAME, DURATION_1, DURATION_2, BUTTON, ORIGIN } = DEFAULT_SWIPE;
     await applyClientMethod({
       methodName: SWIPE,
       args: {[POINTER_NAME]: [
         {type: POINTER_MOVE, duration: DURATION_1, x: swipeStart.x, y: swipeStart.y},
         {type: POINTER_DOWN, button: BUTTON},
-        {type: POINTER_MOVE, duration: DURATION_2, origin: ORIGIN, x: swipeEnd.x, y: swipeEnd.y},
+        {type: POINTER_MOVE, duration: DURATION_2, origin: ORIGIN, x: swipeEndLocal.x, y: swipeEndLocal.y},
         {type: POINTER_UP, button: BUTTON}
       ]},
     });
     clearSwipeAction();
-  }
+  };
+
+  const handleMouseMove = (e) => {
+    if (screenshotInteractionMode !== SELECT) {
+      const offsetX = e.nativeEvent.offsetX;
+      const offsetY = e.nativeEvent.offsetY;
+      const newX = offsetX * scaleRatio;
+      const newY = offsetY * scaleRatio;
+      setX(Math.round(newX));
+      setY(Math.round(newY));
+    }
+  };
+
+  const handleMouseOut = () => {
+    setX(null);
+    setY(null);
+  };
 
   // retrieve and format gesture for svg drawings
-  getGestureCoordinates () {
-    const {FILLED, NEW_DASHED, WHOLE, DASHED} = TYPES;
-    const {showGesture} = this.props;
+  const getGestureCoordinates = () => {
+    const { showGesture } = props;
+    const { FILLED, NEW_DASHED, WHOLE, DASHED } = TYPES;
     const defaultTypes = {pointerDown: WHOLE, pointerUp: DASHED};
-    if (showGesture) {
-      return showGesture.map((pointer) => {
-        // 'type' is used to keep track of the last pointerup/pointerdown move
-        let type = DASHED;
-        const temp = [];
-        for (const tick of pointer.ticks) {
-          if (tick.type !== PAUSE) {
-            const len = temp.length;
-            type = tick.type !== POINTER_MOVE ? defaultTypes[tick.type] : type;
-            if (tick.type === POINTER_MOVE && tick.x !== undefined && tick.y !== undefined) {
-              temp.push({id: tick.id, type, x: tick.x, y: tick.y, color: pointer.color});
-            }
-            if (len === 0) {
-              if (tick.type === POINTER_DOWN) {
-                temp.push({id: tick.id, type: FILLED, x: 0, y: 0, color: pointer.color});
-              }
-            } else {
-              if (tick.type === POINTER_DOWN && temp[len - 1].type === DASHED) {
-                temp[len - 1].type = FILLED;
-              }
-              if (tick.type === POINTER_UP && temp[len - 1].type === WHOLE) {
-                temp[len - 1].type = NEW_DASHED;
-              }
-            }
+
+    if (!showGesture) { return null; }
+    return showGesture.map((pointer) => {
+      // 'type' is used to keep track of the last pointerup/pointerdown move
+      let type = DASHED;
+      const temp = [];
+      for (const tick of pointer.ticks) {
+        if (tick.type === PAUSE) { continue; }
+        const len = temp.length;
+        type = tick.type !== POINTER_MOVE ? defaultTypes[tick.type] : type;
+        if (tick.type === POINTER_MOVE && tick.x !== undefined && tick.y !== undefined) {
+          temp.push({id: tick.id, type, x: tick.x, y: tick.y, color: pointer.color});
+        }
+        if (len === 0) {
+          if (tick.type === POINTER_DOWN) {
+            temp.push({id: tick.id, type: FILLED, x: 0, y: 0, color: pointer.color});
+          }
+        } else {
+          if (tick.type === POINTER_DOWN && temp[len - 1].type === DASHED) {
+            temp[len - 1].type = FILLED;
+          }
+          if (tick.type === POINTER_UP && temp[len - 1].type === WHOLE) {
+            temp[len - 1].type = NEW_DASHED;
           }
         }
-        return temp;
-      });
-    } else {
-      return null;
+      }
+      return temp;
+    });
+  };
+
+  // If we're tapping or swiping, show the 'crosshair' cursor style
+  const screenshotStyle = {};
+  if ([TAP, SWIPE].includes(screenshotInteractionMode) || selectedTick) {
+    screenshotStyle.cursor = 'crosshair';
+  }
+
+  let swipeInstructions = null;
+  if (screenshotInteractionMode === SWIPE && (!swipeStart || !swipeEnd)) {
+    if (!swipeStart) {
+      swipeInstructions = t('Click swipe start point');
+    } else if (!swipeEnd) {
+      swipeInstructions = t('Click swipe end point');
     }
   }
 
-  render () {
-    const {
-      screenshot,
-      mjpegScreenshotUrl,
-      methodCallInProgress,
-      screenshotInteractionMode,
-      swipeStart,
-      swipeEnd,
-      t,
-      scaleRatio,
-      selectedTick,
-      selectedInteractionMode
-    } = this.props;
-    const {x, y} = this.state;
+  const screenSrc = mjpegScreenshotUrl || `data:image/gif;base64,${screenshot}`;
+  const screenImg = <img src={screenSrc} id="screenshot" />;
+  const points = getGestureCoordinates();
 
-    // If we're tapping or swiping, show the 'crosshair' cursor style
-    const screenshotStyle = {};
-    if ([TAP, SWIPE].includes(screenshotInteractionMode) || selectedTick) {
-      screenshotStyle.cursor = 'crosshair';
-    }
-
-    let swipeInstructions = null;
-    if (screenshotInteractionMode === SWIPE && (!swipeStart || !swipeEnd)) {
-      if (!swipeStart) {
-        swipeInstructions = t('Click swipe start point');
-      } else if (!swipeEnd) {
-        swipeInstructions = t('Click swipe end point');
-      }
-    }
-
-    const screenSrc = mjpegScreenshotUrl || `data:image/gif;base64,${screenshot}`;
-    const screenImg = <img src={screenSrc} id="screenshot" />;
-
-    const points = this.getGestureCoordinates();
-
-    // Show the screenshot and highlighter rects.
-    // Show loading indicator if a method call is in progress, unless using MJPEG mode.
-    return <Spin size='large' spinning={!!methodCallInProgress && !mjpegScreenshotUrl}>
+  // Show the screenshot and highlighter rects.
+  // Show loading indicator if a method call is in progress, unless using MJPEG mode.
+  return (
+    <Spin size='large' spinning={!!methodCallInProgress && !mjpegScreenshotUrl}>
       <div className={styles.innerScreenshotContainer}>
-        <div ref={(containerEl) => { this.containerEl = containerEl; }}
+        <div ref={containerEl}
           style={screenshotStyle}
-          onClick={this.handleScreenshotClick.bind(this)}
-          onMouseMove={this.handleMouseMove.bind(this)}
-          onMouseOut={this.handleMouseOut.bind(this)}
+          onClick={handleScreenshotClick}
+          onMouseMove={handleMouseMove}
+          onMouseOut={handleMouseOut}
           className={styles.screenshotBox}>
           {screenshotInteractionMode !== SELECT && <div className={styles.coordinatesContainer}>
             <p>{t('xCoordinate', {x})}</p>
@@ -184,10 +154,9 @@ class Screenshot extends Component {
           </div>}
           {swipeInstructions && <Tooltip open={true} title={swipeInstructions} placement="topLeft">{screenImg}</Tooltip>}
           {!swipeInstructions && screenImg}
-          {screenshotInteractionMode === SELECT && this.containerEl && <HighlighterRects
-            {...this.props}
-            containerEl={this.containerEl}
-          />}
+          {screenshotInteractionMode === SELECT && containerEl.current &&
+            <HighlighterRects {...props} containerEl={containerEl.current} />
+          }
           {screenshotInteractionMode === SWIPE &&
             <svg className={styles.swipeSvg}>
               {swipeStart && !swipeEnd && <circle
@@ -209,30 +178,31 @@ class Screenshot extends Component {
             <svg key='gestureSVG' className={styles.gestureSvg}>
               {points.map((pointer) =>
                 pointer.map((tick, index) =>
-                  <>{index > 0 &&
-                        <line
-                          className={styles[tick.type]}
-                          key={`${tick.id}.line`}
-                          x1={pointer[index - 1].x / scaleRatio}
-                          y1={pointer[index - 1].y / scaleRatio}
-                          x2={tick.x / scaleRatio}
-                          y2={tick.y / scaleRatio}
-                          style={{stroke: tick.color}}
-                        />}
-                  <circle
-                    className={styles[`circle-${tick.type}`]}
-                    key={`${tick.id}.circle`}
-                    cx={tick.x / scaleRatio}
-                    cy={tick.y / scaleRatio}
-                    style={tick.type === TYPES.FILLED ?
-                      {fill: tick.color}
-                      :
-                      {stroke: tick.color}}/></>))}
-            </svg>}
+                  <>
+                    {index > 0 && <line
+                      className={styles[tick.type]}
+                      key={`${tick.id}.line`}
+                      x1={pointer[index - 1].x / scaleRatio}
+                      y1={pointer[index - 1].y / scaleRatio}
+                      x2={tick.x / scaleRatio}
+                      y2={tick.y / scaleRatio}
+                      style={{stroke: tick.color}} />
+                    }
+                    <circle
+                      className={styles[`circle-${tick.type}`]}
+                      key={`${tick.id}.circle`}
+                      cx={tick.x / scaleRatio}
+                      cy={tick.y / scaleRatio}
+                      style={tick.type === TYPES.FILLED ? {fill: tick.color} : {stroke: tick.color}} />
+                  </>
+                )
+              )}
+            </svg>
+          }
         </div>
       </div>
-    </Spin>;
-  }
-}
+    </Spin>
+  );
+};
 
-export default withTranslation(Screenshot);
+export default Screenshot;

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -1,24 +1,18 @@
-import React, { Component } from 'react';
+import React, { useRef } from 'react';
 import _ from 'lodash';
-import {getLocators} from './shared';
+import { getLocators } from './shared';
 import styles from './Inspector.css';
 import { Button, Row, Col, Input, Table, Alert, Tooltip, Select, Spin } from 'antd';
-import { withTranslation } from '../../util';
-import {clipboard, shell} from '../../polyfills';
-import {
-  LoadingOutlined,
-  CopyOutlined,
-  AimOutlined,
-  SendOutlined,
-  ClearOutlined,
-  HourglassOutlined,
-} from '@ant-design/icons';
+import { clipboard, shell } from '../../polyfills';
+import { LoadingOutlined, CopyOutlined, AimOutlined, SendOutlined,
+         ClearOutlined, HourglassOutlined } from '@ant-design/icons';
 import { ROW, ALERT } from '../AntdTypes';
 
-const ButtonGroup = Button.Group;
 const NATIVE_APP = 'NATIVE_APP';
+const CLASS_CHAIN_DOCS_URL = 'https://github.com/facebookarchive/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules';
+const PREDICATE_DOCS_URL = 'https://github.com/facebookarchive/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules';
 
-function selectedElementTableCell (text, copyToClipBoard) {
+const selectedElementTableCell = (text, copyToClipBoard) => {
   if (copyToClipBoard) {
     return <div className={styles['selected-element-table-cells']}>
       <Tooltip title='Copied!' trigger="click">
@@ -30,22 +24,21 @@ function selectedElementTableCell (text, copyToClipBoard) {
   } else {
     return <div className={styles['selected-element-table-cells']}>{text}</div>;
   }
-}
+};
 
 /**
  * Shows details of the currently selected element and shows methods that can
  * be called on the elements (tap, sendKeys)
  */
-class SelectedElement extends Component {
+const SelectedElement = (props) => {
+  const { applyClientMethod, contexts, currentContext, getFindElementsTimes, findElementsExecutionTimes,
+          isFindingElementsTimes, selectedElement, selectedElementId, sourceXML,
+          elementInteractionsNotAvailable, selectedElementSearchInProgress, t } = props;
 
-  constructor (props) {
-    super(props);
-    this.contextSelect = this.contextSelect.bind(this);
-  }
+  const sendKeys = useRef();
 
-  contextSelect () {
-    let {applyClientMethod, contexts, currentContext, setContext, t} = this.props;
-
+  const contextSelect = () => {
+    const { setContext } = props;
     return (
       <Tooltip title={t('contextSwitcher')}>
         <Select value={currentContext} onChange={(value) => {
@@ -59,256 +52,233 @@ class SelectedElement extends Component {
         </Select>
       </Tooltip>
     );
+  };
+
+  const { attributes, classChain, predicateString, xpath } = selectedElement;
+  const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
+
+  // Get the columns for the attributes table
+  let attributeColumns = [{
+    title: t('Attribute'),
+    dataIndex: 'name',
+    key: 'name',
+    width: 100,
+    render: (text) => selectedElementTableCell(text, false),
+  }, {
+    title: t('Value'),
+    dataIndex: 'value',
+    key: 'value',
+    render: (text) => selectedElementTableCell(text, true),
+  }];
+
+  // Get the data for the attributes table
+  let attrArray = _.toPairs(attributes).filter(([key]) => key !== 'path');
+  let dataSource = attrArray.map(([key, value]) => ({
+    key,
+    value,
+    name: key,
+  }));
+  dataSource.unshift({key: 'elementId', value: selectedElementId, name: 'elementId'});
+
+  // Get the columns for the strategies table
+  let findColumns = [{
+    title: t('Find By'),
+    dataIndex: 'find',
+    key: 'find',
+    width: 100,
+    render: (text) => selectedElementTableCell(text, false),
+  }, {
+    title: t('Selector'),
+    dataIndex: 'selector',
+    key: 'selector',
+    render: (text) => selectedElementTableCell(text, true),
+  }];
+
+  if (findElementsExecutionTimes.length > 0) {
+    findColumns.push({
+      title: t('Time'),
+      dataIndex: 'time',
+      key: 'time',
+      align: 'right',
+      width: 100,
+      render: (text) => selectedElementTableCell(text, false),
+    });
   }
 
-  render () {
-    let {
-      applyClientMethod,
-      contexts,
-      currentContext,
-      getFindElementsTimes,
-      findElementsExecutionTimes,
-      isFindingElementsTimes,
-      selectedElement,
-      selectedElementId: elementId,
-      sourceXML,
-      elementInteractionsNotAvailable,
-      selectedElementSearchInProgress,
-      t,
-    } = this.props;
-    const {attributes, classChain, predicateString, xpath} = selectedElement;
-    const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
+  // Get the data for the strategies table
+  let findDataSource = _.toPairs(getLocators(attributes, sourceXML)).map(([key, selector]) => ({
+    key,
+    selector,
+    find: key,
+  }));
 
-    // Get the columns for the attributes table
-    let attributeColumns = [{
-      title: t('Attribute'),
-      dataIndex: 'name',
-      key: 'name',
-      width: 100,
-      render: (text) => selectedElementTableCell(text, false),
+  // If XPath is the only provided data source, warn the user about it's brittleness
+  let showXpathWarning = false;
+  if (findDataSource.length === 0) {
+    showXpathWarning = true;
+  }
 
-    }, {
-      title: t('Value'),
-      dataIndex: 'value',
-      key: 'value',
-      render: (text) => selectedElementTableCell(text, true),
-    }];
+  // Add class chain to the data source as well
+  if (classChain && currentContext === NATIVE_APP) {
+    const classChainText = <span>
+      -ios class chain
+      <strong>
+        <a onClick={(e) => e.preventDefault() || shell.openExternal(CLASS_CHAIN_DOCS_URL)}>&nbsp;(docs)</a>
+      </strong>
+    </span>;
 
-    // Get the data for the attributes table
-    let attrArray = _.toPairs(attributes).filter(([key]) => key !== 'path');
-    let dataSource = attrArray.map(([key, value]) => ({
-      key,
-      value,
-      name: key,
-    }));
-    dataSource.unshift({key: 'elementId', value: elementId, name: 'elementId'});
+    findDataSource.push({
+      key: '-ios class chain',
+      find: classChainText,
+      selector: classChain,
+    });
+  }
 
-    // Get the columns for the strategies table
-    let findColumns = [{
-      title: t('Find By'),
-      dataIndex: 'find',
-      key: 'find',
-      width: 100,
-      render: (text) => selectedElementTableCell(text, false),
-    }, {
-      title: t('Selector'),
-      dataIndex: 'selector',
-      key: 'selector',
-      render: (text) => selectedElementTableCell(text, true),
-    }];
+  // Add predicate string to the data source as well
+  if (predicateString && currentContext === NATIVE_APP) {
+    const predicateStringText = <span>
+      -ios predicate string
+      <strong>
+        <a onClick={(e) => e.preventDefault() || shell.openExternal(PREDICATE_DOCS_URL)}>&nbsp;(docs)</a>
+      </strong>
+    </span>;
 
-    if (findElementsExecutionTimes.length > 0) {
-      findColumns.push({
-        title: t('Time'),
-        dataIndex: 'time',
-        key: 'time',
-        align: 'right',
-        width: 100,
-        render: (text) => selectedElementTableCell(text, false),
-      });
-    }
+    findDataSource.push({
+      key: '-ios predicate string',
+      find: predicateStringText,
+      selector: predicateString,
+    });
+  }
 
-    // Get the data for the strategies table
-    let findDataSource = _.toPairs(getLocators(attributes, sourceXML)).map(([key, selector]) => ({
-      key,
-      selector,
-      find: key,
-    }));
+  // Add XPath to the data source as well
+  if (xpath) {
+    findDataSource.push({
+      key: 'xpath',
+      find: 'xpath',
+      selector: xpath,
+    });
+  }
 
-    // If XPath is the only provided data source, warn the user about it's brittleness
-    let showXpathWarning = false;
-    if (findDataSource.length === 0) {
-      showXpathWarning = true;
-    }
+  // Replace table data with table data that has the times
+  if (findElementsExecutionTimes.length > 0) {
+    findDataSource = findElementsExecutionTimes;
+  }
 
-    // Add class chain to the data source as well
-    if (classChain && currentContext === NATIVE_APP) {
-      const classChainText = <span>
-        -ios class chain
-        <strong>
-          <a onClick={(e) => e.preventDefault() || shell.openExternal('https://github.com/facebookarchive/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules')}>&nbsp;(docs)</a>
-        </strong>
-      </span>;
+  let tapIcon = <AimOutlined/>;
+  if (!(elementInteractionsNotAvailable || selectedElementId) || selectedElementSearchInProgress) {
+    tapIcon = <LoadingOutlined/>;
+  }
 
-      findDataSource.push({
-        key: '-ios class chain',
-        find: classChainText,
-        selector: classChain,
-      });
-    }
-
-    // Add predicate string to the data source as well
-    if (predicateString && currentContext === NATIVE_APP) {
-      const predicateStringText = <span>
-        -ios predicate string
-        <strong>
-          <a onClick={(e) => e.preventDefault() || shell.openExternal('https://github.com/facebookarchive/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules')}>&nbsp;(docs)</a>
-        </strong>
-      </span>;
-
-      findDataSource.push({
-        key: '-ios predicate string',
-        find: predicateStringText,
-        selector: predicateString,
-      });
-    }
-
-    // Add XPath to the data source as well
-    if (xpath) {
-      findDataSource.push({
-        key: 'xpath',
-        find: 'xpath',
-        selector: xpath,
-      });
-    }
-
-    // Replace table data with table data that has the times
-    if (findElementsExecutionTimes.length > 0) {
-      findDataSource = findElementsExecutionTimes;
-    }
-
-    let tapIcon = <AimOutlined/>;
-    if (!(elementInteractionsNotAvailable || elementId) || selectedElementSearchInProgress) {
-      tapIcon = <LoadingOutlined/>;
-    }
-
-    return <div>
-      {elementInteractionsNotAvailable && <Row type={ROW.FLEX} gutter={10} className={styles.selectedElemNotInteractableAlertRow}>
+  return <div>
+    {elementInteractionsNotAvailable &&
+      <Row type={ROW.FLEX} gutter={10} className={styles.selectedElemNotInteractableAlertRow}>
         <Col>
           <Alert type={ALERT.INFO} message={t('interactionsNotAvailable')} showIcon />
         </Col>
-      </Row>}
-      <Row justify="center" type={ROW.FLEX} align="middle" className={styles.elementActions}>
-        <Tooltip title={t('Tap')}>
+      </Row>
+    }
+    <Row justify="center" type={ROW.FLEX} align="middle" className={styles.elementActions}>
+      <Tooltip title={t('Tap')}>
+        <Button
+          disabled={isDisabled}
+          icon={tapIcon}
+          id='btnTapElement'
+          onClick={() => applyClientMethod({methodName: 'click', elementId: selectedElementId})} />
+      </Tooltip>
+      <Button.Group className={styles.elementKeyInputActions}>
+        <Input className={styles.elementKeyInput}
+          disabled={isDisabled}
+          placeholder={t('Enter Keys to Send')}
+          allowClear={true}
+          onChange={(e) => sendKeys.current = e.target.value} />
+        <Tooltip title={t('Send Keys')}>
           <Button
             disabled={isDisabled}
-            icon={tapIcon}
-            id='btnTapElement'
-            onClick={() => applyClientMethod({methodName: 'click', elementId})}
-          />
+            id='btnSendKeysToElement'
+            icon={<SendOutlined/>}
+            onClick={() => applyClientMethod({methodName: 'sendKeys', elementId: selectedElementId, args: [sendKeys.current || '']})} />
         </Tooltip>
-        <ButtonGroup className={styles.elementKeyInputActions}>
-          <Input className={styles.elementKeyInput}
+        <Tooltip title={t('Clear')}>
+          <Button
             disabled={isDisabled}
-            placeholder={t('Enter Keys to Send')}
-            allowClear={true}
-            onChange={(e) => this.setState({sendKeys: e.target.value})}
-          />
-          <Tooltip title={t('Send Keys')}>
-            <Button
-              disabled={isDisabled}
-              id='btnSendKeysToElement'
-              icon={<SendOutlined/>}
-              onClick={() => applyClientMethod({methodName: 'sendKeys', elementId, args: [this.state.sendKeys || '']})}
-            />
-          </Tooltip>
-          <Tooltip title={t('Clear')}>
-            <Button
-              disabled={isDisabled}
-              id='btnClearElement'
-              icon={<ClearOutlined/>}
-              onClick={() => applyClientMethod({methodName: 'clear', elementId})}
-            />
-          </Tooltip>
-        </ButtonGroup>
-        <ButtonGroup>
-          <Tooltip title={t('Copy Attributes to Clipboard')}>
-            <Button
-              disabled={isDisabled}
-              id='btnCopyAttributes'
-              icon={<CopyOutlined/>}
-              onClick={() => clipboard.writeText(JSON.stringify(dataSource))}/>
-          </Tooltip>
-          <Tooltip title={t('Get Timing')}>
-            <Button
-              disabled={isDisabled}
-              id='btnGetTiming'
-              icon={<HourglassOutlined/>}
-              onClick={() => getFindElementsTimes(findDataSource)}
-            />
-          </Tooltip>
-        </ButtonGroup>
-      </Row>
-      {findDataSource.length > 0 &&
-        <Row>
-          <Spin spinning={isFindingElementsTimes}>
-            <Table
-              columns={findColumns}
-              dataSource={findDataSource}
-              size="small"
-              tableLayout='fixed'
-              pagination={false} />
-          </Spin>
-        </Row>
-      }
-      <br />
-      {currentContext === NATIVE_APP && showXpathWarning &&
-        <div>
-          <Alert
-            message={t('usingXPathNotRecommended')}
-            type={ALERT.WARNING}
-            showIcon
-          />
-          <br />
-        </div>
-      }
-      {currentContext === NATIVE_APP && contexts && contexts.length > 1 &&
-        <div>
-          <Alert
-            message={t('usingSwitchContextRecommended')}
-            type={ALERT.WARNING}
-            showIcon
-          />
-          <br />
-        </div>
-      }
-      {currentContext !== NATIVE_APP &&
-        <div>
-          <Alert
-            message={t('usingWebviewContext')}
-            type={ALERT.WARNING}
-            showIcon
-          />
-          <br />
-        </div>
-      }
-      {contexts && contexts.length > 1 &&
-        <div>
-          {this.contextSelect()}
-          <br /><br />
-        </div>
-      }
-      {dataSource.length > 0 &&
-        <Row>
+            id='btnClearElement'
+            icon={<ClearOutlined/>}
+            onClick={() => applyClientMethod({methodName: 'clear', elementId: selectedElementId})} />
+        </Tooltip>
+      </Button.Group>
+      <Button.Group>
+        <Tooltip title={t('Copy Attributes to Clipboard')}>
+          <Button
+            disabled={isDisabled}
+            id='btnCopyAttributes'
+            icon={<CopyOutlined/>}
+            onClick={() => clipboard.writeText(JSON.stringify(dataSource))} />
+        </Tooltip>
+        <Tooltip title={t('Get Timing')}>
+          <Button
+            disabled={isDisabled}
+            id='btnGetTiming'
+            icon={<HourglassOutlined/>}
+            onClick={() => getFindElementsTimes(findDataSource)} />
+        </Tooltip>
+      </Button.Group>
+    </Row>
+    {findDataSource.length > 0 &&
+      <Row>
+        <Spin spinning={isFindingElementsTimes}>
           <Table
-            columns={attributeColumns}
-            dataSource={dataSource}
+            columns={findColumns}
+            dataSource={findDataSource}
             size="small"
+            tableLayout='fixed'
             pagination={false} />
-        </Row>
-      }
-    </div>;
-  }
-}
+        </Spin>
+      </Row>
+    }
+    <br />
+    {currentContext === NATIVE_APP && showXpathWarning &&
+      <div>
+        <Alert
+          message={t('usingXPathNotRecommended')}
+          type={ALERT.WARNING}
+          showIcon />
+        <br />
+      </div>
+    }
+    {currentContext === NATIVE_APP && contexts && contexts.length > 1 &&
+      <div>
+        <Alert
+          message={t('usingSwitchContextRecommended')}
+          type={ALERT.WARNING}
+          showIcon />
+        <br />
+      </div>
+    }
+    {currentContext !== NATIVE_APP &&
+      <div>
+        <Alert
+          message={t('usingWebviewContext')}
+          type={ALERT.WARNING}
+          showIcon />
+        <br />
+      </div>
+    }
+    {contexts && contexts.length > 1 &&
+      <div>
+        {contextSelect()}
+        <br /><br />
+      </div>
+    }
+    {dataSource.length > 0 &&
+      <Row>
+        <Table
+          columns={attributeColumns}
+          dataSource={dataSource}
+          size="small"
+          pagination={false} />
+      </Row>
+    }
+  </div>;
+};
 
-export default withTranslation(SelectedElement);
+export default SelectedElement;

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -79,10 +79,6 @@ class SelectedElement extends Component {
     const {attributes, classChain, predicateString, xpath} = selectedElement;
     const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
 
-    if (!currentContext) {
-      currentContext = NATIVE_APP;
-    }
-
     // Get the columns for the attributes table
     let attributeColumns = [{
       title: t('Attribute'),

--- a/app/renderer/components/Inspector/SessionCodeBox.js
+++ b/app/renderer/components/Inspector/SessionCodeBox.js
@@ -1,63 +1,43 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Card, Tooltip, Button, Select } from 'antd';
 import { CopyOutlined, CodeOutlined } from '@ant-design/icons';
-import { withTranslation } from '../../util';
 import InspectorStyles from './Inspector.css';
 import frameworks from '../../lib/client-frameworks';
 import { highlight } from 'highlight.js';
 import { clipboard } from '../../polyfills';
 
-const Option = Select.Option;
+const SessionCodeBox = ({ actionFramework, setActionFramework, sessionDetails, t }) => {
 
-class SessionCodeBox extends Component {
-
-  code () {
-    let { sessionDetails, actionFramework } = this.props;
-    let {host, port, path, https, desiredCapabilities} = sessionDetails;
-
-    let framework = new frameworks[actionFramework](host, port, path,
-      https, desiredCapabilities);
-    let rawCode = framework.getCodeString(true);
+  const code = () => {
+    const { host, port, path, https, desiredCapabilities } = sessionDetails;
+    const framework = new frameworks[actionFramework](host, port, path, https, desiredCapabilities);
+    const rawCode = framework.getCodeString(true);
 
     return highlight(framework.language, rawCode, true).value;
-  }
+  };
 
-  actionBar () {
-    const { setActionFramework, actionFramework, t } = this.props;
+  const actionBar = () => <div>
+    <Select defaultValue={actionFramework} onChange={setActionFramework}
+      className={InspectorStyles['framework-dropdown']} size='small'>
+      {Object.keys(frameworks).map((f) =>
+        <Select.Option value={f} key={f}>{frameworks[f].readableName}</Select.Option>
+      )}
+    </Select>
+    <Tooltip title={t('Copy Code to Clipboard')}>
+      <Button
+        icon={<CopyOutlined/>}
+        onClick={() => clipboard.writeText(code())}
+        type='text' />
+    </Tooltip>
+  </div>;
 
-    let frameworkOpts = Object.keys(frameworks).map(
-      (f) => <Option value={f} key={f}>
-        {frameworks[f].readableName}
-      </Option>);
-
-    return <div>
-      <Select defaultValue={actionFramework} onChange={setActionFramework}
-        className={InspectorStyles['framework-dropdown']} size="small">
-        {frameworkOpts}
-      </Select>
-      <Tooltip title={t('Copy Code to Clipboard')}>
-        <Button
-          icon={<CopyOutlined/>}
-          onClick={() => clipboard.writeText(this.code())}
-          type='text'
-        />
-      </Tooltip>
-    </div>;
-  }
-
-  render () {
-    const { t } = this.props;
-
-    return <Card title={<span><CodeOutlined /> {t('Start this Kind of Session with Code')}</span>}
+  return (
+    <Card title={<span><CodeOutlined /> {t('Start this Kind of Session with Code')}</span>}
       className={InspectorStyles['recorded-actions']}
-      extra={this.actionBar()}
-    >
-      <div
-        className={InspectorStyles['recorded-code']}
-        dangerouslySetInnerHTML={{__html: this.code()}} />
+      extra={actionBar()}>
+      <div className={InspectorStyles['recorded-code']} dangerouslySetInnerHTML={{__html: code()}} />
+    </Card>
+  );
+};
 
-    </Card>;
-  }
-}
-
-export default withTranslation(SessionCodeBox);
+export default SessionCodeBox;

--- a/app/renderer/components/Inspector/SiriCommandModal.js
+++ b/app/renderer/components/Inspector/SiriCommandModal.js
@@ -1,46 +1,30 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Modal, Button, Input, Row } from 'antd';
-import { withTranslation } from '../../util';
 
-class SiriCommandModal extends Component {
+const SiriCommandModal = (props) => {
+  const { siriCommandValue, setSiriCommandValue, isSiriCommandModalVisible, t } = props;
 
-  onSubmit () {
-    const {
-      siriCommandValue,
-      hideSiriCommandModal,
-      applyClientMethod
-    } = this.props;
+  const onSubmit = () => {
+    const { applyClientMethod } = props;
     applyClientMethod({ methodName: 'executeScript', args: ['mobile:siriCommand', [{text: siriCommandValue}]]});
+    onCancel();
+  };
+
+  const onCancel = () => {
+    const { hideSiriCommandModal } = props;
     hideSiriCommandModal();
-  }
+  };
 
-  onCancel () {
-    const {hideSiriCommandModal} = this.props;
-    hideSiriCommandModal();
-  }
+  // Footer displays all the buttons at the bottom of the Modal
+  return <Modal open={isSiriCommandModalVisible}
+    title={t('Execute Siri Command')}
+    onCancel={onCancel}
+    footer={<Button onClick={onSubmit} type="primary">{t('Execute Command')}</Button>}>
+    <Row>
+      {t('Command')}
+      <Input.TextArea onChange={(e) => setSiriCommandValue(e.target.value)} value={siriCommandValue} />
+    </Row>
+  </Modal>;
+};
 
-  render () {
-    const {
-      siriCommandValue,
-      setSiriCommandValue,
-      isSiriCommandModalVisible,
-      t,
-    } = this.props;
-
-    // Footer displays all the buttons at the bottom of the Modal
-    return <Modal open={isSiriCommandModalVisible}
-      title={t('Execute Siri Command')}
-      onCancel={this.onCancel.bind(this)}
-      footer=
-        {[
-          <Button onClick={this.onSubmit.bind(this)} type="primary">{t('Execute Command')}</Button>
-        ]}>
-      <Row>
-        {t('Command')}
-        <Input.TextArea onChange={(e) => setSiriCommandValue(e.target.value)} value={siriCommandValue} />
-      </Row>
-    </Modal>;
-  }
-}
-
-export default withTranslation(SiriCommandModal);
+export default SiriCommandModal;

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -67,10 +67,10 @@ const Source = (props) => {
   const treeData = source && recursive(source);
 
   return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
+    {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
+    {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
     {/* Show loading indicator in MJPEG mode if a method call is in progress and source refresh is on */}
     <Spin size='large' spinning={!!methodCallInProgress && mjpegScreenshotUrl && isSourceRefreshOn}>
-      {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
-      {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
       {/* Must switch to a new antd Tree component when there's changes to treeData  */}
       {treeData ?
         <Tree

--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -1,8 +1,7 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Tree, Spin } from 'antd';
 import LocatorTestModal from './LocatorTestModal';
 import InspectorStyles from './Inspector.css';
-import { withTranslation } from '../../util';
 import SiriCommandModal from './SiriCommandModal';
 
 const IMPORTANT_ATTRS = [
@@ -16,10 +15,12 @@ const IMPORTANT_ATTRS = [
 /**
  * Shows the 'source' of the app as a Tree
  */
-class Source extends Component {
+const Source = (props) => {
+  const { source, sourceError, setExpandedPaths, expandedPaths, selectedElement = {}, showSourceAttrs,
+          methodCallInProgress, mjpegScreenshotUrl, isSourceRefreshOn, t } = props;
 
-  getFormattedTag (el, showAllAttrs) {
-    const {tagName, attributes} = el;
+  const getFormattedTag = (el, showAllAttrs) => {
+    const { tagName, attributes } = el;
     let attrs = [];
 
     for (let attr of Object.keys(attributes)) {
@@ -36,73 +37,57 @@ class Source extends Component {
     return <span>
       &lt;<b className={InspectorStyles.sourceTag}>{tagName}</b>{attrs}&gt;
     </span>;
-  }
+  };
 
   /**
    * Binds to antd Tree onSelect. If an item is being unselected, path is undefined
    * otherwise 'path' refers to the element's path.
    */
-  handleSelectElement (path) {
-    const {selectElement, unselectElement} = this.props;
+  const handleSelectElement = (path) => {
+    const { selectElement, unselectElement } = props;
 
     if (!path) {
       unselectElement();
     } else {
       selectElement(path);
     }
-  }
+  };
 
-  render () {
-    const {
-      source,
-      sourceError,
-      setExpandedPaths,
-      expandedPaths,
-      selectedElement = {},
-      showSourceAttrs,
-      methodCallInProgress,
-      mjpegScreenshotUrl,
-      isSourceRefreshOn,
-      t,
-    } = this.props;
-    const {path} = selectedElement;
+  // Recursives through the source and renders a TreeNode for an element
+  const recursive = (elemObj) => {
+    if (!((elemObj || {}).children || []).length) { return null; }
 
-    // Recursives through the source and renders a TreeNode for an element
-    let recursive = (elemObj) => {
-      if (!((elemObj || {}).children || []).length) {return null;}
+    return elemObj.children.map((el) => ({
+      title: getFormattedTag(el, showSourceAttrs),
+      key: el.path,
+      children: recursive(el),
+    }));
+  };
 
-      return elemObj.children.map((el) => ({
-        title: this.getFormattedTag(el, showSourceAttrs),
-        key: el.path,
-        children: recursive(el),
-      }));
-    };
+  const treeData = source && recursive(source);
 
-    const treeData = source && recursive(source);
-
-    return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
+  return <div id='sourceContainer' className={InspectorStyles['tree-container']} tabIndex="0">
+    {/* Show loading indicator in MJPEG mode if a method call is in progress and source refresh is on */}
+    <Spin size='large' spinning={!!methodCallInProgress && mjpegScreenshotUrl && isSourceRefreshOn}>
       {!source && !sourceError && <i>{t('Gathering initial app source…')}</i>}
       {sourceError && t('couldNotObtainSource', {errorMsg: JSON.stringify(sourceError)})}
-      {/* Show loading indicator in MJPEG mode if a method call is in progress and source refresh is on */}
-      <Spin size='large' spinning={!!methodCallInProgress && mjpegScreenshotUrl && isSourceRefreshOn}>
-        {/* Must switch to a new antd Tree component when there's changes to treeData  */}
-        {treeData ?
-          <Tree
-            defaultExpandAll={true}
-            onExpand={setExpandedPaths}
-            expandedKeys={expandedPaths}
-            onSelect={(selectedPaths) => this.handleSelectElement(selectedPaths[0])}
-            selectedKeys={[path]}
-            treeData={treeData} />
-          :
-          <Tree
-            treeData={[]} />
-        }
-      </Spin>
-      <LocatorTestModal {...this.props} />
-      <SiriCommandModal {...this.props} />
-    </div>;
-  }
-}
+      {/* Must switch to a new antd Tree component when there's changes to treeData  */}
+      {treeData ?
+        <Tree
+          defaultExpandAll={true}
+          onExpand={setExpandedPaths}
+          expandedKeys={expandedPaths}
+          onSelect={(selectedPaths) => handleSelectElement(selectedPaths[0])}
+          selectedKeys={[selectedElement.path]}
+          treeData={treeData} />
+        :
+        <Tree
+          treeData={[]} />
+      }
+    </Spin>
+    <LocatorTestModal {...props} />
+    <SiriCommandModal {...props} />
+  </div>;
+};
 
-export default withTranslation(Source);
+export default Source;

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -21,6 +21,7 @@ import { SET_SOURCE_AND_SCREENSHOT, QUIT_SESSION_REQUESTED, QUIT_SESSION_DONE,
 import { SCREENSHOT_INTERACTION_MODE, INTERACTION_MODE, APP_MODE } from '../components/Inspector/shared';
 
 const DEFAULT_FRAMEWORK = 'java';
+const NATIVE_APP = 'NATIVE_APP';
 
 const INITIAL_STATE = {
   savedGestures: [],
@@ -83,7 +84,7 @@ export default function inspector (state = INITIAL_STATE, action) {
         ...state,
         contexts: action.contexts,
         contextsError: action.contextsError,
-        currentContext: action.currentContext,
+        currentContext: action.currentContext || NATIVE_APP,
         currentContextError: action.currentContextError,
         source: action.source,
         sourceXML: action.sourceXML,


### PR DESCRIPTION
This PR continues the implementation of #879, covering almost all the components in the Session route. The two exceptions being `GestureEditor` and `Inspector`, which are the most complex components, so I thought it best to leave them for a separate PR.

As I expected, this was overall more complicated than Session, with more uses of React hooks. Like with Session, a few cleanups were also done here, mainly in `ElementLocator`, `LocatedElements`, and `HighlighterRects`.

Each individual component was tested to load and execute its main functionality.