### PR TITLE
fix: undefined value reference

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -531,7 +531,8 @@ export function newSession (caps, attachSessId = null) {
           const {protocol, hostname, port, path} = serverOpts;
           try {
             const detailsUrl = `${protocol}://${hostname}:${port}${path.replace(/\/$/, '')}/session/${attachSessId}`;
-            attachedSessionCaps = (await axios(detailsUrl).data).value;
+            const res = await axios({url: detailsUrl, headers: { 'content-type': HEADERS_CONTENT }, timeout: CONN_TIMEOUT});
+            attachedSessionCaps = res.data.value;
           } catch (err) {
             // rethrow the error as session not running, but first log the original error to
             // console


### PR DESCRIPTION
I saw "cannot read properties of undefined" error for `value` in current implementation. Maybe `(await axios(detailsUrl).data)` result was undefined then. Lets wait the axios response, then check the data and value. This fixed my observed issue
