### PR TITLE
fix: update xpath selector selection logic

### DIFF
--- a/app/renderer/components/Inspector/Source.js
+++ b/app/renderer/components/Inspector/Source.js
@@ -14,7 +14,6 @@ const IMPORTANT_ATTRS = [
   'label',
   'value',
   'id',
-  'class',
 ];
 
 /**

--- a/app/renderer/util.js
+++ b/app/renderer/util.js
@@ -15,20 +15,29 @@ const UNIQUE_XPATH_ATTRIBUTES = [
   'name',
   'content-desc',
   'id',
+  'resource-id',
   'accessibility-id',
+];
+
+// Attributes that we should recommend as a fallback but ideally only in conjunction with other
+// attributes
+const MAYBE_UNIQUE_XPATH_ATTRIBUTES = [
+  'label',
   'text',
+  'value',
+  'class',
+  'type',
+];
+
+const UNIQUE_CLASS_CHAIN_ATTRIBUTES = [
+  'name',
   'label',
   'value',
 ];
 
-const UNIQUE_CLASS_CHAIN_ATTRIBUTES = [
-  'label',
-  'name',
-  'value',
-];
 const UNIQUE_PREDICATE_ATTRIBUTES = [
-  'label',
   'name',
+  'label',
   'value',
   'type',
 ];
@@ -97,7 +106,7 @@ export function xmlToJSON (source) {
  * @returns {[boolean, number?]} tuple consisting of (1) whether the xpath is unique and (2) its index in
  * the set of other similar nodes if not unique
  */
