### PR TITLE
chore: only run Crowdin update if changes exist

### DIFF
--- a/.github/workflows/crowdin-update-resources.yml
+++ b/.github/workflows/crowdin-update-resources.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - 'assets/locales/en/translation.json'
+      - '.github/workflows/crowdin-update-resources.yml' # this file
 
 jobs:
   build:

--- a/.github/workflows/crowdin-update-resources.yml
+++ b/.github/workflows/crowdin-update-resources.yml
@@ -5,6 +5,8 @@ name: Update Crowdin English Resources
 on:
   push:
     branches: [main]
+    paths:
+      - 'assets/locales/en/translation.json'
 
 jobs:
   build:


### PR DESCRIPTION
Currently Crowdin resource update runs for every commit on main, even if no relevant changes exist. Now it will only run for changes in the translation file, and the workflow file.