### PR TITLE
feat: add button to save current application screenshot

### DIFF
--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -43,7 +43,7 @@ const downloadFile = (href, filename) => {
 
 const downloadXML = (sourceXML) => {
   const href = 'data:application/xml;charset=utf-8,' + encodeURIComponent(sourceXML);
-  const filename = 'source.xml';
+  const filename = `app-source-${new Date().toJSON()}.xml`;
   downloadFile(href, filename);
 };
 

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -29,16 +29,28 @@ const MAX_SCREENSHOT_WIDTH = 500;
 const MJPEG_STREAM_CHECK_INTERVAL = 1000;
 const SESSION_EXPIRY_PROMPT_TIMEOUT = 60 * 60 * 1000; // Give user 1 hour to reply
 
-const downloadXML = (sourceXML) => {
+const downloadFile = (href, filename) => {
   let element = document.createElement('a');
-  element.setAttribute('href', 'data:application/xml;charset=utf-8,' + encodeURIComponent(sourceXML));
-  element.setAttribute('download', 'source.xml');
+  element.setAttribute('href', href);
+  element.setAttribute('download', filename);
   element.style.display = 'none';
 
   document.body.appendChild(element);
   element.click();
 
   document.body.removeChild(element);
+};
+
+const downloadXML = (sourceXML) => {
+  const href = 'data:application/xml;charset=utf-8,' + encodeURIComponent(sourceXML);
+  const filename = 'source.xml';
+  downloadFile(href, filename);
+};
+
+const downloadScreenshot = (screenshot) => {
+  const href = `data:image/png;base64,${screenshot}`;
+  const filename = 'appium-inspector-screenshot.png';
+  downloadFile(href, filename);
 };
 
 const Inspector = (props) => {
@@ -208,6 +220,9 @@ const Inspector = (props) => {
             disabled={isGestureEditorVisible} />
         </Tooltip>
       </Button.Group>
+      {showScreenshot && !mjpegScreenshotUrl && <Tooltip title={t('Download Screenshot')}>
+        <Button icon={<DownloadOutlined/>} onClick={() => downloadScreenshot(screenshot)}/>
+      </Tooltip>}
     </Space>
   </div>;
 

--- a/app/renderer/components/Inspector/Inspector.js
+++ b/app/renderer/components/Inspector/Inspector.js
@@ -49,7 +49,7 @@ const downloadXML = (sourceXML) => {
 
 const downloadScreenshot = (screenshot) => {
   const href = `data:image/png;base64,${screenshot}`;
-  const filename = 'appium-inspector-screenshot.png';
+  const filename = `appium-inspector-${new Date().toJSON()}.png`;
   downloadFile(href, filename);
 };
 

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -101,6 +101,7 @@
   "Select Elements": "Select Elements",
   "Swipe By Coordinates": "Swipe By Coordinates",
   "Tap By Coordinates": "Tap By Coordinates",
+  "Download Screenshot": "Download Screenshot",
   "Back": "Back",
   "Start Refreshing Source": "Start Refreshing Source",
   "Pause Refreshing Source": "Pause Refreshing Source",


### PR DESCRIPTION
This PR adds a new button that allows to save the full-size version of the currently shown application screenshot:
![screenshot-button](https://github.com/appium/appium-inspector/assets/37242620/cc0be925-f293-4e17-b99f-125eac7069f6)

It is one of those features that initially didn't even occur to me, but once it did, I realised it could be extremely useful.
Note that the button is not shown in MJPEG mode.