-function isXpathUnique(xpath, doc, domNode) {
+function determineXpathUniqueness(xpath, doc, domNode) {
   let othersWithAttr = [];
 
   // If the XPath does not parse, move to the next unique attribute
@@ -115,68 +124,121 @@ function isXpathUnique(xpath, doc, domNode) {
 }
 
 /**
+ * Given an xml doc and a current dom node, try to find a robust xpath selector qualified by
+ * key attributes, which is unique in the document (or unique plus index).
+ *
+ * @param {string} xpath
+ * @param {DOMDocument} doc
+ * @param {Array<string>|Array<[string, string]>} attrs - a list of attributes to consider, or
+ * a list of pairs of attributes to consider in conjunction
+ *
+ * @returns {[string|undefined, boolean|undefined]} tuple consisting of (1) the xpath selector discovered, and (2)
+ * whether this selector is absolutely unique in the document (true) or qualified by index (false)
+ */
+function getUniqueXPath(doc, domNode, attrs) {
+  let uniqueXpath, semiUniqueXpath;
+  const tagForXpath = domNode.tagName || '*';
+  const isPairs = attrs.length > 0 && _.isArray(attrs[0]);
+
+  for (const attrName of attrs) {
+    let xpath;
+    if (isPairs) {
+      const [attr1Name, attr2Name] = attrName;
+      const [attr1Value, attr2Value] = attrName.map(domNode.getAttribute.bind(domNode));
+      if (!attr1Value || !attr2Value) {
+        continue;
+      }
+      xpath = `//${tagForXpath}[@${attr1Name}="${attr1Value}" and @${attr2Name}="${attr2Value}"]`;
+    } else {
+      const attrValue = domNode.getAttribute(attrName);
+      if (!attrValue) {
+        continue;
+      }
+      xpath = `//${tagForXpath}[@${attrName}="${attrValue}"]`;
+    }
+    const [isUnique, indexIfNotUnique] = determineXpathUniqueness(xpath, doc, domNode);
+    if (isUnique) {
+      uniqueXpath = xpath;
+      break;
+    }
+
+    // if the xpath wasn't totally unique it might still be our best bet. Store a less unique
+    // version qualified by an index for later in semiUniqueXpath. If we can't find a better
+    // unique option down the road, we'll fall back to this
+    if (!semiUniqueXpath && !_.isUndefined(indexIfNotUnique)) {
+      semiUniqueXpath = `(${xpath})[${indexIfNotUnique + 1}]`;
+    }
+  }
+  if (uniqueXpath) {
+    return [uniqueXpath, true];
+  }
+  if (semiUniqueXpath) {
+    return [semiUniqueXpath, false];
+  }
+  return [];
+}
+
+/**
  * Get an optimal XPath for a DOMNode
  *
  * @param {DOMDocument} doc
  * @param {DOMNode} domNode
- * @param {Array<String>} uniqueAttributes Attributes we know are unique
  * @returns {string|null}
  */
-export function getOptimalXPath (doc, domNode, uniqueAttributes) {
+export function getOptimalXPath (doc, domNode) {
   try {
     // BASE CASE #1: If this isn't an element, we're above the root, return empty string
     if (!domNode.tagName || domNode.nodeType !== 1) {
       return '';
     }
 
-    const tagForXpath = domNode.tagName || '*';
-    let semiUniqueXpath = null;
+    const attrsForPairs = [...UNIQUE_XPATH_ATTRIBUTES, ...MAYBE_UNIQUE_XPATH_ATTRIBUTES];
+    const attrPairsPermutations = attrsForPairs.flatMap((v1, i) =>
+      attrsForPairs.slice(i + 1).map((v2) => [v1, v2]));
 
-    // BASE CASE #2: If this node has a unique attribute or content attribute, return an absolute XPath with that attribute
-    for (const attrName of uniqueAttributes) {
-      const attrValue = domNode.getAttribute(attrName);
-      if (!attrValue) {
-        continue;
-      }
-      const xpath = `//${tagForXpath}[@${attrName}="${attrValue}"]`;
-      const [isUnique, indexIfNotUnique] = isXpathUnique(xpath, doc, domNode);
-      if (isUnique) {
+    const cases = [
+      // BASE CASE #2: If this node has a unique attribute or content attribute, return an absolute
+      // XPath with that attribute
+      UNIQUE_XPATH_ATTRIBUTES,
+
+      // BASE CASE #3: If this node has a unique pair of attributes including 'maybe' attributes,
+      // return an xpath based on that pair
+      attrPairsPermutations,
+
+      // BASE CASE #4: Look for a 'maybe' unique attribute on its own. It's better if we find one
+      // of these that's unique in conjunction with another attribute, but if not, that's OK.
+      // Better than a hierarchical query.
+      MAYBE_UNIQUE_XPATH_ATTRIBUTES,
+    ];
+
+    // It's possible that in all of these cases we don't find a truly unique selector. But
+    // a selector qualified by attribute with an index attached like //*[@id="foo"][1] is still
+    // better than a fully path-based selector. We call this a 'semi unique xpath'
+    let semiUniqueXpath;
+
+    // Go through each of our cases and look for selectors for each case in order
+    for (const attrs of cases) {
+      const [xpath, isFullyUnique] = getUniqueXPath(doc, domNode, attrs);
+      if (isFullyUnique) {
+        // if we ever encounter an actually unique selector, return it straightaway
         return xpath;
-      }
-
-      // if the xpath wasn't totally unique it might still be our best bet. Store a less unique
-      // version qualified by an index for later in semiUniqueXpath. If we can't find a better
-      // unique option down the road, we'll fall back to this
-      if (!semiUniqueXpath && !_.isUndefined(indexIfNotUnique)) {
-        semiUniqueXpath = `(${xpath})[${indexIfNotUnique + 1}]`;
+      } else if (!semiUniqueXpath && xpath) {
+        // if we have a semin unique selector, and haven't already captured a semi unique selector,
+        // hold onto it for later. If we end up without any unique selectors from any of the cases,
+        // then we'll return this. But we want to make sure to return our FIRST instance of a semi
+        // unique selector, since it might theoretically be the best.
+        semiUniqueXpath = xpath;
       }
     }
 
-    // BASE CASE #3: If this node has a unique pair of attributes, return an xpath based on that pair
-    const pairAttributes = uniqueAttributes.flatMap((v1, i) =>
-      uniqueAttributes.slice(i + 1).map((v2) => [v1, v2]));
-    for (const [attr1Name, attr2Name] of pairAttributes) {
-      const attr1Value = domNode.getAttribute(attr1Name);
-      const attr2Value = domNode.getAttribute(attr2Name);
-      if (!attr1Value || !attr2Value) {
-        continue;
-      }
-      const xpath = `//${tagForXpath}[@${attr1Name}="${attr1Value}" and @${attr2Name}="${attr2Value}"]`;
-      if (isXpathUnique(xpath, doc, domNode)[0]) {
-        return xpath;
-      }
-    }
-
-    // if we couldn't find any good totally unique or pairwise unique attributes, but we did find
-    // almost unique attributes qualified by an index, return that instead
+    // Once we've gone through all our cases, if we do have a semi uniqe xpath, send that back
     if (semiUniqueXpath) {
       return semiUniqueXpath;
     }
 
     // Otherwise fall back to a purely hierarchical expression of this dom node's position in the
     // document as a last resort.
-
-    // Get the relative xpath of this node using tagName
+    // First get the relative xpath of this node using tagName
     let xpath = `/${domNode.tagName}`;
 
     // If this node has siblings of the same tagName, get the index of this node
@@ -194,7 +256,7 @@ export function getOptimalXPath (doc, domNode, uniqueAttributes) {
     }
 
     // Make a recursive call to this nodes parents and prepend it to this xpath
-    return getOptimalXPath(doc, domNode.parentNode, uniqueAttributes) + xpath;
+    return getOptimalXPath(doc, domNode.parentNode) + xpath;
   } catch (error) {
     // If there's an unexpected exception, abort and don't get an XPath
     log.error(`The most optimal XPATH could not be determined because an error was thrown: '${JSON.stringify(error, null, 2)}'`);

--- a/test/unit/util-specs.js
+++ b/test/unit/util-specs.js
@@ -10,8 +10,8 @@ chai.use(chaiAsPromised);
 
 // Helper that checks that the optimal xpath for a node is the one that we expect and also
 // checks that the XPath successfully locates the node in it's doc
-function testXPath (doc, node, expectedXPath, uniqueAttributes = ['id']) {
-  getOptimalXPath(doc, node, uniqueAttributes).should.equal(expectedXPath);
+function testXPath (doc, node, expectedXPath) {
+  getOptimalXPath(doc, node).should.equal(expectedXPath);
   xpath.select(expectedXPath, doc)[0].should.equal(node);
 }
 
@@ -477,14 +477,10 @@ describe('util.js', function () {
       });
       it('should set an absolute xpath if unique attributes is set to "content-desc" and that attr is set', function () {
         const doc = new DOMParser().parseFromString(`<node content-desc='foo'></node>`);
-        testXPath(doc, doc.firstChild, '//node[@content-desc="foo"]', ['content-desc']);
-      });
-      it('should set an absolute xpath if unique attributes is set to "content-desc" and "something-else" and that "content-desc" is set', function () {
-        const doc = new DOMParser().parseFromString(`<node content-desc='foo'></node>`);
-        testXPath(doc, doc.firstChild, '//node[@content-desc="foo"]', ['something-else', 'content-desc']);
+        testXPath(doc, doc.firstChild, '//node[@content-desc="foo"]');
       });
       it('should set relative xpath with tagname if no unique attributes are set', function () {
-        const doc = new DOMParser().parseFromString(`<node content-desc='foo'></node>`);
+        const doc = new DOMParser().parseFromString(`<node non-unique-attr='foo'></node>`);
         testXPath(doc, doc.firstChild, '/node');
       });
     });
@@ -493,26 +489,26 @@ describe('util.js', function () {
 
       it('should set first child node to relative xpath with tagname if the child node has no siblings', function () {
         doc = new DOMParser().parseFromString(`<xml>
-          <child-node content-desc='hello'>Hello</child-node>
+          <child-node non-unique-attr='hello'>Hello</child-node>
         </xml>`);
-        testXPath(doc, doc.getElementsByTagName('child-node')[0], '/xml/child-node', []);
+        testXPath(doc, doc.getElementsByTagName('child-node')[0], '/xml/child-node');
       });
 
       it('should set first child node to relative xpath with tagname and index', function () {
         doc = new DOMParser().parseFromString(`<xml>
-          <child-node content-desc='hello'>Hello</child-node>
-          <child-node content-desc='world'>World</child-node>
+          <child-node non-unique-attr='hello'>Hello</child-node>
+          <child-node non-unique-attr='world'>World</child-node>
         </xml>`);
-        testXPath(doc, doc.getElementsByTagName('child-node')[0], '/xml/child-node[1]', []);
-        testXPath(doc, doc.getElementsByTagName('child-node')[1], '/xml/child-node[2]', []);
+        testXPath(doc, doc.getElementsByTagName('child-node')[0], '/xml/child-node[1]');
+        testXPath(doc, doc.getElementsByTagName('child-node')[1], '/xml/child-node[2]');
       });
       it('should set first child node to absolute xpath if it has ID set', function () {
         doc = new DOMParser().parseFromString(`<xml>
           <child-node content-desc='hello'>Hello</child-node>
           <child-node content-desc='world'>World</child-node>
         </xml>`);
-        testXPath(doc, doc.getElementsByTagName('child-node')[0], '//child-node[@content-desc="hello"]', ['content-desc']);
-        testXPath(doc, doc.getElementsByTagName('child-node')[1], '//child-node[@content-desc="world"]', ['content-desc']);
+        testXPath(doc, doc.getElementsByTagName('child-node')[0], '//child-node[@content-desc="hello"]');
+        testXPath(doc, doc.getElementsByTagName('child-node')[1], '//child-node[@content-desc="world"]');
       });
       it('should index children based on tagName', function () {
         doc = new DOMParser().parseFromString(`<xml>
@@ -604,17 +600,22 @@ describe('util.js', function () {
       });
       it('should return conjunctively unique xpath locators if they exist', function () {
         doc = new DOMParser().parseFromString(`<root>
-          <child text='bar'></child>
+          <child id='foo' text='bar'></child>
           <child text='yo'></child>
           <child id='foo' text='yo'></child>
           <child id='foo'></child>
+          <child text='zoom'></child>
+          <child id='bar' text='ohai'></child>
+          <child id='bar' text='ohai'></child>
         </root>`);
         const children = doc.getElementsByTagName('child');
-        const attrs = ['id', 'text'];
-        testXPath(doc, children[0], '//child[@text="bar"]', attrs);
-        testXPath(doc, children[1], '(//child[@text="yo"])[1]', attrs);
-        testXPath(doc, children[2], '//child[@id="foo" and @text="yo"]', attrs);
-        testXPath(doc, children[3], '(//child[@id="foo"])[2]', attrs);
+        testXPath(doc, children[0], '//child[@id="foo" and @text="bar"]');
+        testXPath(doc, children[1], '(//child[@text="yo"])[1]');
+        testXPath(doc, children[2], '//child[@id="foo" and @text="yo"]');
+        testXPath(doc, children[3], '(//child[@id="foo"])[3]');
+        testXPath(doc, children[4], '//child[@text="zoom"]');
+        testXPath(doc, children[5], '(//child[@id="bar"])[1]');
+        testXPath(doc, children[6], '(//child[@id="bar"])[2]');
       });
     });
 


### PR DESCRIPTION
I realized there are actually two categories of 'unique' attributes when constructing a selector.

- intentionally unique / static (things like 'id' or 'content-desc' which the developer sets ideally in a way which is unique and doesn't change from run to run. this doesn't mean they are actually always unique. but from the perspective of selector generation, if we find a unique 'id' attribute on an element, then this is sufficient for us to consider the selector unique enough)
- accidentally unique / dynamic (things like 'text' or 'label' which might contain e.g. user generated content or other strings. the fact that they are unique in the xml document is not necessarily a good predictor that they will be unique on subsequent runs of the app.)

This change refactors the selector generation logic to reflect this. If we find an element with an 'accidentally' unique 'text' attribute, we now first attempt to conjoin it with an other attribute (like 'id'), to strengthen the chance that from run to run the selector will not break.

And we still fall back to suggesting a selector based solely on a unique 'text' field, since that is still going to be more likely to work from run to run than a static hierarchical selector.

