### PR TITLE
fix: improve highlighter positions in webview

### DIFF
--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -251,7 +251,7 @@ export default class AppiumClient {
       await this.driver.switchContext(NATIVE_APP);
     }
 
-    const { statBarHeight, viewportRect } = await this.driver.getSession();
+    const sessionDetails = await this.driver.getSession();
     const isAndroid = this.driver.client.isAndroid;
 
     // Get all available contexts (or the error, if one appears)
@@ -274,7 +274,7 @@ export default class AppiumClient {
           webviewLeftOffset = x;
         } else {
           // fallback to default top offset value if element retrieval failed
-          webviewTopOffset = viewportRect.top;
+          webviewTopOffset = sessionDetails.viewportRect.top;
         }
       } else if (this.driver.client.isIOS) {
         // on iOS, find the top status bar and address bar and use its Y endpoint
@@ -285,7 +285,7 @@ export default class AppiumClient {
         }
         // in landscape mode, there is empty space on both sides (at default zoom level), so add offset for that too
         if (windowSize.height < windowSize.width) {
-          webviewLeftOffset = statBarHeight;
+          webviewLeftOffset = sessionDetails.statBarHeight;
         }
       }
 

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -9,7 +9,7 @@ const { TAP, SWIPE, GESTURE } = SCREENSHOT_INTERACTION_MODE;
 const ANDROID_WEBVIEW_SELECTOR = '//android.webkit.WebView[1]';
 // Selector for the iOS status bar and Safari address bar - not always present
 const IOS_TOP_CONTROLS_SELECTOR = '**/XCUIElementTypeOther[`name CONTAINS "SafariWindow"`]' +
