### PR TITLE
fix: adjust highlighters for Android tablets

### DIFF
--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -211,11 +211,13 @@ export default class AppiumClient {
       if (_.toLower(platformName) === 'android' && _.toLower(automationName) === 'uiautomator2') {
         // returned Android height and width can both be affected by UiAutomator2 calculations
         // we stick with device dimensions, but swap them depending on detected orientation
+        // deviceScreenSize value fits portrait mode for phones, but landscape mode for tablets
         const [width, height] = deviceScreenSize.split('x');
-        if (windowSize.height > windowSize.width) { // portrait mode
+        if ((windowSize.height > windowSize.width && height > width) || // phone portrait mode
+            (windowSize.height < windowSize.width && height < width)) { // tablet landscape mode
           windowSize.height = height;
           windowSize.width = width;
-        } else { // landscape mode
+        } else { // phone landscape mode / tablet portrait mode
           windowSize.height = width;
           windowSize.width = height;
         }


### PR DESCRIPTION
This PR fixes an issue where element highlighters for Android tablets were being drawn incorrectly.
The core issue stems from the `deviceScreenSize` parameters, which appear to match portrait mode for phones, but landscape mode for tablets. This has now been adjusted for.
Resolves #1154.