### PR TITLE
fix: do not repeat notification about session closed due to inactivity

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -680,18 +680,6 @@ export function clearSwipeAction () {
   };
 }
 
-export function promptKeepAlive () {
-  return (dispatch) => {
-    dispatch({type: PROMPT_KEEP_ALIVE});
-  };
-}
-
-export function hideKeepAlivePrompt () {
-  return (dispatch) => {
-    dispatch({type: HIDE_PROMPT_KEEP_ALIVE});
-  };
-}
-
 export function selectCommandGroup (group) {
   return (dispatch) => {
     dispatch({type: SELECT_COMMAND_GROUP, group});
@@ -747,8 +735,7 @@ export function runKeepAliveLoop () {
       // If the new command limit has been surpassed, prompt user if they want to keep session going
       // Give them WAIT_FOR_USER_KEEP_ALIVE ms to respond
       if (now - lastActiveMoment > NO_NEW_COMMAND_LIMIT) {
-        const action = promptKeepAlive();
-        action(dispatch);
+        dispatch({type: PROMPT_KEEP_ALIVE});
 
         // After the time limit kill the session (this timeout will be killed if they keep it alive)
         const userWaitTimeout = setTimeout(() => {
@@ -783,8 +770,7 @@ export function killKeepAliveLoop () {
 export function keepSessionAlive () {
   return (dispatch, getState) => {
     const {userWaitTimeout} = getState().inspector;
-    const action = hideKeepAlivePrompt();
-    action(dispatch);
+    dispatch({type: HIDE_PROMPT_KEEP_ALIVE});
     dispatch({type: SET_LAST_ACTIVE_MOMENT, lastActiveMoment: +(new Date())});
     if (userWaitTimeout) {
       clearTimeout(userWaitTimeout);

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -722,10 +722,10 @@ export function setCommandArg (index, value) {
 export function runKeepAliveLoop () {
   return (dispatch, getState) => {
     dispatch({type: SET_LAST_ACTIVE_MOMENT, lastActiveMoment: Date.now()});
-    const {driver} = getState().inspector;
+    const { driver } = getState().inspector;
 
     const keepAliveInterval = setInterval(async () => {
-      const {lastActiveMoment} = getState().inspector;
+      const { lastActiveMoment, showKeepAlivePrompt } = getState().inspector;
       console.log('Pinging Appium server to keep session active'); // eslint-disable-line no-console
       try {
         await driver.getTimeouts(); // Pings the Appium server to keep it alive
@@ -734,7 +734,7 @@ export function runKeepAliveLoop () {
 
       // If the new command limit has been surpassed, prompt user if they want to keep session going
       // Give them WAIT_FOR_USER_KEEP_ALIVE ms to respond
-      if (now - lastActiveMoment > NO_NEW_COMMAND_LIMIT) {
+      if (now - lastActiveMoment > NO_NEW_COMMAND_LIMIT && !showKeepAlivePrompt) {
         dispatch({type: PROMPT_KEEP_ALIVE});
 
         // After the time limit kill the session (this timeout will be killed if they keep it alive)

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -110,7 +110,6 @@ export const TOGGLE_REFRESHING_STATE = 'TOGGLE_REFRESHING_STATE';
 
 const KEEP_ALIVE_PING_INTERVAL = 20 * 1000;
 const NO_NEW_COMMAND_LIMIT = 24 * 60 * 60 * 1000; // Set timeout to 24 hours
-const WAIT_FOR_USER_KEEP_ALIVE = 60 * 60 * 1000; // Give user 1 hour to reply
 
 // A debounced function that calls findElement and gets info about the element
 const findElement = _.debounce(async function (strategyMap, dispatch, getState, path) {
@@ -716,6 +715,12 @@ export function setCommandArg (index, value) {
   };
 }
 
+export function setUserWaitTimeout (userWaitTimeout) {
+  return (dispatch) => {
+    dispatch({type: SET_USER_WAIT_TIMEOUT, userWaitTimeout});
+  };
+}
+
 /**
  * Ping server every 30 seconds to prevent `newCommandTimeout` from killing session
  */
@@ -733,16 +738,8 @@ export function runKeepAliveLoop () {
       const now = Date.now();
 
       // If the new command limit has been surpassed, prompt user if they want to keep session going
-      // Give them WAIT_FOR_USER_KEEP_ALIVE ms to respond
       if (now - lastActiveMoment > NO_NEW_COMMAND_LIMIT && !showKeepAlivePrompt) {
         dispatch({type: PROMPT_KEEP_ALIVE});
-
-        // After the time limit kill the session (this timeout will be killed if they keep it alive)
-        const userWaitTimeout = setTimeout(() => {
-          const action = quitSession(i18n.t('Session closed due to inactivity'), false);
-          action(dispatch, getState);
-        }, WAIT_FOR_USER_KEEP_ALIVE);
-        dispatch({type: SET_USER_WAIT_TIMEOUT, userWaitTimeout});
       }
     }, KEEP_ALIVE_PING_INTERVAL);
     dispatch({type: SET_KEEP_ALIVE_INTERVAL, keepAliveInterval});

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -26,6 +26,7 @@ const MIN_HEIGHT = 610;
 const MAX_SCREENSHOT_WIDTH = 500;
 
 const MJPEG_STREAM_CHECK_INTERVAL = 1000;
+const SESSION_EXPIRY_PROMPT_TIMEOUT = 60 * 60 * 1000; // Give user 1 hour to reply
 
 const downloadXML = (sourceXML) => {
   let element = document.createElement('a');
@@ -41,8 +42,8 @@ const downloadXML = (sourceXML) => {
 
 const Inspector = (props) => {
   const { screenshot, screenshotError, selectedElement = {}, quitSession, showRecord,
-          screenshotInteractionMode, visibleCommandMethod,
-          selectedInteractionMode, selectInteractionMode, setVisibleCommandResult,
+          screenshotInteractionMode, visibleCommandMethod, selectedInteractionMode,
+          selectInteractionMode, setVisibleCommandResult, setUserWaitTimeout,
           showKeepAlivePrompt, keepSessionAlive, sourceXML, visibleCommandResult,
           mjpegScreenshotUrl, isAwaitingMjpegStream, toggleShowCentroids, showCentroids,
           isGestureEditorVisible, toggleShowAttributes, isSourceRefreshOn, windowSize, t } = props;
@@ -164,6 +165,16 @@ const Inspector = (props) => {
       }
     };
   }, [JSON.stringify(windowSize)]);
+
+  // If session expiry prompt is shown, start timeout until session is automatically quit
+  useEffect(() => {
+    if (showKeepAlivePrompt) {
+      const userWaitTimeout = setTimeout(() => {
+        quitSession(t('Session closed due to inactivity'), false);
+      }, SESSION_EXPIRY_PROMPT_TIMEOUT);
+      setUserWaitTimeout(userWaitTimeout);
+    }
+  }, [showKeepAlivePrompt]);
 
   const screenShotControls = <div className={InspectorStyles['screenshot-controls']}>
     <Space size='middle'>

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -167,6 +167,7 @@ const Inspector = (props) => {
   }, [JSON.stringify(windowSize)]);
 
   // If session expiry prompt is shown, start timeout until session is automatically quit
+  // Timeout is canceled if user selects either action in prompt (keep session alive or quit)
   useEffect(() => {
     if (showKeepAlivePrompt) {
       const userWaitTimeout = setTimeout(() => {

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -492,7 +492,7 @@ export default function inspector (state = INITIAL_STATE, action) {
     case SET_USER_WAIT_TIMEOUT:
       return {
         ...state,
-        userWaitTimeout: null,
+        userWaitTimeout: action.userWaitTimeout,
       };
 
     case SET_LAST_ACTIVE_MOMENT:


### PR DESCRIPTION
This PR fixes issues with the session expiry prompt and timeouts, which could have caused repeated 'Session closed' errors to be shown after the session had already been closed.
The timeout functionality that handles the expiry of this inactivity prompt has also been moved directly to the Inspector component. This is done in preparation for #882.