### PR TITLE
Update dev install doc and single test run

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Want to help us develop this app? We'd love it! Getting set up to do development
 2. Install dependencies (`npm ci`)
 
 > **Note** There are some possible requirements prior to the install, because of [node-gyp](https://github.com/nodejs/node-gyp#installation):
+>
 > - [Python](https://www.python.org/)
 > - some C/C++ compiler tools matching your operating system
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Want to help us develop this app? We'd love it! Getting set up to do development
 From here, have a look at the `scripts` field of our package.json to see what kind of dev scripts you might want to run. Some of the most useful are:
 
 - `npm test`: run basic lint and unit tests
-- `npm e2e`: run E2E tests
+- `npm run e2e`: run E2E tests
 - `npm run dev`: run the app in dev mode (will refresh when you make code changes)
 - `npm run build`: build the production version of the app into `dist/`
 - `npm run build:browser`: build a version of the app for web browsers into `dist-browser/`

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Issues that have to do with the Inspector specifically can be reported here at t
 Want to help us develop this app? We'd love it! Getting set up to do development is pretty easy:
 
 1. Clone the repo
-2. Install dependencies (`npm install`)
+2. Install dependencies (`npm ci`)
 
 From here, have a look at the `scripts` field of our package.json to see what kind of dev scripts you might want to run. Some of the most useful are:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ Want to help us develop this app? We'd love it! Getting set up to do development
 1. Clone the repo
 2. Install dependencies (`npm ci`)
 
+> **Note** There are some possible requirements prior to the install, because of [node-gyp](https://github.com/nodejs/node-gyp#installation):
+> - [Python](https://www.python.org/)
+> - some C/C++ compiler tools matching your operating system
+
 From here, have a look at the `scripts` field of our package.json to see what kind of dev scripts you might want to run. Some of the most useful are:
 
 - `npm test`: run basic lint and unit tests

--- a/test/unit/webview-helpers-specs.js
+++ b/test/unit/webview-helpers-specs.js
@@ -5,6 +5,7 @@ import {join} from 'path';
 
 import {parseSource} from '../../app/renderer/lib/webview-helpers';
 
+chai.should();
 chai.use(chaiAsPromised);
 
 describe('webview-helpers.js', function () {


### PR DESCRIPTION
1. Better use `npm ci` than `npm install`, to fully rely on `package-lock.json` and not possibly modify it unintentionally

1. Add note about `node-gyp` required installs for python and c/c++ compiler tools

1. Running `webview-helpers-specs.js` only in my IDE resulted in
```
TypeError: Cannot read properties of undefined (reading 'eql')
```
And I found that it is the only spec that calls `chai.use(chaiAsPromised);` but not `chai.should();`.