### PR TITLE
style: remove custom anticon :hover style

### DIFF
--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -17,9 +17,16 @@
   margin-left: 10px;
 }
 
-.sessionContainer :global(.anticon:hover) {
-  background-color: #f08080;
+.sessionContainer :global(.ant-btn-icon-only:not([disabled]):hover),
+.sessionContainer :global(.ant-btn-icon-only:not([disabled]):focus) {
   color: white;
+  border-color: #f08080;
+  background: #f08080;
+}
+.sessionContainer :global(.ant-btn-icon-only:not([disabled]):active) {
+  color: white;
+  border-color: #dc3d32;
+  background: #dc3d32;
 }
 
 .sessionContainer :global(.addCloudProviderTab) {

--- a/app/renderer/components/Session/Session.css
+++ b/app/renderer/components/Session/Session.css
@@ -17,18 +17,6 @@
   margin-left: 10px;
 }
 
-.sessionContainer :global(.ant-btn-icon-only:not([disabled]):hover),
-.sessionContainer :global(.ant-btn-icon-only:not([disabled]):focus) {
-  color: white;
-  border-color: #f08080;
-  background: #f08080;
-}
-.sessionContainer :global(.ant-btn-icon-only:not([disabled]):active) {
-  color: white;
-  border-color: #dc3d32;
-  background: #dc3d32;
-}
-
 .sessionContainer :global(.addCloudProviderTab) {
   font-style: italic;
 }


### PR DESCRIPTION
The existing style is mostly [antd](https://github.com/ant-design/ant-design/tree/4.24.15) default blue, and custom sets `anticon` `:hover` to be like red.
But in most buttons with icon only a reduced part is colored like this ; this change ~makes it be applied to the whole button~ removes this custom style.

![btn-hover-style](https://github.com/appium/appium-inspector/assets/217720/a2cded1a-a816-4b1b-9bab-1c86791b604f)

~Looking at [antd mixins for buttons](https://github.com/ant-design/ant-design/blob/4.24.15/components/button/style/mixin.less#L14), I deal with the same pseudo-classes (`:hover`, `:focus`, and `:active`), and then I set the same 3 style properties (`color`, `border-color`, and `background`).~
And this keeps the default style when the button is `disabled`.

Some not directly targeted elements were previously having the custom `:hover` style too, like some arrows for toggle blocks or dropdowns, and also the link icon at the bottom-left.
They all have the default style back as not targeted by the selectors anymore.
