### PR TITLE
fix: adjustments for shared recorder framework code

### DIFF
--- a/app/renderer/lib/client-frameworks/framework.js
+++ b/app/renderer/lib/client-frameworks/framework.js
@@ -1,4 +1,5 @@
 import { DEFAULT_TAP, DEFAULT_SWIPE } from '../../components/Inspector/shared';
+import _ from 'lodash';
 
 export default class Framework {
 
@@ -36,22 +37,6 @@ export default class Framework {
     return `${this.scheme}://${this.host}:${this.port}${this.path === '/' ? '' : this.path}`;
   }
 
-  get name () {
-    throw new Error('Must implement name getter');
-  }
-
-  get language () {
-    throw new Error('Must implement language getter');
-  }
-
-  addAction (action, params) {
-    this.actions.push({action, params});
-  }
-
-  wrapWithBoilerplate () {
-    throw new Error('Must implement wrapWithBoilerplate');
-  }
-
   indent (str, spaces) {
     let lines = str.split('\n');
     let spaceStr = '';
@@ -66,12 +51,14 @@ export default class Framework {
 
   getCodeString (includeBoilerplate = false) {
     let str = '';
+    let code;
     for (let {action, params} of this.actions) {
       const genCodeFn = `codeFor_${action}`;
       if (!this[genCodeFn]) {
-        throw new Error(`Need to implement '${genCodeFn}()': ${this[genCodeFn]}`);
+        code = this.addComment(`Code generation for action '${action}' is not currently supported`);
+      } else {
+        code = this[genCodeFn](...params);
       }
-      let code = this[genCodeFn](...params);
       if (code) {
         str += `${code}\n`;
       }
@@ -105,9 +92,12 @@ export default class Framework {
     return varName;
   }
 
-  codeFor_findAndAssign () {
-    throw new Error('Need to implement codeFor_findAndAssign');
+  handleUnsupportedLocatorStrategy (strategy, locator) {
+    return this.addComment(`Code generation for locator strategy '${strategy}' ` +
+      `(selector '${locator}') is not currently supported`);
   }
+
+  // Common entrypoints for code generation
 
   codeFor_findElement (strategy, locator) {
     let [localVar, wasNew] = this.getVarForFind(strategy, locator);
@@ -116,16 +106,25 @@ export default class Framework {
       // finding it again
       return '';
     }
-
     return this.codeFor_findAndAssign(strategy, locator, localVar);
-
   }
 
-  codeFor_tap () {
-    throw new Error('Need to implement codeFor_tap');
+  codeFor_executeScript (varNameIgnore, varIndexIgnore, scriptCmd, jsonArg) {
+    // jsonArg is expected to be an array with 0-1 objects
+    if (_.isEmpty(jsonArg)) {
+      return this.codeFor_executeScriptNoArgs(scriptCmd);
+    }
+    return this.codeFor_executeScriptWithArgs(scriptCmd, jsonArg);
   }
 
-  codeFor_swipe () {
-    throw new Error('Need to implement codeFor_tap');
+  codeFor_startActivity (varNameIgnore, varIndexIgnore, ...args) {
+    const argNames = ['appPackage', 'appActivity', 'appWaitPackage', 'intentAction', 'intentCategory',
+      'intentFlags', 'optionalIntentArguments', 'dontStopAppOnReset'];
+    // zip argument names and values into a JSON object, so that we can reuse executeScript
+    const argsJsonObject = _.zipObject(argNames, args);
+    // filter out arguments with no values
+    const cleanedArgsJson = _.omitBy(argsJsonObject, _.isUndefined);
+    return this.codeFor_executeScriptWithArgs('mobile: startActivity', [cleanedArgsJson]);
   }
+
 }

--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -43,6 +43,10 @@ ${code}
 `;
   }
 
+  addComment(comment) {
+    return `// ${comment}`;
+  }
+
   codeFor_executeScript (varNameIgnore, varIndexIgnore, args) {
     return `${this.type}.execute(${args})`;
   }
@@ -59,7 +63,7 @@ ${code}
       case '-android datamatcher': locator = `android=${locator}`; break;
       case '-ios predicate string': locator = `ios=${locator}`; break;
       case '-ios class chain': locator = `ios=${locator}`; break; // TODO: Handle IOS class chain properly. Not all libs support it. Or take it out
-      default: throw new Error(`Can't handle strategy ${strategy}`);
+      default: return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
       return `let ${localVar} = mob.findElements(${JSON.stringify(locator)});`;

--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -40,6 +40,10 @@ ${this.indent(code, 2)}
 main().catch(console.log);`;
   }
 
+  addComment(comment) {
+    return `// ${comment}`;
+  }
+
   codeFor_executeScript (/*varNameIgnore, varIndexIgnore, args*/) {
     return `/* TODO implement executeScript */`;
   }
@@ -58,7 +62,7 @@ main().catch(console.log);`;
       case '-android viewtag': locator = `android=unsupported`; break;
       case '-ios predicate string': locator = `ios=${locator}`; break;
       case '-ios class chain': locator = `ios=${locator}`; break; // TODO: Handle IOS class chain properly. Not all libs support it. Or take it out
-      default: throw new Error(`Can't handle strategy ${strategy}`);
+      default: return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
       return `let ${localVar} = await driver.$$(${JSON.stringify(locator)});`;

--- a/app/renderer/lib/client-frameworks/python.js
+++ b/app/renderer/lib/client-frameworks/python.js
@@ -39,6 +39,10 @@ ${code}
 driver.quit()`;
   }
 
+  addComment(comment) {
+    return `# ${comment}`;
+  }
+
   codeFor_executeScript (varNameIgnore, varIndexIgnore, args) {
     return `driver.execute_script('${args}')`;
   }
@@ -57,7 +61,7 @@ driver.quit()`;
       '-ios class chain': 'AppiumBy.IOS_CLASS_CHAIN',
     };
     if (!suffixMap[strategy]) {
-      throw new Error(`Strategy ${strategy} can't be code-gened`);
+      return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
       return `${localVar} = driver.find_elements(by=${suffixMap[strategy]}, value=${JSON.stringify(locator)})`;

--- a/app/renderer/lib/client-frameworks/robot.js
+++ b/app/renderer/lib/client-frameworks/robot.js
@@ -46,6 +46,10 @@ ${this.indent(code, 4)}
 `;
   }
 
+  addComment(comment) {
+    return `# ${comment}`;
+  }
+
   codeFor_findAndAssign (strategy, locator/*, localVar, isArray*/) {
     let suffixMap = {
       xpath: 'xpath',
@@ -60,7 +64,7 @@ ${this.indent(code, 4)}
       '-ios class chain': 'ios_uiautomation', // TODO: Could not find iOS UIAutomation
     };
     if (!suffixMap[strategy]) {
-      throw new Error(`Strategy ${strategy} can't be code-gened`);
+      return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     //TODO: in the robot case, we need the ID on the codeFor_ for execution
     this.lastID = `${strategy}=${locator}`;

--- a/app/renderer/lib/client-frameworks/ruby.js
+++ b/app/renderer/lib/client-frameworks/ruby.js
@@ -30,6 +30,10 @@ driver.quit`;
     return `driver.execute_script '${args}'`;
   }
 
+  addComment(comment) {
+    return `# ${comment}`;
+  }
+
   codeFor_findAndAssign (strategy, locator, localVar, isArray) {
     let suffixMap = {
       'xpath': ':xpath',
@@ -44,7 +48,7 @@ driver.quit`;
       '-ios class chain': ':class_chain',
     };
     if (!suffixMap[strategy]) {
-      throw new Error(`Strategy ${strategy} can't be code-gened`);
+      return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
       return `${localVar} = driver.find_elements ${suffixMap[strategy]}, ${JSON.stringify(locator)}`;


### PR DESCRIPTION
While working on recorder updates for Python, I made various changes that affect all recorder frameworks, so I decided to submit them as a separate PR.
Changes include:
* Fix `codeFor_executeScript` for Java (wrong expected format for the argument variable)
* Move `codeFor_startActivity` to the base class since it will be the same for all frameworks
* Split `codeFor_executeScript` into handler methods with argument and without arguments. Move common method to the base class since it will be the same for all frameworks
* Remove various base class methods that are unused or already implemented in all recorder frameworks
* When encountering an unsupported locator strategy or method, do not raise error, but instead add a comment in the generated code
  * There is one situation where an error may still be raised - if `codeFor_startActivity` is requested for a non-Java framework. This will be resolved once `codeFor_executeScriptWithArgs` is implemented in all frameworks.