### PR TITLE
fix: group gesture action buttons + add missing key for drawn gesture points

### DIFF
--- a/app/renderer/components/Inspector/SavedGestures.js
+++ b/app/renderer/components/Inspector/SavedGestures.js
@@ -97,18 +97,13 @@ const SavedGestures = (props) => {
       return {title: SAVED_ACTIONS_OBJ[key], key: SAVED_ACTIONS_OBJ[key], render: (_, record) => {
         const gesture = getGestureByID(record.key);
         return (
-          <div>
+          <Button.Group>
             <Tooltip title={t('Play')}>
               <Button key='play' type='primary' icon={<PlayCircleOutlined />} onClick={() => onPlay(gesture)}/>
             </Tooltip>
-            <Button
-              icon={<EditOutlined/>}
-              onClick={() => loadSavedGesture(gesture)}
-            />
-            <Button
-              icon={<DeleteOutlined/>}
-              onClick={() => handleDelete(gesture.id)}/>
-          </div>
+            <Button icon={<EditOutlined/>} onClick={() => loadSavedGesture(gesture)}/>
+            <Button icon={<DeleteOutlined/>} onClick={() => handleDelete(gesture.id)}/>
+          </Button.Group>
         );
       }};
     } else {

--- a/app/renderer/components/Inspector/Screenshot.js
+++ b/app/renderer/components/Inspector/Screenshot.js
@@ -178,7 +178,7 @@ const Screenshot = (props) => {
             <svg key='gestureSVG' className={styles.gestureSvg}>
               {points.map((pointer) =>
                 pointer.map((tick, index) =>
-                  <>
+                  <React.Fragment key={tick.id}>
                     {index > 0 && <line
                       className={styles[tick.type]}
                       key={`${tick.id}.line`}
@@ -194,7 +194,7 @@ const Screenshot = (props) => {
                       cx={tick.x / scaleRatio}
                       cy={tick.y / scaleRatio}
                       style={tick.type === TYPES.FILLED ? {fill: tick.color} : {stroke: tick.color}} />
-                  </>
+                  </React.Fragment>
                 )
               )}
             </svg>


### PR DESCRIPTION
Two small fixes for the saved gesture usage scenario:
* Use `Button.Group` for the saved gesture actions buttons (looks nicer)
* Add missing key for the drawn gesture points (otherwise React throws a warning)