### PR TITLE
chore: update PR auto-labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,31 +2,26 @@ version: v1
 
 labels:
   - label: 'enhancement'
-    sync: true
     matcher:
       title: '^feat.*?:'
 
   - label: 'fix'
-    sync: true
     matcher:
       title: '^fix.*?:'
 
   - label: 'documentation'
-    sync: true
     matcher:
       title: '^docs.*?:'
+      files: ['README.md', 'docs/**']
 
   - label: 'chore'
-    sync: true
     matcher:
       title: '^chore.*?:'
 
   - label: 'dependencies'
-    sync: true
     matcher:
       files: ['package-lock.json']
 
   - label: 'i18n'
-    sync: true
     matcher:
       files: ['assets/locales/**']


### PR DESCRIPTION
* remove `sync: true` option since it will just remove manually added labels upon new commits
* also add documentation label for changes to README or /docs files