### PR TITLE
fix: resolve issue with leftover expand centroid

### DIFF
--- a/app/renderer/components/Inspector/HighlighterRects.js
+++ b/app/renderer/components/Inspector/HighlighterRects.js
@@ -85,7 +85,7 @@ const HighlighterRects = (props) => {
         accessible: source.attributes ? source.attributes.accessible : null
       }
     };
-    const coordinates = `${obj.properties.centerX}.${obj.properties.centerY}`;
+    const coordinates = `${obj.properties.centerX},${obj.properties.centerY}`;
     obj.properties.container = isElementContainer(obj, elements);
 
     elements.push(obj);


### PR DESCRIPTION
Caught this bug by accident. It could cause React to throw a warning about duplicate keys, and render an expand centroid at the screenshot's top left corner, which would remain visible even after hiding centroids, likely until the session would be closed.

The problem was caused by a possible overlap between element highlighter keys and centroid keys.
Element highlighter keys are their index in the source tree, separated by dots, meaning the first child of the root would have the key `0.0`.
Centroid keys are their coordinates, but also separated by a dot, so a centroid at (x:0, y:0) would also have the key `0.0`.
The issue was resolved by using a comma when creating the centroid key.