### PR TITLE
chore: add i18n label for Crowdin sync

### DIFF
--- a/.github/workflows/crowdin-sync-translations.yml
+++ b/.github/workflows/crowdin-sync-translations.yml
@@ -32,5 +32,6 @@ jobs:
           token: ${{ github.token }}
           commit-message: 'chore: Update translations'
           title: 'chore: Update translations'
+          labels: i18n
           branch: crowdin-sync-${{ github.run_id }}
           body: 'Update Crowdin Translations: https://crowdin.com/project/appium-desktop'


### PR DESCRIPTION
Not sure why auto-labeler doesn't apply to the Crowdin sync PR, but thankfully the sync job also allows specifying the label.