### PR TITLE
chore(deps): remove ky

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -866,18 +866,15 @@ export function getRunningSessions () {
 
     try {
       const adjPath = path.endsWith('/') ? path : `${path}/`;
+      const url = `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`;
       const res = username && accessKey
-        ? await axios({
-          url: `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`,
-          headers: {
-            'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`,
-            'content-type': HEADERS_CONTENT
-          }
-        })
-        : await axios({
-          url: `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`,
-          headers: {'content-type': HEADERS_CONTENT}
-        });
+        ? await axios({url, headers: {
+          'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`,
+          'content-type': HEADERS_CONTENT
+        }})
+        : await axios({url, headers: {
+          'content-type': HEADERS_CONTENT
+        }});
       dispatch({type: GET_SESSIONS_DONE, sessions: res.data.value});
     } catch (err) {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -8,7 +8,7 @@ import i18n from '../../configs/i18next.config.renderer';
 import CloudProviders from '../components/Session/CloudProviders';
 import { Web2Driver } from 'web2driver';
 import { addVendorPrefixes } from '../util';
-import ky from 'ky/umd';
+import axios from 'axios';
 import moment from 'moment';
 import { APP_MODE } from '../components/Inspector/shared';
 import { ipcRenderer, fs, util } from '../polyfills';
@@ -531,7 +531,7 @@ export function newSession (caps, attachSessId = null) {
           const {protocol, hostname, port, path} = serverOpts;
           try {
             const detailsUrl = `${protocol}://${hostname}:${port}${path.replace(/\/$/, '')}/session/${attachSessId}`;
-            attachedSessionCaps = (await ky(detailsUrl).json()).value;
+            attachedSessionCaps = (await axios(detailsUrl).data).value;
           } catch (err) {
             // rethrow the error as session not running, but first log the original error to
             // console
@@ -867,16 +867,18 @@ export function getRunningSessions () {
     try {
       const adjPath = path.endsWith('/') ? path : `${path}/`;
       const res = username && accessKey
-        ? await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`, {
+        ? await axios({
+          url: `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`,
           headers: {
             'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`,
             'content-type': HEADERS_CONTENT
           }
-        }).json()
-        : await ky(`http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`, {
+        })
+        : await axios({
+          url: `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`,
           headers: {'content-type': HEADERS_CONTENT}
-        }).json();
-      dispatch({type: GET_SESSIONS_DONE, sessions: res.value});
+        });
+      dispatch({type: GET_SESSIONS_DONE, sessions: res.data.value});
     } catch (err) {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console
       dispatch({type: GET_SESSIONS_DONE});

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -867,14 +867,10 @@ export function getRunningSessions () {
     try {
       const adjPath = path.endsWith('/') ? path : `${path}/`;
       const url = `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}sessions`;
-      const res = username && accessKey
-        ? await axios({url, headers: {
-          'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`,
-          'content-type': HEADERS_CONTENT
-        }})
-        : await axios({url, headers: {
-          'content-type': HEADERS_CONTENT
-        }});
+      const res = await axios({url, headers: {
+        'content-type': HEADERS_CONTENT,
+        ...(username && accessKey ? {'Authorization': `Basic ${btoa(`${username}:${accessKey}`)}`} : {})
+      }});
       dispatch({type: GET_SESSIONS_DONE, sessions: res.data.value});
     } catch (err) {
       console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "i18next-fs-backend": "2.3.0",
         "i18next-http-backend": "2.4.1",
         "i18next-localstorage-backend": "4.2.0",
-        "ky": "0.25.1",
         "lodash": "4.17.21",
         "moment": "2.29.4",
         "react": "18.2.0",
@@ -15262,17 +15261,6 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/ky": {
-      "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/ky/-/ky-0.25.1.tgz",
-      "integrity": "sha512-PjpCEWlIU7VpiMVrTwssahkYXX1by6NCT0fhTUX34F3DTinARlgMpriuroolugFPcMgpPWrOW4mTb984Qm1RXA==",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/ky?sponsor=1"
-      }
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.22",

--- a/package.json
+++ b/package.json
@@ -137,7 +137,6 @@
     "cheerio": "1.0.0-rc.11: errors with export namespace",
     "electron-settings": "V5: need to rewrite to IPC while keeping browser version working",
     "htmlparser2": "8.0.0: errors with export namespace",
-    "ky": "0.26.0: module is now ESM and parcel tries to bundle it with require",
     "uuid": "Obsolete: can be replaced with crypto.randomUUID in Electron 14+"
   },
   "dependencies": {
@@ -157,7 +156,6 @@
     "i18next-fs-backend": "2.3.0",
     "i18next-http-backend": "2.4.1",
     "i18next-localstorage-backend": "4.2.0",
-    "ky": "0.25.1",
     "lodash": "4.17.21",
     "moment": "2.29.4",
     "react": "18.2.0",


### PR DESCRIPTION
This PR replaces `ky` with `axios`. There's no need for two HTTP clients, and `ky` was outdated anyway.
Local session discovery was tested to still work.