### PR TITLE
feat: add Java JUnit 5 recorder

### DIFF
--- a/app/renderer/lib/client-frameworks/index.js
+++ b/app/renderer/lib/client-frameworks/index.js
@@ -1,6 +1,7 @@
 import JsWdIoFramework from './js-wdio';
 import JsOxygenFramework from './js-oxygen';
-import JavaFramework from './java';
+import JavaJUnit4Framework from './java-junit4';
+import JavaJUnit5Framework from './java-junit5';
 import PythonFramework from './python';
 import RubyFramework from './ruby';
 import RobotFramework from './robot';
@@ -8,7 +9,8 @@ import RobotFramework from './robot';
 const frameworks = {
   jsWdIo: JsWdIoFramework,
   jsOxygen: JsOxygenFramework,
-  java: JavaFramework,
+  java: JavaJUnit4Framework,
+  javaJUnit5: JavaJUnit5Framework,
   python: PythonFramework,
   ruby: RubyFramework,
   robot: RobotFramework,

--- a/app/renderer/lib/client-frameworks/java-common.js
+++ b/app/renderer/lib/client-frameworks/java-common.js
@@ -7,8 +7,8 @@ class JavaFramework extends Framework {
     return 'java';
   }
 
-  wrapWithBoilerplate (code) {
-    let [pkg, cls] = (() => {
+  getBoilerplateParams () {
+    const [pkg, cls] = (() => {
       if (this.caps.platformName) {
         switch (this.caps.platformName.toLowerCase()) {
           case 'ios': return ['ios', 'IOSDriver'];
@@ -23,52 +23,8 @@ class JavaFramework extends Framework {
         return ['unknownPlatform', 'UnknownDriver'];
       }
     })();
-    let capStr = this.indent(Object.keys(this.caps).map((k) => `.amend(${JSON.stringify(k)}, ${JSON.stringify(this.caps[k])})`).join('\n'), 6);
-    // Import everything from Selenium in order to use WebElement, Point and other classes.
-    return `
-// This sample code supports Appium Java client >=9
-// https://github.com/appium/java-client
-import io.appium.java_client.remote.options.BaseOptions;
-import io.appium.java_client.${pkg}.${cls};
-import java.net.URL;
-import java.time.Duration;
-import java.util.Arrays;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openqa.selenium.*;
-
-public class SampleTest {
-
-  private ${cls} driver;
-
-  @Before
-  public void setUp() {
-    var options = new BaseOptions()
-${capStr};
-
-    private URL getUrl() {
-      try {
-        return new URL("${this.serverUrl}");
-      } catch (MalformedURLException e) {
-        e.printStackTrace();
-      }
-    }
-
-    driver = new ${cls}(this.getUrl(), options);
-  }
-
-  @Test
-  public void sampleTest() {
-${this.indent(code, 4)}
-  }
-
-  @After
-  public void tearDown() {
-    driver.quit();
-  }
-}
-`;
+    const capStr = this.indent(_.map(this.caps, (v, k) => `.amend(${JSON.stringify(k)}, ${JSON.stringify(v)})`).join('\n'), 6);
+    return [pkg, cls, capStr];
   }
 
   addComment(comment) {
@@ -419,7 +375,5 @@ driver.perform(Arrays.asList(swipe));
     return `driver.context("${name}");`;
   }
 }
-
-JavaFramework.readableName = 'Java - JUnit';
 
 export default JavaFramework;

--- a/app/renderer/lib/client-frameworks/java-junit4.js
+++ b/app/renderer/lib/client-frameworks/java-junit4.js
@@ -1,0 +1,57 @@
+import JavaFramework from './java-common';
+
+class JavaJUnit4Framework extends JavaFramework {
+
+  wrapWithBoilerplate (code) {
+    const [pkg, cls, capStr] = this.getBoilerplateParams();
+    // Import everything from Selenium in order to use WebElement, Point and other classes.
+    return `// This sample code supports Appium Java client >=9
+// https://github.com/appium/java-client
+import io.appium.java_client.remote.options.BaseOptions;
+import io.appium.java_client.${pkg}.${cls};
+import java.net.URL;
+import java.time.Duration;
+import java.util.Arrays;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.*;
+
+public class SampleTest {
+
+  private ${cls} driver;
+
+  @Before
+  public void setUp() {
+    var options = new BaseOptions()
+${capStr};
+
+    private URL getUrl() {
+      try {
+        return new URL("${this.serverUrl}");
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+
+    driver = new ${cls}(this.getUrl(), options);
+  }
+
+  @Test
+  public void sampleTest() {
+${this.indent(code, 4)}
+  }
+
+  @After
+  public void tearDown() {
+    driver.quit();
+  }
+}
+`;
+  }
+
+}
+
+JavaJUnit4Framework.readableName = 'Java - JUnit4';
+
+export default JavaJUnit4Framework;

--- a/app/renderer/lib/client-frameworks/java-junit5.js
+++ b/app/renderer/lib/client-frameworks/java-junit5.js
@@ -1,0 +1,57 @@
+import JavaFramework from './java-common';
+
+class JavaJUnit5Framework extends JavaFramework {
+
+  wrapWithBoilerplate (code) {
+    const [pkg, cls, capStr] = this.getBoilerplateParams();
+    // Import everything from Selenium in order to use WebElement, Point and other classes.
+    return `// This sample code supports Appium Java client >=9
+// https://github.com/appium/java-client
+import io.appium.java_client.remote.options.BaseOptions;
+import io.appium.java_client.${pkg}.${cls};
+import java.net.URL;
+import java.time.Duration;
+import java.util.Arrays;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.*;
+
+public class SampleTest {
+
+  private ${cls} driver;
+
+  @BeforeEach
+  public void setUp() {
+    var options = new BaseOptions()
+${capStr};
+
+    private URL getUrl() {
+      try {
+        return new URL("${this.serverUrl}");
+      } catch (MalformedURLException e) {
+        e.printStackTrace();
+      }
+    }
+
+    driver = new ${cls}(this.getUrl(), options);
+  }
+
+  @Test
+  public void sampleTest() {
+${this.indent(code, 4)}
+  }
+
+  @AfterEach
+  public void tearDown() {
+    driver.quit();
+  }
+}
+`;
+  }
+
+}
+
+JavaJUnit5Framework.readableName = 'Java - JUnit5';
+
+export default JavaJUnit5Framework;


### PR DESCRIPTION
This PR adds a new recorder for Java JUnit 5. The only difference from JUnit 4 is some imports and annotations, so most of the code generation is shared between both classes, and each class only implements its own boilerplate method.
Resolves #156.