### PR TITLE
chore: fix missing highlighter key

### DIFF
--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -194,6 +194,7 @@ const HighlighterRects = (props) => {
         elSize={size}
         elLocation={elLocation}
         scaleRatio={scaleRatio}
+        key={`el.${elLocation.x}.${elLocation.y}.${size.width}.${size.height}`}
         xOffset={highlighterXOffset} />
     );
   }


### PR DESCRIPTION
Quick PR to add a `key` property that React was complaining about.
This key is for a highlighter shown when selecting a found element, so its only properties are its dimensions, and the key must be assembled from all of them in order to be uniquely rendered.