### PR TITLE
feat: update Oxygen recorder code

### DIFF
--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -80,11 +80,11 @@ ${code}`;
   // Execute Script
 
   codeFor_executeScriptNoArgs (scriptCmd) {
-    return `${this.type}.execute(${JSON.stringify(scriptCmd)});`;
+    return `${this.type}.getDriver().executeScript(${JSON.stringify(scriptCmd)});`;
   }
 
   codeFor_executeScriptWithArgs (scriptCmd, jsonArg) {
-    return `${this.type}.execute(${JSON.stringify(scriptCmd)}, ${JSON.stringify(jsonArg[0])});`;
+    return `${this.type}.getDriver().executeScript(${JSON.stringify(scriptCmd)}, ${JSON.stringify(jsonArg)});`;
   }
 
   // App Management

--- a/app/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/renderer/lib/client-frameworks/js-oxygen.js
@@ -7,68 +7,51 @@ class JsOxygenFramework extends Framework {
   }
 
   get type () {
-    if (this.caps && this.caps.platformName) {
-      const platformName = this.caps.platformName.toLowerCase();
-      if (platformName === 'windows') {
-        return 'win';
-      }
-      if (['android', 'androiddriver'].includes(platformName)) {
-        return 'mob';
-      }
-      if (['ios', 'iosdriver'].includes(platformName)) {
-        return 'mob';
-      }
+    if (this.caps && this.caps.platformName &&
+        this.caps.platformName.toLowerCase() === 'windows') {
+      return 'win';
     }
     return 'mob';
   }
 
   wrapWithBoilerplate (code) {
-    if (code && code.includes('mob.open')) {
-      this.caps.browserName = '__chrome_or_safari__';
-    } else {
-      this.caps.app = '__application_path_or_name__';
-    }
-    let caps = JSON.stringify(this.caps, null, 2);
-    let url = JSON.stringify(`${this.scheme}://${this.host}:${this.port}${this.path}`);
-    return `// Requires the Oxygen HQ client library
+    return `// This sample code uses the Oxygen HQ client library
 // (npm install oxygen-cli -g)
 // Then paste this into a .js file and run with:
 // oxygen <file>.js
-const capabilities = ${caps};
-const appiumUrl = ${url};
-${this.type}.init(capabilities, appiumUrl);
 
-${code}
+const caps = ${JSON.stringify(this.caps)};
+const appiumUrl = "${this.serverUrl}";
+${this.type}.init(caps, appiumUrl);
 
-`;
+${code}`;
   }
 
   addComment(comment) {
     return `// ${comment}`;
   }
 
-  codeFor_executeScript (varNameIgnore, varIndexIgnore, args) {
-    return `${this.type}.execute(${args})`;
-  }
-
   codeFor_findAndAssign (strategy, locator, localVar, isArray) {
-    // wdio has its own way of indicating the strategy in the locator string
-    switch (strategy) {
-      case 'xpath': break; // xpath does not need to be updated
-      case 'accessibility id': locator = `~${locator}`; break;
-      case 'id': locator = `id=${locator}`; break;
-      case 'name': locator = `name=${locator}`; break;
-      case 'class name': locator = `css=${locator}`; break;
-      case '-android uiautomator': locator = `android=${locator}`; break;
-      case '-android datamatcher': locator = `android=${locator}`; break;
-      case '-ios predicate string': locator = `ios=${locator}`; break;
-      case '-ios class chain': locator = `ios=${locator}`; break; // TODO: Handle IOS class chain properly. Not all libs support it. Or take it out
-      default: return this.handleUnsupportedLocatorStrategy(strategy, locator);
+    // oxygen internally uses wdio for element search
+    const validStrategies = [
+      'xpath',
+      'accessibility id',
+      'id',
+      'class name',
+      'name',
+      '-android uiautomator',
+      '-android datamatcher',
+      '-android viewtag',
+      '-ios predicate string',
+      '-ios class chain'
+    ];
+    if (!validStrategies.includes(strategy)) {
+      return this.handleUnsupportedLocatorStrategy(strategy, locator);
     }
     if (isArray) {
-      return `let ${localVar} = mob.findElements(${JSON.stringify(locator)});`;
+      return `const ${localVar} = mob.findElements(${JSON.stringify(`${strategy}:${locator}`)});`;
     } else {
-      return `let ${localVar} = mob.findElement(${JSON.stringify(locator)});`;
+      return `const ${localVar} = mob.findElement(${JSON.stringify(`${strategy}:${locator}`)});`;
     }
   }
 
@@ -84,85 +67,109 @@ ${code}
     return `${this.type}.type(${this.getVarName(varName, varIndex)}, ${JSON.stringify(text)});`;
   }
 
