### PR TITLE
fix(build): fix race condition for Windows artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
       "package.json"
     ],
     "win": {
-      "artifactName": "${productName}-windows-${version}.${ext}",
+      "artifactName": "${productName}-windows-${version}-${arch}.${ext}",
       "target": [
         "nsis",
         "zip"


### PR DESCRIPTION
Azure Pipelines were seemingly failing to build Windows artifacts because 7zip had 2 processes writing to the same file. This gives each process a different file to write to.
I tested this locally and the issue was gone.