### PR TITLE
fix: slightly adjust element highlighter placement

### DIFF
--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -59,7 +59,6 @@
 .inspector-main .screenshot-container img {
     max-width: 100%;
     max-height: 100%;
-    border: 1px solid #eee;
     box-shadow: 0px 0px 1px 2px rgba(0, 0, 0, 0.05);
 }
 

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -63,10 +63,7 @@ const Inspector = (props) => {
 
   // Calculate the ratio for scaling items overlaid on the screenshot
   // (highlighter rectangles/circles, gestures, etc.)
-  const updateScaleRatio = () => {
-    const screenshotImg = screenshotEl.current.querySelector('img');
-    setScaleRatio(windowSize.width / screenshotImg.offsetWidth);
-  };
+  const updateScaleRatio = (imgWidth) => setScaleRatio(windowSize.width / imgWidth);
 
   const updateScaleRatioDebounced = debounce(updateScaleRatio, 500);
 
@@ -94,7 +91,7 @@ const Inspector = (props) => {
       screenshotBox.style.maxWidth = `${imgRect.width}px`;
     }
 
-    updateScaleRatioDebounced();
+    updateScaleRatioDebounced(imgRect.width);
   };
 
   const updateSourceTreeWidthDebounced = debounce(updateSourceTreeWidth, 50);


### PR DESCRIPTION
This PR slightly adjusts the placement of element highlighters over the app screenshot:
* Remove the border around the app screenshot - highlighters were taking it into account
* Do not truncate the image width when calculating the scale ratio (use `width` instead of `offsetWidth`)
  * Since this width was already retrieved in the parent method, it is now being passed as a parameter, which allows to remove one `querySelector` request