### PR TITLE
fix: improve error for invalid JSON in command argument

### DIFF
--- a/app/renderer/components/Inspector/Commands.js
+++ b/app/renderer/components/Inspector/Commands.js
@@ -24,6 +24,19 @@ const Commands = (props) => {
     // Make a copy of the arguments to avoid state mutation
     let copiedArgs = _.cloneDeep(args);
 
+    let parsingSuccess = true;
+    const parseJsonArgument = (index) => {
+      try {
+        copiedArgs[index] = JSON.parse(args[index]);
+      } catch (e) {
+        notification.error({
+          message: t('invalidJson', {json: args[index]}),
+          duration: 5,
+        });
+        parsingSuccess = false;
+      }
+    };
+
     // Special case for 'rotateDevice'
     if (commandName === 'rotateDevice') {
       copiedArgs = {x: args[0], y: args[1], duration: args[2], radius: args[3], rotation: args[4], touchCount: args[5]};
@@ -37,32 +50,21 @@ const Commands = (props) => {
     // Special case for 'execute'
     if (commandName === 'executeScript') {
       if (!_.isEmpty(args[1])) {
-        try {
-          copiedArgs[1] = JSON.parse(args[1]);
-        } catch (e) {
-          notification.error({
-            message: t('invalidJson', {json: args[1]}),
-            duration: 5,
-          });
-        }
+        parseJsonArgument(1);
       }
     }
 
     // Special case for 'updateSettings'
     if (commandName === 'updateSettings') {
       if (_.isString(args[0])) {
-        try {
-          copiedArgs[0] = JSON.parse(args[0]);
-        } catch (e) {
-          notification.error({
-            message: t('invalidJson', {json: args[0]}),
-            duration: 5,
-          });
-        }
+        parseJsonArgument(0);
       }
     }
 
-    applyClientMethod({methodName: commandName, args: copiedArgs, skipRefresh: !refresh, ignoreResult: false});
+    if (parsingSuccess) {
+      applyClientMethod({methodName: commandName, args: copiedArgs, skipRefresh: !refresh, ignoreResult: false});
+    }
+
     cancelPendingCommand();
   };
 

--- a/app/renderer/components/Inspector/Commands.js
+++ b/app/renderer/components/Inspector/Commands.js
@@ -20,9 +20,10 @@ const Commands = (props) => {
   const parseJsonString = (jsonString) => {
     try {
       return JSON.parse(jsonString);
-    } catch (e) {
+    } catch (err) {
       notification.error({
-        message: t('invalidJson', {json: jsonString}),
+        message: t('invalidJson'),
+        description: err.message,
         duration: 5,
       });
       return null;

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -241,7 +241,7 @@
   "Save Capability Set As": "Save Capability Set As…",
   "Edit Raw JSON": "Edit Raw JSON",
   "Enter Parameters for:": "Enter Parameters for:",
-  "invalidJson": "Invalid JSON: '{{json}}'",
+  "invalidJson": "Invalid JSON",
   "Execute Script": "Execute Script",
   "App Management": "App Management",
   "Clipboard": "Clipboard",

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -241,6 +241,7 @@
   "Save Capability Set As": "Save Capability Set As…",
   "Edit Raw JSON": "Edit Raw JSON",
   "Enter Parameters for:": "Enter Parameters for:",
+  "invalidJson": "Invalid JSON: '{{json}}'",
   "Execute Script": "Execute Script",
   "App Management": "App Management",
   "Clipboard": "Clipboard",


### PR DESCRIPTION
Currently, when attempting to call the `executeScript` or `updateSettings` command, if an invalid JSON argument is given, the app will return 2 errors - one for the invalid JSON, and another for the actual method execution.

Changes included in this PR:
* do not call the client method if JSON parsing fails
* add translation key for the JSON error, which also adds the failed JSON string inside the error