-  codeFor_back () {
-    return `${this.type}.back();`;
-  }
-
   codeFor_tap (varNameIgnore, varIndexIgnore, pointerActions) {
     const {x, y} = this.getTapCoordinatesFromPointerActions(pointerActions);
-
     return `${this.type}.tap(${x}, ${y});`;
   }
 
   codeFor_swipe (varNameIgnore, varIndexIgnore, pointerActions) {
     const {x1, y1, x2, y2} = this.getSwipeCoordinatesFromPointerActions(pointerActions);
-
     return `${this.type}.swipeScreen(${x1}, ${y1}, ${x2}, ${y2});`;
   }
 
+  // Execute Script
+
+  codeFor_executeScriptNoArgs (scriptCmd) {
+    return `${this.type}.execute(${JSON.stringify(scriptCmd)});`;
+  }
+
+  codeFor_executeScriptWithArgs (scriptCmd, jsonArg) {
+    return `${this.type}.execute(${JSON.stringify(scriptCmd)}, ${JSON.stringify(jsonArg[0])});`;
+  }
+
+  // App Management
+
   codeFor_getCurrentActivity () {
-    return `let activityName = ${this.type}.getCurrentActivity();`;
+    return `let activityName = ${this.codeFor_executeScriptNoArgs('mobile: getCurrentActivity')}`;
   }
 
   codeFor_getCurrentPackage () {
-    return `let packageName = ${this.type}.getCurrentPackage();`;
+    return `let packageName = ${this.codeFor_executeScriptNoArgs('mobile: getCurrentPackage')}`;
   }
 
   codeFor_installApp (varNameIgnore, varIndexIgnore, app) {
-    return `${this.type}.installApp('${app}');`;
+    return `${this.type}.installApp("${app}");`;
   }
 
   codeFor_isAppInstalled (varNameIgnore, varIndexIgnore, app) {
     return `let isAppInstalled = ${this.type}.isAppInstalled("${app}");`;
   }
 
