### PR TITLE
chore(renovate): remove obsolete ky config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,6 @@
       "matchPackageNames": [],
       "matchUpdateTypes": ["major"],
       "enabled": false
-    },
-    {
-      "matchPackageNames": ["ky"],
-      "matchUpdateTypes": ["minor"],
-      "enabled": false
     }
   ],
   "baseBranches": ["main"],


### PR DESCRIPTION
Since `ky` is no longer being used, its specific Renovate configuration can also be removed.