### PR TITLE
fix: reduce getSession endpoint calls in hybrid mode

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -590,8 +590,10 @@ export function newSession(caps, attachSessId = null) {
             throw new Error(i18n.t('attachSessionNotRunning', {attachSessId}));
           }
         }
-        serverOpts.isIOS = Boolean(attachedSessionCaps.platformName.match(/iOS/i));
-        serverOpts.isAndroid = Boolean(attachedSessionCaps.platformName.match(/Android/i));
+        // Chrome MJSONWP mode returns "platform" instead of "platformName"
+        const platformName = attachedSessionCaps.platformName || attachedSessionCaps.platform
+        serverOpts.isIOS = Boolean(platformName.match(/iOS/i));
+        serverOpts.isAndroid = Boolean(platformName.match(/Android/i));
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts, attachedSessionCaps);
         driver._isAttachedSession = true;
       } else {

--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -591,7 +591,7 @@ export function newSession(caps, attachSessId = null) {
           }
         }
         // Chrome MJSONWP mode returns "platform" instead of "platformName"
-        const platformName = attachedSessionCaps.platformName || attachedSessionCaps.platform
+        const platformName = attachedSessionCaps.platformName || attachedSessionCaps.platform;
         serverOpts.isIOS = Boolean(platformName.match(/iOS/i));
         serverOpts.isAndroid = Boolean(platformName.match(/Android/i));
         driver = await Web2Driver.attachToSession(attachSessId, serverOpts, attachedSessionCaps);

--- a/app/renderer/lib/appium-client.js
+++ b/app/renderer/lib/appium-client.js
@@ -277,7 +277,6 @@ export default class AppiumClient {
       await this.driver.switchContext(NATIVE_APP);
     }
 
-    const sessionDetails = await this.driver.getSession();
     const isAndroid = this.driver.client.isAndroid;
 
     // Get all available contexts (or the error, if one appears)
@@ -307,8 +306,12 @@ export default class AppiumClient {
             const systemBars = await this.driver.executeScript('mobile:getSystemBars', []);
             webviewTopOffset = systemBars.statusBar.height;
           } catch (e) {
-            // in case driver does not support mobile:getSystemBars
-            webviewTopOffset = sessionDetails.viewportRect.top;
+            try {
+              // to minimize the endpoint call which gets error in newer chromedriver.
+              const sessionDetails = await this.driver.getSession();
+              // in case driver does not support mobile:getSystemBars
+              webviewTopOffset = sessionDetails.viewportRect.top;
+            } catch (ign) {}
           }
         }
       } else if (this.driver.client.isIOS) {
@@ -327,8 +330,11 @@ export default class AppiumClient {
             const deviceScreenInfo = await this.driver.executeScript('mobile:deviceScreenInfo', []);
             webviewLeftOffset = deviceScreenInfo.statusBarSize.height;
           } catch (e) {
-            // in case driver does not support mobile:deviceScreenInfo
-            webviewLeftOffset = sessionDetails.statBarHeight;
+            try {
+              const sessionDetails = await this.driver.getSession();
+              // in case driver does not support mobile:deviceScreenInfo
+              webviewLeftOffset = sessionDetails.statBarHeight;
+            } catch (ign) {}
           }
         }
       }


### PR DESCRIPTION
W3C WebDriver spec does not support `getSession` endpoint call. chrome session with w3c mode returned 404 for the endpoint recently, then `this.driver.getSession` got 404.
Newer drivers do not need to got to fallback, which needs to call getSession, so lets minimize the endpoint call in `appium-client.js`.

In Session.js, it has a case that MJSONWP mode returns `platform` instead of `platformName` in chrome.

e.g, with:
```
  "appium:chromeOptions": {
    "w3c": false
  }
```

then, `attachedSessionCaps.platformName` returns `null` but `attachedSessionCaps.platform` has expected value. So lets get the platformName with `attachedSessionCaps.platformName || attachedSessionCaps.platform`