### PR TITLE
chore: add dependencies label in labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,8 +20,11 @@ labels:
     sync: true
     matcher:
       title: '^chore.*?:'
-      files:
-        all: ['!package-lock.json']
+
+  - label: 'dependencies'
+    sync: true
+    matcher:
+      files: ['package-lock.json']
 
   - label: 'i18n'
     sync: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base", ":semanticCommitTypeAll(chore)", ":pinAllExceptPeerDependencies"],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,5 @@
 {
   "extends": ["config:base", ":semanticCommitTypeAll(chore)", ":pinAllExceptPeerDependencies"],
-  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
This adds the dependencies label config in the labeler, for cases where dependencies are changed by someone other than Renovate.
Renovate's own configured labeling is intentionally kept, since it also covers things like GitHub Actions, which are harder to track with the labeler.