### PR TITLE
fix: resolve issue with Start Session sometimes needing a second click

### DIFF
--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -1,6 +1,6 @@
 import {LinkOutlined} from '@ant-design/icons';
 import {Badge, Button, Spin, Tabs} from 'antd';
-import _ from 'lodash';
+import _, {cloneDeep} from 'lodash';
 import React, {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 
@@ -53,7 +53,7 @@ const Session = (props) => {
   };
 
   const loadNewSession = async (caps, attachSessId = null) => {
-    if (await newSession(caps, attachSessId)) {
+    if (await newSession(cloneDeep(caps), attachSessId)) {
       navigate('/inspector', {replace: true});
     }
   };

--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -1,6 +1,6 @@
 import {LinkOutlined} from '@ant-design/icons';
 import {Badge, Button, Spin, Tabs} from 'antd';
-import _, {cloneDeep} from 'lodash';
+import _ from 'lodash';
 import React, {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 
@@ -53,7 +53,7 @@ const Session = (props) => {
   };
 
   const loadNewSession = async (caps, attachSessId = null) => {
-    if (await newSession(cloneDeep(caps), attachSessId)) {
+    if (await newSession(_.cloneDeep(caps), attachSessId)) {
       navigate('/inspector', {replace: true});
     }
   };


### PR DESCRIPTION
I found `start session` would throw error `Invariant failed: A state mutation was detected between dispatches, in the path 'session.caps.0.name'.  This may cause incorrect behavior.` first time. function `loadNewSession` use caps directly would cause this bug.

This pr will fix this bug by `cloneDeep(caps)`