-  '/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther';
+  '/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther[1]';
 
 export const NATIVE_APP = 'NATIVE_APP';
 let _instance = null;

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -274,7 +274,13 @@ export default class AppiumClient {
           webviewLeftOffset = x;
         } else {
           // fallback to default top offset value if element retrieval failed
-          webviewTopOffset = sessionDetails.viewportRect.top;
+          try {
+            const systemBars = await this.driver.executeScript('mobile:getSystemBars', []);
+            webviewTopOffset = systemBars.statusBar.height;
+          } catch (e) {
+            // in case driver does not support mobile:getSystemBars
+            webviewTopOffset = sessionDetails.viewportRect.top;
+          }
         }
       } else if (this.driver.client.isIOS) {
         // on iOS, find the top status bar and address bar and use its Y endpoint
@@ -285,7 +291,13 @@ export default class AppiumClient {
         }
         // in landscape mode, there is empty space on both sides (at default zoom level), so add offset for that too
         if (windowSize.height < windowSize.width) {
-          webviewLeftOffset = sessionDetails.statBarHeight;
+          try {
+            const deviceScreenInfo = await this.driver.executeScript('mobile:deviceScreenInfo', []);
+            webviewLeftOffset = deviceScreenInfo.statusBarSize.height;
+          } catch (e) {
+            // in case driver does not support mobile:deviceScreenInfo
+            webviewLeftOffset = sessionDetails.statBarHeight;
+          }
         }
       }
 

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -269,8 +269,9 @@ export default class AppiumClient {
         // on Android, find the root webview element and use its Y startpoint
         const webview = await this.fetchElement({strategy: 'xpath', selector: ANDROID_WEBVIEW_SELECTOR});
         if (webview.el) {
-          const { y } = await webview.el.getRect();
+          const { x, y } = await webview.el.getRect();
           webviewTopOffset = y;
+          webviewLeftOffset = x;
         }
       } else {
         // on iOS, find the top status bar and address bar and use its Y endpoint

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -266,7 +266,7 @@ export default class AppiumClient {
     // to account for any top and left offsets
     if (currentContext !== NATIVE_APP) {
       if (isAndroid) {
-        // on Android, find the root webview element and use its Y startpoint
+        // on Android, find the root webview element and use its X and Y startpoints
         const webview = await this.fetchElement({strategy: 'xpath', selector: ANDROID_WEBVIEW_SELECTOR});
         if (webview.el) {
           const { x, y } = await webview.el.getRect();

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -6,7 +6,7 @@ import { SCREENSHOT_INTERACTION_MODE, APP_MODE } from '../components/Inspector/s
 const { TAP, SWIPE, GESTURE } = SCREENSHOT_INTERACTION_MODE;
 
 // Selector for the Android webview - includes the correct top and bottom boundaries
-const ANDROID_WEBVIEW_SELECTOR = '//android.webkit.WebView[1]';
+const ANDROID_WEBVIEW_SELECTOR = 'android.webkit.WebView';
 // Selector for the iOS status bar and Safari address bar - not always present
 const IOS_TOP_CONTROLS_SELECTOR = '**/XCUIElementTypeOther[`name CONTAINS "SafariWindow"`]' +
   '/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther[1]';
@@ -267,7 +267,7 @@ export default class AppiumClient {
     if (currentContext !== NATIVE_APP) {
       if (isAndroid) {
         // on Android, find the root webview element and use its X and Y startpoints
-        const webview = await this.fetchElement({strategy: 'xpath', selector: ANDROID_WEBVIEW_SELECTOR});
+        const webview = await this.fetchElement({strategy: 'class name', selector: ANDROID_WEBVIEW_SELECTOR});
         if (webview.el) {
           const { x, y } = await webview.el.getRect();
           webviewTopOffset = y;

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -1,9 +1,15 @@
 import _ from 'lodash';
 import Bluebird from 'bluebird';
-import {getWebviewStatusAddressBarHeight, parseSource, setHtmlElementAttributes} from './webview-helpers';
-import {SCREENSHOT_INTERACTION_MODE, APP_MODE} from '../components/Inspector/shared';
+import { parseSource, setHtmlElementAttributes } from './webview-helpers';
+import { SCREENSHOT_INTERACTION_MODE, APP_MODE } from '../components/Inspector/shared';
 
-const {TAP, SWIPE, GESTURE} = SCREENSHOT_INTERACTION_MODE;
+const { TAP, SWIPE, GESTURE } = SCREENSHOT_INTERACTION_MODE;
+
+// Selector for the Android webview - includes the correct top and bottom boundaries
+const ANDROID_WEBVIEW_SELECTOR = '//android.webkit.WebView[1]';
+// Selector for the iOS status bar and Safari address bar - not always present
+const IOS_TOP_CONTROLS_SELECTOR = '**/XCUIElementTypeOther[`name CONTAINS "SafariWindow"`]' +
+  '/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther/XCUIElementTypeOther';
 
 export const NATIVE_APP = 'NATIVE_APP';
 let _instance = null;
@@ -116,7 +122,7 @@ export default class AppiumClient {
       windowSizeUpdate = await this.getWindowUpdate();
       // only do context updates if user has selected web/hybrid mode (takes forever)
       if (appMode === APP_MODE.WEB_HYBRID) {
-        contextUpdate = await this.getContextUpdate();
+        contextUpdate = await this.getContextUpdate(windowSizeUpdate);
       }
       sourceUpdate = await this.getSourceUpdate();
     }
@@ -221,34 +227,34 @@ export default class AppiumClient {
     return {windowSize, windowSizeError};
   }
 
-  async getContextUpdate () {
-    let contexts,
-        contextsError,
-        currentContext,
-        currentContextError,
-        pixelRatio,
-        platformName,
-        statBarHeight,
-        viewportRect,
-        webViewPosition;
+  // Retrieve all detected contexts, as well as the current context
+  // If retrieval of either one fails, return the error(s)
+  // Additionally, if webview is used, adjust the found element positions to fit screenshot
+  // Only called while in hybrid mode
+  async getContextUpdate ({ windowSize }) {
+    let contexts, contextsError, currentContext, currentContextError, webviewTopOffset;
+    let webviewLeftOffset = 0;
+
     if (!await this.hasContextsCommand()) {
       return {currentContext: null, contexts: []};
     }
 
+    // First get the current context (or the error, if one appears)
     try {
       currentContext = await this.driver.getContext();
     } catch (e) {
       currentContextError = e;
     }
 
-    // Note: These methods need to be executed in the native context because ChromeDriver behaves differently
+    // The retrieval of all contexts and webview position adjustments require some native context use
     if (currentContext !== NATIVE_APP) {
       await this.driver.switchContext(NATIVE_APP);
     }
 
-    ({platformName, pixelRatio, statBarHeight, viewportRect} = await this.driver.getSession());
+    const { platformName, statBarHeight, viewportRect } = await this.driver.getSession();
     const isAndroid = _.toLower(platformName) === 'android';
 
+    // Get all available contexts (or the error, if one appears)
     try {
       contexts = await this.driver.executeScript('mobile:getContexts', []);
       contexts = isAndroid ? this.parseAndroidContexts(contexts) : contexts;
@@ -256,55 +262,43 @@ export default class AppiumClient {
       contextsError = e;
     }
 
-
+    // For webview context, the viewport needs to be recalculated
+    // to account for any top and left offsets
     if (currentContext !== NATIVE_APP) {
-      try {
-        // Get the webview offset
-        if (viewportRect) {
-          // The viewport rectangles are based on the screen density,
-          // iOS needs CSS pixels
-          webViewPosition = {
-            x: isAndroid ? viewportRect.left : Math.round(viewportRect.left / pixelRatio),
-            y: isAndroid ? viewportRect.top : Math.round(viewportRect.top / pixelRatio),
-          };
-        } else {
-          // Fallback
-          const el = await this.driver.findElement(
-            isAndroid ? 'xpath' : '-ios class chain',
-            isAndroid ? '//android.webkit.WebView' : '**/XCUIElementTypeWebView'
-          );
-          if (el) {
-            webViewPosition = await el.getRect();
-          }
+      if (isAndroid) {
+        // on Android, find the root webview element and use its Y startpoint
+        const webview = await this.fetchElement({strategy: 'xpath', selector: ANDROID_WEBVIEW_SELECTOR});
+        if (webview.el) {
+          const { y } = await webview.el.getRect();
+          webviewTopOffset = y;
         }
-      } catch (ign) {
+      } else {
+        // on iOS, find the top status bar and address bar and use its Y endpoint
+        const topBar = await this.fetchElement({strategy: '-ios class chain', selector: IOS_TOP_CONTROLS_SELECTOR});
+        if (topBar.el) {
+          const { y, height } = await topBar.el.getRect();
+          webviewTopOffset = y + height;
+        }
+        // on landscape mode, there is empty space on both sides (at default zoom level), so add offset for that too
+        if (windowSize.height < windowSize.width) {
+          webviewLeftOffset = statBarHeight;
+        }
       }
-      await this.driver.switchContext(currentContext);
-    }
 
-    /**
-     * If its a webview then update the HTML with the element location
-     * so the source can be used in the native inspector
-     */
-    try {
-      if (currentContext !== NATIVE_APP) {
-        // Fallback if the webview position can't be determined,
-        // then do it based on the web context
-        if (!webViewPosition) {
-          webViewPosition = {
-            x: 0,
-            y: await this.driver.executeScript(
-              `return (${getWebviewStatusAddressBarHeight}).apply(null, arguments)`,
-              [{platformName, statBarHeight}],
-            ),
-          };
-        }
-        await this.driver.executeScript(
-          `return (${setHtmlElementAttributes}).apply(null, arguments)`,
-          [{platformName, webviewStatusAddressBarHeight: webViewPosition.y}],
-        );
+      // if element retrieval failed for any reason (e.g. bars can be hidden on iOS),
+      // fallback to default value, depending on platform
+      if (webviewTopOffset === undefined) {
+        webviewTopOffset = isAndroid ? viewportRect.top : 0;
       }
-    } catch (ign) {
+
+      // Native context calculation part is done - switch back to webview context
+      await this.driver.switchContext(currentContext);
+
+      // Adjust all elements by the calculated offsets
+      await this.driver.executeScript(
+        `return (${setHtmlElementAttributes}).apply(null, arguments)`,
+        [{platformName, webviewTopOffset, webviewLeftOffset}],
+      );
     }
 
     return {contexts, contextsError, currentContext, currentContextError};

--- a/app/renderer/lib/webview-helpers.js
+++ b/app/renderer/lib/webview-helpers.js
@@ -1,37 +1,5 @@
-import {load} from 'cheerio';
-import {parseDocument} from 'htmlparser2';
-
-/**
- * JS code that is executed in the webview to determine the status+address bar height
- *
- * NOTE:
- * object destructuring the arguments resulted in this error with iOS (not with Android)
- *
- * `Duplicate parameter 'e' not allowed in function with destructuring parameters.`
- *
- * That's why the object destructuring is done in the method itself
- */
-export function getWebviewStatusAddressBarHeight (obj) {
-  // Calculate the status + address bar height
-  // Address bar height for iOS 11+ is 50, for lower it is 44,
-  // but we take 50 as a default here
-  // For Chrome it is 56 for Android 6 to 10
-  const {platformName, statBarHeight} = obj;
-  const isAndroid = platformName.toLowerCase() === 'android';
-  // iOS uses CSS sizes for elements and screenshots, Android sizes times DRP
-  const dpr = isAndroid ? window.devicePixelRatio : 1;
-  const screenHeight = window.screen.height;
-  const viewportHeight = window.innerHeight;
-  // Need to determine this later for Chrome
-  const osAddressBarDefaultHeight = isAndroid ? 56 : 50;
-  const addressToolBarHeight = screenHeight - viewportHeight - statBarHeight;
-  // When a manual scroll has been executed for iOS and Android
-  // the address bar becomes smaller
-  const addressBarHeight = (addressToolBarHeight >= 0) && (addressToolBarHeight - osAddressBarDefaultHeight) < 0
-    ? addressToolBarHeight : osAddressBarDefaultHeight;
-
-  return statBarHeight + (addressBarHeight * dpr);
-}
+import { load } from 'cheerio';
+import { parseDocument } from 'htmlparser2';
 
 /**
  * JS code that is executed in the webview to set the needed attributes on the DOM so the source can be used for the
@@ -45,7 +13,7 @@ export function getWebviewStatusAddressBarHeight (obj) {
  * That's why the object destructuring is done in the method itself
  */
 export function setHtmlElementAttributes (obj) {
-  const {platformName, webviewStatusAddressBarHeight} = obj;
+  const { platformName, webviewTopOffset, webviewLeftOffset } = obj;
   const htmlElements = document.body.getElementsByTagName('*');
   const isAndroid = platformName.toLowerCase() === 'android';
   // iOS uses CSS sizes for elements and screenshots, Android sizes times DRP
@@ -56,8 +24,8 @@ export function setHtmlElementAttributes (obj) {
 
     el.setAttribute('data-appium-inspector-width', Math.round(rect.width * dpr));
     el.setAttribute('data-appium-inspector-height', Math.round(rect.height * dpr));
-    el.setAttribute('data-appium-inspector-x', Math.round(rect.left * dpr));
-    el.setAttribute('data-appium-inspector-y', Math.round(webviewStatusAddressBarHeight + (rect.top * dpr)));
+    el.setAttribute('data-appium-inspector-x', Math.round(webviewLeftOffset + (rect.left * dpr)));
+    el.setAttribute('data-appium-inspector-y', Math.round(webviewTopOffset + (rect.top * dpr)));
   });
 }
 

--- a/app/renderer/lib/webview-helpers.js
+++ b/app/renderer/lib/webview-helpers.js
@@ -13,10 +13,10 @@ import { parseDocument } from 'htmlparser2';
  * That's why the object destructuring is done in the method itself
  */
 export function setHtmlElementAttributes (obj) {
-  const { platformName, webviewTopOffset, webviewLeftOffset } = obj;
+  const { isAndroid, webviewTopOffset, webviewLeftOffset } = obj;
   const htmlElements = document.body.getElementsByTagName('*');
-  const isAndroid = platformName.toLowerCase() === 'android';
   // iOS uses CSS sizes for elements and screenshots, Android sizes times DRP
+  // for other platforms, use default DRP of 1
   const dpr = isAndroid ? window.devicePixelRatio : 1;
 
   Array.from(htmlElements).forEach((el) => {


### PR DESCRIPTION
This PR improves calculations for generating element highlighters when inspecting a webview. Both iOS and Android had issues in such situations.
Note that highlighter generation in native context is not affected.

### Android
Here the problem was fairly simple - the top offset from the Chrome address bar was being ignored:
![android-old-landscape](https://github.com/appium/appium-inspector/assets/37242620/82e67328-8276-438e-82c1-c983d98e2257)
The issue was fixed by finding the actual webview element (`android.webkit.WebView`), which had correct dimensions, and using its X and Y coordinates as the starting points:
![android-new-landscape](https://github.com/appium/appium-inspector/assets/37242620/e8d5a3ff-b73f-47ef-be03-6ec5ef4b509c)
This also allowed to fix a problem in landscape mode, where the X axis would also need an offset if the device had a hole punch camera or a similar hardware configuration, resulting in the webpage not extending to that area.

The solution was also confirmed to work when the Chrome address bar was scrolled out of view.

### iOS
At first glance, the highlighter positions were correct... until the phone was turned to landscape mode, or the user set the address bar at the top:
![ios-old-landscape](https://github.com/appium/appium-inspector/assets/37242620/b226e5ad-2ee8-4b4b-823b-3c2eab06541f)
![ios-old-portrait](https://github.com/appium/appium-inspector/assets/37242620/d034d26c-2f25-4485-8cd8-9a3240cf9e04)
The X and Y offsets each needed their own fix. For the Y offset, the implementation was similar to Android, but since there was no ideal webview element here, the offset was instead obtained from the top status+address bar:
![ios-new-portrait](https://github.com/appium/appium-inspector/assets/37242620/706b3bc7-3ed6-42ff-83d0-cac16532e51e)
The X offset appeared only in landscape mode, at both ends of the screen, and seemed to match the status bar height, so that was exactly the value that was used:
![ios-new-landscape](https://github.com/appium/appium-inspector/assets/37242620/c6872c6f-7213-4435-b0eb-e1bc33358a00)

The solution was also confirmed to work when the top address bar in portrait orientation was scrolled out of view, as well as when the top bar in landscape orientation was scrolled _into_ view.