### PR TITLE
feat: update WDIO recorder code

### DIFF
--- a/app/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/renderer/lib/client-frameworks/js-wdio.js
@@ -14,23 +14,19 @@ class JsWdIoFramework extends Framework {
   }
 
   wrapWithBoilerplate (code) {
-    let host = JSON.stringify(this.host);
-    let caps = JSON.stringify(this.caps);
-    let proto = JSON.stringify(this.scheme);
-    let path = JSON.stringify(this.path);
-    return `// Requires the webdriverio client library
+    return `// This sample code supports WebdriverIO client >=7
 // (npm i --save webdriverio)
 // Then paste this into a .js file and run with Node:
 // node <file>.js
 
-const {remote} = require('webdriverio');
+import {remote} from 'webdriverio';
 async function main () {
-  const caps = ${caps}
+  const caps = ${JSON.stringify(this.caps)}
   const driver = await remote({
-    protocol: ${proto},
-    hostname: ${host},
+    protocol: "${this.scheme}",
+    hostname: "${this.host}",
     port: ${this.port},
-    path: ${path},
+    path: "${this.path}",
     capabilities: caps
   });
 ${this.indent(code, 2)}
@@ -44,30 +40,27 @@ main().catch(console.log);`;
     return `// ${comment}`;
   }
 
-  codeFor_executeScript (/*varNameIgnore, varIndexIgnore, args*/) {
-    return `/* TODO implement executeScript */`;
-  }
-
-
   codeFor_findAndAssign (strategy, locator, localVar, isArray) {
-    // wdio has its own way of indicating the strategy in the locator string
-    switch (strategy) {
-      case 'xpath': break; // xpath does not need to be updated
-      case 'accessibility id': locator = `~${locator}`; break;
-      case 'id': locator = `${locator}`; break;
-      case 'name': locator = `name=${locator}`; break;
-      case 'class name': locator = `${locator}`; break;
-      case '-android uiautomator': locator = `android=${locator}`; break;
-      case '-android datamatcher': locator = `android=${locator}`; break;
-      case '-android viewtag': locator = `android=unsupported`; break;
-      case '-ios predicate string': locator = `ios=${locator}`; break;
-      case '-ios class chain': locator = `ios=${locator}`; break; // TODO: Handle IOS class chain properly. Not all libs support it. Or take it out
-      default: return this.handleUnsupportedLocatorStrategy(strategy, locator);
+    // wdio allows to specify strategy as a locator prefix
+    const validStrategies = [
+      'xpath',
+      'accessibility id',
+      'id',
+      'class name',
+      'name',
+      '-android uiautomator',
+      '-android datamatcher',
+      '-android viewtag',
+      '-ios predicate string',
+      '-ios class chain'
+    ];
+    if (!validStrategies.includes(strategy)) {
+      return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
-      return `let ${localVar} = await driver.$$(${JSON.stringify(locator)});`;
+      return `const ${localVar} = await driver.$$(${JSON.stringify(`${strategy}:${locator}`)});`;
     } else {
-      return `let ${localVar} = await driver.$(${JSON.stringify(locator)});`;
+      return `const ${localVar} = await driver.$(${JSON.stringify(`${strategy}:${locator}`)});`;
     }
   }
 
@@ -80,93 +73,118 @@ main().catch(console.log);`;
   }
 
   codeFor_sendKeys (varName, varIndex, text) {
-    return `await ${this.getVarName(varName, varIndex)}.setValue(${JSON.stringify(text)});`;
-  }
-
-  codeFor_back () {
-    return `await driver.back();`;
+    return `await ${this.getVarName(varName, varIndex)}.addValue(${JSON.stringify(text)});`;
   }
 
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
     const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
-
-    return `await driver.touchAction({actions: 'tap', x: ${x}, y: ${y}})`;
+    return `await driver.touchAction({
+  action: 'tap', x: ${x}, y: ${y}
+});`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
     const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
-
     return `await driver.touchAction([
-  {action: 'press', x: ${x1}, y: ${y1}},
-  {action: 'moveTo', x: ${x2}, y: ${y2}},
+  { action: 'press', x: ${x1}, y: ${y1} },
+  { action: 'moveTo', x: ${x2}, y: ${y2} },
   'release'
 ]);`;
   }
 
+  // Execute Script
+
+  codeFor_executeScriptNoArgs (scriptCmd) {
+    return `await driver.executeScript(${JSON.stringify(scriptCmd)});`;
+  }
+
+  codeFor_executeScriptWithArgs (scriptCmd, jsonArg) {
+    return `await driver.executeScript(${JSON.stringify(scriptCmd)}, ${JSON.stringify(jsonArg)});`;
+  }
+
+  // App Management
+
   codeFor_getCurrentActivity () {
-    return `let activityName = await driver.getCurrentActivity();`;
+    return `let activityName = ${this.codeFor_executeScriptNoArgs('mobile: getCurrentActivity')}`;
   }
 
   codeFor_getCurrentPackage () {
-    return `let packageName = await driver.getCurrentPackage();`;
+    return `let packageName = ${this.codeFor_executeScriptNoArgs('mobile: getCurrentPackage')}`;
   }
 
-
   codeFor_installApp (varNameIgnore, varIndexIgnore, app) {
-    return `await driver.installApp('${app}');`;
+    return `await driver.installApp("${app}");`;
   }
 
   codeFor_isAppInstalled (varNameIgnore, varIndexIgnore, app) {
     return `let isAppInstalled = await driver.isAppInstalled("${app}");`;
   }
 
-  codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
-    return `await driver.background(${timeout});`;
+  codeFor_activateApp (varNameIgnore, varIndexIgnore, app) {
+    return `await driver.activateApp("${app}");`;
+  }
+
+  codeFor_terminateApp (varNameIgnore, varIndexIgnore, app) {
+    return `await driver.terminateApp("${app}");`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {
-    return `await driver.removeApp('${app}')`;
+    return `await driver.removeApp("${app}")`;
   }
 
   codeFor_getStrings (varNameIgnore, varIndexIgnore, language, stringFile) {
-    return `let appStrings = await driver.getStrings(${language ? `${language}, ` : ''}${stringFile ? `"${stringFile}` : ''});`;
+    return `let appStrings = await driver.getStrings(${language ? `"${language}", ` : ''}${stringFile ? `"${stringFile}"` : ''});`;
   }
 
-  codeFor_getClipboard (varNameIgnore, varIndexIgnore, contentType) {
-    return `let clipboardText = await driver.getClipboard(${contentType ? `${contentType}, ` : ''});`;
+  // Clipboard
+
+  codeFor_getClipboard () {
+    return `let clipboardText = await driver.getClipboard();`;
   }
 
   codeFor_setClipboard (varNameIgnore, varIndexIgnore, clipboardText) {
-    return `await driver.setClipboard('${clipboardText}')`;
+    return `await driver.setClipboard("${clipboardText}")`;
   }
 
-  codeFor_pressKeyCode (varNameIgnore, varIndexIgnore, keyCode, metaState, flags) {
-    return `await driver.longPressKeyCode(${keyCode}, ${metaState}, ${flags});`;
+  // File Transfer
+
+  codeFor_pushFile (varNameIgnore, varIndexIgnore, pathToInstallTo, fileContentString) {
+    return `await driver.pushFile("${pathToInstallTo}", "${fileContentString}");`;
   }
 
-  codeFor_longPressKeyCode (varNameIgnore, varIndexIgnore, keyCode, metaState, flags) {
-    return `await driver.longPressKeyCode(${keyCode}, ${metaState}, ${flags});`;
+  codeFor_pullFile (varNameIgnore, varIndexIgnore, pathToPullFrom) {
+    return `let fileBase64 = await driver.pullFile("${pathToPullFrom}");`;
   }
 
-  codeFor_hideKeyboard () {
-    return `await driver.hideKeyboard();`;
+  codeFor_pullFolder (varNameIgnore, varIndexIgnore, folderToPullFrom) {
+    return `let folderBase64 = await driver.pullFolder("${folderToPullFrom}");`;
   }
+
+  // Device Interaction
+
+  codeFor_isLocked () {
+    return `let isLocked = ${this.codeFor_executeScriptNoArgs('mobile: isLocked')}`;
+  }
+
+  codeFor_rotateDevice (varNameIgnore, varIndexIgnore, x, y, radius, rotation, touchCount, duration) {
+    return `await driver.rotateDevice(${x}, ${y}, ${radius}, ${rotation}, ${touchCount}, ${duration});`;
+  }
+
+  codeFor_touchId (varNameIgnore, varIndexIgnore, match) {
+    return `await driver.touchId(${match});`;
+  }
+
+  codeFor_toggleEnrollTouchId (varNameIgnore, varIndexIgnore, enroll) {
+    return `await driver.toggleEnrollTouchId(${enroll});`;
+  }
+
+  // Keyboard
 
   codeFor_isKeyboardShown () {
     return `let isKeyboardShown = await driver.isKeyboardShown();`;
   }
 
-  codeFor_pushFile (varNameIgnore, varIndexIgnore, pathToInstallTo, fileContentString) {
-    return `await driver.pushFile('${pathToInstallTo}', '${fileContentString}');`;
-  }
-
-  codeFor_pullFile (varNameIgnore, varIndexIgnore, pathToPullFrom) {
-    return `let data = await driver.pullFile('${pathToPullFrom}');`;
-  }
-
-  codeFor_pullFolder (varNameIgnore, varIndexIgnore, folderToPullFrom) {
-    return `let data = await driver.pullFolder('${folderToPullFrom}');`;
-  }
+  // Connectivity
 
   codeFor_toggleAirplaneMode () {
     return `await driver.toggleAirplaneMode();`;
@@ -178,10 +196,6 @@ main().catch(console.log);`;
 
   codeFor_toggleWiFi () {
     return `await driver.toggleWiFi();`;
-  }
-
-  codeFor_toggleLocationServices () {
-    return `await driver.toggleLocationServices();`;
   }
 
   codeFor_sendSMS (varNameIgnore, varIndexIgnore, phoneNumber, text) {
@@ -200,64 +214,14 @@ main().catch(console.log);`;
     return `await driver.gsmVoice("${state}");`;
   }
 
-  codeFor_shake () {
-    return `await driver.shake();`;
-  }
-
-  codeFor_lock (varNameIgnore, varIndexIgnore, seconds) {
-    return `await driver.lock(${seconds});`;
-  }
-
-  codeFor_unlock () {
-    return `await driver.unlock();`;
-  }
-
-  codeFor_isLocked () {
-    return `let isLocked = await driver.isLocked();`;
-  }
-
-  codeFor_rotateDevice (varNameIgnore, varIndexIgnore, x, y, radius, rotation, touchCount, duration) {
-    return `await driver.rotateDevice(${x}, ${y}, ${radius}, ${rotation}, ${touchCount}, ${duration});`;
-  }
-
-  codeFor_getPerformanceData (varNameIgnore, varIndexIgnore, packageName, dataType, dataReadTimeout) {
-    return `let performanceData = driver.getPerformanceData("${packageName}", "${dataType}", ${dataReadTimeout});`;
-  }
-
-  codeFor_getPerformanceDataTypes () {
-    return `let performanceDataTypes = await driver.getPerformanceDataTypes()`;
-  }
-
-  codeFor_touchId (varNameIgnore, varIndexIgnore, match) {
-    return `await driver.touchId(${match});`;
-  }
-
-  codeFor_toggleEnrollTouchId (varNameIgnore, varIndexIgnore, enroll) {
-    return `await driver.toggleEnrollTouchId(${enroll});`;
-  }
-
-  codeFor_openNotifications () {
-    return `await driver.openNotifications();`;
-  }
-
-  codeFor_getDeviceTime () {
-    return `let time = await driver.getDeviceTime();`;
-  }
-
-  codeFor_fingerprint (varNameIgnore, varIndexIgnore, fingerprintId) {
-    return `await driver.fingerprint(${fingerprintId});`;
-  }
+  // Session
 
   codeFor_getSession () {
-    return `let caps = await driver.getSession();`;
+    return `let sessionDetails = await driver.getSession();`;
   }
 
   codeFor_setTimeouts (/*varNameIgnore, varIndexIgnore, timeoutsJson*/) {
     return '/* TODO implement setTimeouts */';
-  }
-
-  codeFor_setCommandTimeout (/*varNameIgnore, varIndexIgnore, ms*/) {
-    return `// Not supported: setCommandTimeout`;
   }
 
   codeFor_getOrientation () {
@@ -277,15 +241,15 @@ main().catch(console.log);`;
   }
 
   codeFor_getLogTypes () {
-    return `let getLogTypes = await driver.getLogTypes();`;
+    return `let logTypes = await driver.getLogTypes();`;
   }
 
   codeFor_getLogs (varNameIgnore, varIndexIgnore, logType) {
-    return `let logs = await driver.getLogs('${logType}');`;
+    return `let logs = await driver.getLogs("${logType}");`;
   }
 
   codeFor_updateSettings (varNameIgnore, varIndexIgnore, settingsJson) {
-    return `await driver.updateSettings(${settingsJson});`;
+    return `await driver.updateSettings(${JSON.stringify(settingsJson)});`;
   }
 
   codeFor_getSettings () {
@@ -300,6 +264,10 @@ main().catch(console.log);`;
 
   codeFor_getUrl () {
     return `let current_url = await driver.getUrl();`;
+  }
+
+  codeFor_back () {
+    return `await driver.back();`;
   }
 
   codeFor_forward () {
@@ -321,7 +289,7 @@ main().catch(console.log);`;
   }
 
   codeFor_switchContext (varNameIgnore, varIndexIgnore, name) {
-    return `await driver.switchContext('${name}');`;
+    return `await driver.switchContext("${name}");`;
   }
 }
 


### PR DESCRIPTION
This PR updates the recorder-generated code for the WDIO client.

* Change boilerplate import to ESM
* Always pass locator strategy to element lookup ([reference](https://github.com/webdriverio/webdriverio/blob/v7/packages/webdriverio/tests/findStrategy.test.ts#L310))
* Fix `executeScript` and `updateSettings`
* Add `activateApp` and `terminateApp`
* Change many methods deprecated in `ruby_lib_core` 7.3 to their mobile extension equivalents
* Reorder and group driver command implementations