### PR TITLE
fix: do not open inspector screen if session creation fails

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -263,7 +263,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('sauceCredentialsRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         https = false;
         if (!isPlainObject(desiredCapabilities[SAUCE_OPTIONS_CAP])) {
@@ -280,7 +280,7 @@ export function newSession (caps, attachSessId = null) {
           headspinUrl = new URL(session.server.headspin.webDriverUrl);
         } catch (ign) {
           showError(new Error(`${session.server.headspin.webDriverUrl} is invalid url`), null, 0);
-          return;
+          return false;
         }
         host = session.server.headspin.hostname = headspinUrl.hostname;
         path = session.server.headspin.path = headspinUrl.pathname;
@@ -300,7 +300,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('Perfecto SecurityToken is required'),
             duration: 4
           });
-          return;
+          return false;
         }
         desiredCapabilities['perfecto:options'] = {securityToken: token};
         https = session.server.perfecto.ssl;
@@ -321,7 +321,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('browserstackCredentialsRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         https = session.server.browserstack.ssl = (parseInt(port, 10) === 443);
         break;
@@ -350,7 +350,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('lambdatestCredentialsRequired'),
             duration: 4,
           });
-          return;
+          return false;
         }
         https = session.server.lambdatest.ssl = parseInt(port, 10) === 443;
         break;
@@ -365,7 +365,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('bitbarCredentialsRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         desiredCapabilities['bitbar:options'] = {
           source: 'appiumdesktop',
@@ -387,7 +387,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('kobitonCredentialsRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         https = session.server.kobiton.ssl = true;
         break;
@@ -404,7 +404,7 @@ export function newSession (caps, attachSessId = null) {
             description: 'PCLOUDY username and api key are required!',
             duration: 4
           });
-          return;
+          return false;
         }
         https = session.server.pcloudy.ssl = true;
         break;
@@ -424,7 +424,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('testingbotCredentialsRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         https = session.server.testingbot.ssl = true;
         break;
@@ -435,7 +435,7 @@ export function newSession (caps, attachSessId = null) {
             description: i18n.t('experitestAccessKeyURLRequired'),
             duration: 4
           });
-          return;
+          return false;
         }
         desiredCapabilities['experitest:accessKey'] = session.server.experitest.accessKey;
 
@@ -444,7 +444,7 @@ export function newSession (caps, attachSessId = null) {
           experitestUrl = new URL(session.server.experitest.url);
         } catch (ign) {
           showError(new Error(`${session.server.experitest.url} is invalid url`), null, 0);
-          return;
+          return false;
         }
 
         host = session.server.experitest.hostname = experitestUrl.hostname;
@@ -537,7 +537,7 @@ export function newSession (caps, attachSessId = null) {
       }
     } catch (err) {
       showError(err, null, 0);
-      return;
+      return false;
     } finally {
       dispatch({type: NEW_SESSION_DONE});
       // Save the current server settings
@@ -588,6 +588,7 @@ export function newSession (caps, attachSessId = null) {
       mjpegScreenshotUrl
     });
     action(dispatch);
+    return true;
   };
 }
 

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -36,8 +36,9 @@ const Session = (props) => {
   };
 
   const loadNewSession = async (caps, attachSessId = null) => {
-    await newSession(caps, attachSessId);
-    navigate('/inspector', { replace: true });
+    if (await newSession(caps, attachSessId)) {
+      navigate('/inspector', { replace: true });
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
This PR resolves #1026. The inspector screen should no longer open if session creation fails for any reason.