### PR TITLE
chore: remove unused template commands

### DIFF
--- a/app/renderer/lib/client-frameworks/java.js
+++ b/app/renderer/lib/client-frameworks/java.js
@@ -38,14 +38,14 @@ public class SampleTest {
   private ${cls} driver;
   private PORT = ${port};
   private HOST = ${host};
-  
+
 
   @Before
   public void setUp() throws MalformedURLException {
     DesiredCapabilities desiredCapabilities = new DesiredCapabilities();
 ${capStr}
 
-    
+
 
     private URL getUrl(String host, String port) {
         try {
@@ -188,20 +188,8 @@ ${this.indent(code, 4)}
     return `boolean isAppInstalled = driver.isAppInstalled("${app}");`;
   }
 
-  codeFor_launchApp () {
-    return `driver.launchApp();`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `driver.runAppInBackground(Duration.ofSeconds(${timeout}));`;
-  }
-
-  codeFor_closeApp () {
-    return `driver.closeApp();`;
-  }
-
-  codeFor_reset () {
-    return `driver.reset();`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {

--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -112,20 +112,8 @@ ${code}
     return `let isAppInstalled = ${this.type}.isAppInstalled("${app}");`;
   }
 
-  codeFor_launchApp () {
-    return `${this.type}.launchApp();`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `${this.type}.getDriver().background(${timeout});`;
-  }
-
-  codeFor_closeApp () {
-    return `${this.type}.closeApp();`;
-  }
-
-  codeFor_reset () {
-    return `${this.type}.resetApp();`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {

--- a/app/renderer/lib/client-frameworks/js-wd.js
+++ b/app/renderer/lib/client-frameworks/js-wd.js
@@ -108,20 +108,8 @@ main().catch(console.log);
     return `driver.isAppInstalled("${app}");`;
   }
 
-  codeFor_launchApp () {
-    return `await driver.launchApp();`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `await driver.background(${timeout});`;
-  }
-
-  codeFor_closeApp () {
-    return `await driver.closeApp();`;
-  }
-
-  codeFor_reset () {
-    return `await driver.reset();`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {

--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -116,20 +116,8 @@ main().catch(console.log);`;
     return `let isAppInstalled = await driver.isAppInstalled("${app}");`;
   }
 
-  codeFor_launchApp () {
-    return `await driver.launchApp();`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `await driver.background(${timeout});`;
-  }
-
-  codeFor_closeApp () {
-    return `await driver.closeApp();`;
-  }
-
-  codeFor_reset () {
-    return `await driver.reset();`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {

--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -122,20 +122,8 @@ actions.perform()
     return `is_app_installed = driver.is_app_installed('${app}');`;
   }
 
-  codeFor_launchApp () {
-    return `driver.launch_app()`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `driver.background_app(${timeout})`;
-  }
-
-  codeFor_closeApp () {
-    return `driver.close_app()`;
-  }
-
-  codeFor_reset () {
-    return `driver.reset()`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {

--- a/app/renderer/lib/client-frameworks/robot.js
+++ b/app/renderer/lib/client-frameworks/robot.js
@@ -27,8 +27,8 @@ class RobotFramework extends Framework {
 #
 #  more keywords on: http://serhatbolsu.github.io/robotframework-appiumlibrary/AppiumLibrary.html
 #
-# if your tests fails saying 'did not match any elements' consider use 'wait activity' or 
-# 'wait until page contains element' before a click command 
+# if your tests fails saying 'did not match any elements' consider use 'wait activity' or
+# 'wait until page contains element' before a click command
 
 *** Settings ***
 Library           AppiumLibrary
@@ -127,19 +127,7 @@ ${this.indent(code, 4)}
     return ``;
   }
 
-  codeFor_launchApp () {
-    return ``;
-  }
-
   codeFor_background () {
-    return ``;
-  }
-
-  codeFor_closeApp () {
-    return ``;
-  }
-
-  codeFor_reset () {
     return ``;
   }
 

--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -111,20 +111,8 @@ driver.quit`;
     return `is_app_installed = driver.app_installed? '${app}'`;
   }
 
-  codeFor_launchApp () {
-    return `driver.launch_app`;
-  }
-
   codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
     return `driver.background_app ${timeout}`;
-  }
-
-  codeFor_closeApp () {
-    return `driver.close_app`;
-  }
-
-  codeFor_reset () {
-    return `driver.reset`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {


### PR DESCRIPTION
As same as https://github.com/appium/appium-inspector/pull/1147, we can remove launchApp/closeApp/reset commands from template since these commands no longer exists in this inspector library