### PR TITLE
fix: update robotqa session path for Appium 2

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -419,7 +419,7 @@ export function newSession (caps, attachSessId = null) {
         break;
       } case ServerTypes.roboticmobi: {
         host = 'remote.robotqa.com';
-        path = '/wd/hub';
+        path = '/';
         port = 443;
         https = session.server.roboticmobi.ssl = true;
         if (caps) {


### PR DESCRIPTION
Changes remote path for Appium 2x. "/wd/hub" removed.