### PR TITLE
fix: hide ugly scrollbars in Firefox

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -98,6 +98,7 @@
 .inspector-main :global(.ant-card-body) {
     height: calc(100% - 48px);
     padding: 12px;
+    scrollbar-width: none;  /* -webkit-scrollbar for Firefox */
 }
 
 .inspector-main .interaction-tab-container :global(.ant-tabs) {

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -101,6 +101,7 @@
 }
 
 .scrollingTab {
+  scrollbar-width: none; /* -webkit-scrollbar for Firefox */
   overflow-y: scroll;
   height: 100%;
 }


### PR DESCRIPTION
I opened the browser build in Firefox and was wondering why I was seeing scrollbars all over the place. Realised that `-webkit-scrollbar` doesn't apply to non-WebKit environments - who would have thought.
So here I've added a fix that _is only supported_ in Firefox. ([at least for now](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width#browser_compatibility))