### PR TITLE
fix: improve screen size calculation for Android landscape mode & when changing orientation

### DIFF
--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -201,14 +201,18 @@ export default class AppiumClient {
     let windowSize, windowSizeError;
     const {client: {capabilities: {deviceScreenSize, platformName, automationName}}} = this.driver;
     try {
-      // The call doesn't need to be made for Android for two reasons
-      // - when appMode is hybrid Chrome driver doesn't know this command
-      // - the data is already on the driver
+      windowSize = await this.driver.getWindowRect();
       if (_.toLower(platformName) === 'android' && _.toLower(automationName) === 'uiautomator2') {
+        // returned Android height and width can both be affected by UiAutomator2 calculations
+        // we stick with device dimensions, but swap them depending on detected orientation
         const [width, height] = deviceScreenSize.split('x');
-        windowSize = {width, height, x: 0, y: 0};
-      } else {
-        windowSize = await this.driver.getWindowRect();
+        if (windowSize.height > windowSize.width) { // portrait mode
+          windowSize.height = height;
+          windowSize.width = width;
+        } else { // landscape mode
+          windowSize.height = width;
+          windowSize.width = height;
+        }
       }
     } catch (e) {
       windowSizeError = e;


### PR DESCRIPTION
This PR improves the screen size calculation specifically when using UiAutomator2, either in landscape mode, or when changing device orientation in any way. It also fixes #665 and fixes #701.
The core issue was caused by the window width and height being effectively hardcoded to portrait mode.

The fix reuses the existing `driver.getWindowRect` call to check the current dimensions (which may be smaller than the full screen size, due to UiAutomator2 calculations that I will discuss in a separate issue). The dimensions are then used only to determine the screen orientation, and the actual values are still taken from the full screen size, as before. This means that portrait mode behavior is entirely unchanged.

Due to the aforementioned UiAutomator2 calculations, as well as some webview adjustments that I need to look into, the highlighter positions are still not perfect. But I believe that this change already improves the situation.
Here is a comparison for the rarest case, webview in landscape. This is how it looked before this fix:
![webview-landscape-before](https://github.com/appium/appium-inspector/assets/37242620/669be9b4-8f99-401d-89a1-3a24b23209c7)
In the app source, I have selected the link element for the Google account button. We can see that in the screenshot, the highlighter is not visible, as it has been cut off. What's more, changing the inspector window size here would further break these positions.
And this is how it looks after this fix:
![webview-landscape-after](https://github.com/appium/appium-inspector/assets/37242620/3c0c5395-34e1-489f-89a7-8402aeb0f0ea)
The widths and X-positions for all highlighters have been fixed, and the requested highlighter is not longer cut off. Changing the inspector window size also does not break this. Still, you can still see that there is an unwanted Y-axis offset, which will be addressed in the future.

I also noticed a code comment that `driver.getWindowRect` was previously not called here due to Chrome not supporting this command - it was apparently added in Chrome 65 (released March 2018), so it should be safe to cut off support for any versions older than that.