### PR TITLE
chore: add auto-labeler for PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,29 @@
+version: v1
+
+labels:
+  - label: 'enhancement'
+    sync: true
+    matcher:
+      title: '^feat.*?:'
+
+  - label: 'fix'
+    sync: true
+    matcher:
+      title: '^fix.*?:'
+
+  - label: 'documentation'
+    sync: true
+    matcher:
+      title: '^docs.*?:'
+
+  - label: 'chore'
+    sync: true
+    matcher:
+      title: '^chore.*?:'
+      files:
+        all: ['!package-lock.json']
+
+  - label: 'i18n'
+    sync: true
+    matcher:
+      files: ['assets/locales/**']

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,0 +1,16 @@
+name: Labeler
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  labeler:
+    permissions:
+      pull-requests: write
+    name: Auto-Label PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fuxingloh/multi-labeler@v2


### PR DESCRIPTION
Adds an auto-labeler action for PRs, same as in the main Appium repo.
The `dependencies` label is still configured in `renovate.json` (although it may also be worth moving that here for a single source of truth)