### PR TITLE
fix: correctly account for position and scroll values of webviews

### DIFF
--- a/app/renderer/lib/webview-helpers.js
+++ b/app/renderer/lib/webview-helpers.js
@@ -24,8 +24,14 @@ export function setHtmlElementAttributes(obj) {
 
     el.setAttribute('data-appium-inspector-width', Math.round(rect.width * dpr));
     el.setAttribute('data-appium-inspector-height', Math.round(rect.height * dpr));
-    el.setAttribute('data-appium-inspector-x', Math.round(webviewLeftOffset + rect.left * dpr));
-    el.setAttribute('data-appium-inspector-y', Math.round(webviewTopOffset + rect.top * dpr));
+    el.setAttribute(
+      'data-appium-inspector-x',
+      Math.round(webviewLeftOffset + (rect.left - window.scrollX) * dpr),
+    );
+    el.setAttribute(
+      'data-appium-inspector-y',
+      Math.round(webviewTopOffset + (rect.top - window.scrollY) * dpr),
+    );
   });
 }
 


### PR DESCRIPTION
This PR fixes two things:

1. On iOS, webviews that didn't occupy the full screen (as in Safari) were not previously considered.
2. On both platforms, `window.scrollX` and `window.scrollY` were also not considered, which are necessary when thinking about the positions of web elements on the screen (web element position is absolute, not viewport relative as mobile elements are).