-  codeFor_background (varNameIgnore, varIndexIgnore, timeout) {
-    return `${this.type}.getDriver().background(${timeout});`;
+  codeFor_activateApp (varNameIgnore, varIndexIgnore, app) {
+    return `${this.type}.getDriver().activateApp("${app}");`;
+  }
+
+  codeFor_terminateApp (varNameIgnore, varIndexIgnore, app) {
+    return `${this.type}.getDriver().terminateApp("${app}");`;
   }
 
   codeFor_removeApp (varNameIgnore, varIndexIgnore, app) {
-    return `${this.type}.removeApp('${app}')`;
+    return `${this.type}.removeApp("${app}")`;
   }
 
   codeFor_getStrings (varNameIgnore, varIndexIgnore, language, stringFile) {
-    return `let appStrings = ${this.type}.getDriver().getStrings(${language ? `${language}, ` : ''}${stringFile ? `"${stringFile}` : ''});`;
+    return `let appStrings = ${this.type}.getDriver().getStrings(${language ? `"${language}", ` : ''}${stringFile ? `"${stringFile}"` : ''});`;
   }
+
+  // Clipboard
 
   codeFor_getClipboard () {
     return `let clipboardText = ${this.type}.getDriver().getClipboard();`;
   }
 
   codeFor_setClipboard (varNameIgnore, varIndexIgnore, clipboardText) {
-    return `${this.type}.getDriver().setClipboard('${clipboardText}')`;
+    return `${this.type}.getDriver().setClipboard("${clipboardText}")`;
   }
 
-  codeFor_pressKeyCode (varNameIgnore, varIndexIgnore, keyCode) {
-    return `${this.type}.pressKeyCode(${keyCode});`;
+  // File Transfer
+
+  codeFor_pushFile (varNameIgnore, varIndexIgnore, pathToInstallTo, fileContentString) {
+    return `${this.type}.getDriver().pushFile("${pathToInstallTo}", "${fileContentString}");`;
   }
 
-  codeFor_longPressKeyCode (varNameIgnore, varIndexIgnore, keyCode) {
-    return `${this.type}.longPressKeyCode(${keyCode});`;
+  codeFor_pullFile (varNameIgnore, varIndexIgnore, pathToPullFrom) {
+    return `let fileBase64 = ${this.type}.getDriver().pullFile("${pathToPullFrom}");`;
   }
 
-  codeFor_hideKeyboard () {
-    return `${this.type}.hideKeyboard();`;
+  codeFor_pullFolder (varNameIgnore, varIndexIgnore, folderToPullFrom) {
+    return `let fileBase64 = ${this.type}.getDriver().pullFolder("${folderToPullFrom}");`;
   }
+
+  // Device Interaction
+
+  codeFor_isLocked () {
+    return `let isLocked = ${this.codeFor_executeScriptNoArgs('mobile: isLocked')}`;
+  }
+
+  codeFor_rotateDevice (varNameIgnore, varIndexIgnore, x, y, radius, rotation, touchCount, duration) {
+    return `${this.type}.getDriver().rotateDevice({x: ${x}, y: ${y}, duration: ${duration}, radius: ${radius}, rotation: ${rotation}, touchCount: ${touchCount}});`;
+  }
+
+  codeFor_touchId (varNameIgnore, varIndexIgnore, match) {
+    return `${this.type}.getDriver().touchId(${match});`;
+  }
+
+  codeFor_toggleEnrollTouchId (varNameIgnore, varIndexIgnore, enroll) {
+    return `${this.type}.getDriver().toggleEnrollTouchId(${enroll});`;
+  }
+
+  // Keyboard
 
   codeFor_isKeyboardShown () {
     return `let isKeyboardShown = ${this.type}.getDriver().isKeyboardShown();`;
   }
 
-  codeFor_pushFile (varNameIgnore, varIndexIgnore, pathToInstallTo, fileContentString) {
-    return `${this.type}.getDriver().pushFile('${pathToInstallTo}', '${fileContentString}');`;
-  }
-
-  codeFor_pullFile (varNameIgnore, varIndexIgnore, pathToPullFrom) {
-    return `let fileBase64 = ${this.type}.getDriver().pullFile('${pathToPullFrom}');`;
-  }
-
-  codeFor_pullFolder (varNameIgnore, varIndexIgnore, folderToPullFrom) {
-    return `let fileBase64 = ${this.type}.getDriver().pullFolder('${folderToPullFrom}');`;
-  }
+  // Connectivity
 
   codeFor_toggleAirplaneMode () {
     return `${this.type}.getDriver().toggleAirplaneMode();`;
@@ -176,84 +183,30 @@ ${code}
     return `${this.type}.getDriver().toggleWiFi();`;
   }
 
-  codeFor_toggleLocationServices () {
-    return `${this.type}.getDriver().toggleLocationServices();`;
-  }
-
   codeFor_sendSMS (varNameIgnore, varIndexIgnore, phoneNumber, text) {
-    return `${this.type}.getDriver().sendSms('${phoneNumber}', '${text}');`;
+    return `${this.type}.getDriver().sendSms("${phoneNumber}", "${text}");`;
   }
 
   codeFor_gsmCall (varNameIgnore, varIndexIgnore, phoneNumber, action) {
-    return `${this.type}.getDriver().gsmCall('${phoneNumber}', '${action}');`;
+    return `${this.type}.getDriver().gsmCall("${phoneNumber}", "${action}");`;
   }
 
   codeFor_gsmSignal (varNameIgnore, varIndexIgnore, signalStrength) {
-    return `${this.type}.getDriver().gsmSignal(${signalStrength});`;
+    return `${this.type}.getDriver().gsmSignal("${signalStrength}");`;
   }
 
   codeFor_gsmVoice (varNameIgnore, varIndexIgnore, state) {
-    return `${this.type}.getDriver().gsmVoice('${state}');`;
+    return `${this.type}.getDriver().gsmVoice("${state}");`;
   }
 
-  codeFor_shake () {
-    return `${this.type}.shake();`;
-  }
-
-  codeFor_lock (varNameIgnore, varIndexIgnore, seconds) {
-    return `${this.type}.getDriver().lock(${seconds});`;
-  }
-
-  codeFor_unlock () {
-    return `${this.type}.getDriver().unlock();`;
-  }
-
-  codeFor_isLocked () {
-    return `let isLocked = ${this.type}.getDriver().isLocked();`;
-  }
-
-  codeFor_rotateDevice (varNameIgnore, varIndexIgnore, x, y, radius, rotation, touchCount, duration) {
-    return `${this.type}.getDriver().rotateDevice({x: ${x}, y: ${y}, duration: ${duration}, radius: ${radius}, rotation: ${rotation}, touchCount: ${touchCount}});`;
-  }
-
-  codeFor_getPerformanceData (varNameIgnore, varIndexIgnore, packageName, dataType, dataReadTimeout) {
-    return `let performanceData = ${this.type}.getDriver().getPerformanceData('${packageName}', '${dataType}', ${dataReadTimeout});`;
-  }
-
-  codeFor_getPerformanceDataTypes () {
-    return `let supportedPerformanceDataTypes = ${this.type}.getDriver().getPerformanceDataTypes();`;
-  }
-
-  codeFor_touchId (varNameIgnore, varIndexIgnore, match) {
-    return `${this.type}.getDriver().touchId(${match});`;
-  }
-
-  codeFor_toggleEnrollTouchId (varNameIgnore, varIndexIgnore, enroll) {
-    return `${this.type}.getDriver().toggleEnrollTouchId(${enroll});`;
-  }
-
-  codeFor_openNotifications () {
-    return `${this.type}.getDriver().openNotifications();`;
-  }
-
-  codeFor_getDeviceTime () {
-    return `let time = ${this.type}.getDeviceTime();`;
-  }
-
-  codeFor_fingerprint (varNameIgnore, varIndexIgnore, fingerprintId) {
-    return `${this.type}.getDriver().fingerPrint(${fingerprintId});`;
-  }
+  // Session
 
   codeFor_getSession () {
-    return `let caps = ${this.type}.getDriver().capabilities;`;
+    return `let caps = ${this.type}.getDriver().getSession();`;
   }
 
   codeFor_setTimeouts (/*varNameIgnore, varIndexIgnore, timeoutsJson*/) {
     return '/* TODO implement setTimeouts */';
-  }
-
-  codeFor_setCommandTimeout () {
-    return `// Not supported: setCommandTimeout`;
   }
 
   codeFor_getOrientation () {
@@ -277,15 +230,51 @@ ${code}
   }
 
   codeFor_getLogs (varNameIgnore, varIndexIgnore, logType) {
-    return `let logs = ${this.type}.getDriver().getLogs('${logType}');`;
+    return `let logs = ${this.type}.getDriver().getLogs("${logType}");`;
   }
 
   codeFor_updateSettings (varNameIgnore, varIndexIgnore, settingsJson) {
-    return `${this.type}.getDriver().updateSettings(${settingsJson});`;
+    return `${this.type}.getDriver().updateSettings(${JSON.stringify(settingsJson)});`;
   }
 
   codeFor_getSettings () {
     return `let settings = ${this.type}.getDriver().getSettings();`;
+  }
+
+  // Web
+
+  codeFor_navigateTo (varNameIgnore, varIndexIgnore, url) {
+    return `${this.type}.open("${url}");`;
+  }
+
+  codeFor_getUrl () {
+    return `${this.type}.getUrl();`;
+  }
+
+  codeFor_back () {
+    return `${this.type}.back();`;
+  }
+
+  codeFor_forward () {
+    return `${this.type}.getDriver().forward();`;
+  }
+
+  codeFor_refresh () {
+    return `${this.type}.getDriver().refresh();`;
+  }
+
+  // Context
+
+  codeFor_getContext () {
+    return `let context = ${this.type}.getDriver().getContext();`;
+  }
+
+  codeFor_getContexts () {
+    return `let contexts = ${this.type}.getDriver().getContexts();`;
+  }
+
+  codeFor_switchContext (varNameIgnore, varIndexIgnore, name) {
+    return `${this.type}.setContext("${name}");`;
   }
 }
 


### PR DESCRIPTION
This PR updates the recorder-generated code for the Oxygen HQ client. Similarly to Robot, I'm not sure how well maintained this client is, but this should be an improvement nonetheless.

* Simplify module detection (`win` or `mob`)
* Rely on WDIO for locator strategy identification
* Fix `executeScript` and `updateSettings`
* Add `activateApp`, `terminateApp`, various web and context methods
* Change many methods deprecated in `ruby_lib_core` 7.3 to their mobile extension equivalents
* Reorder and group driver command implementations