### PR TITLE
fix: rename Desired Capabilities to Capability Builder

### DIFF
--- a/app/renderer/components/Session/Session.js
+++ b/app/renderer/components/Session/Session.js
@@ -125,7 +125,7 @@ const Session = (props) => {
           className={SessionStyles.scrollingTabCont}
           items={[
             {
-              label: t('Desired Capabilities'),
+              label: t('Capability Builder'),
               key: 'new',
               className: SessionStyles.scrollingTab,
               children: <CapabilityEditor {...props} />,

--- a/assets/locales/en/translation.json
+++ b/assets/locales/en/translation.json
@@ -160,7 +160,7 @@
   "allowUnauthorizedCerts": "Allow Unauthorized Certificates",
   "Use Proxy": "Use Proxy",
   "JSON Representation": "JSON Representation",
-  "Desired Capabilities": "Desired Capabilities",
+  "Capability Builder": "Capability Builder",
   "Saved Capability Sets": "Saved Capability Sets",
   "Attach to Session": "Attach to Session…",
   "localhost": "localhost",


### PR DESCRIPTION
This renames the 'Desired Capabiities' tab in the session builder to 'Capability Builder', which is already used in the docs.