### PR TITLE
fix: resolve issue with unwanted incremental scaling in landscape

### DIFF
--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -84,7 +84,6 @@ const Inspector = (props) => {
 
     const imgRect = img.getBoundingClientRect();
     const screenshotRect = screenshotBox.getBoundingClientRect();
-    screenshotBox.style.flexBasis = `${imgRect.width}px`;
     if (imgRect.height < screenshotRect.height) {
       // get what the img width would be if it fills screenshot box height
       const attemptedWidth = (screenshotRect.height / imgRect.height) * imgRect.width;


### PR DESCRIPTION
This fixes a problem I've mainly noticed when working with an app in landscape orientation.
When opening such an app with the default inspector app window dimensions, the screenshot width is around 450 pixels. However, if I refresh the source, the screenshot width slightly increases, and continues increasing until it reaches the max limit of 500 pixels:

https://github.com/appium/appium-inspector/assets/37242620/f95dafba-0445-406d-9064-75861616a0ac

Now, the default screenshot width is a bit smaller at 430 pixels, but it no longer changes upon source refresh:

https://github.com/appium/appium-inspector/assets/37242620/9ef0b346-7013-40b2-bbeb-e4296fd31bde



Of course, the screenshot size can still be adjusted by changing the app window size.

