### PR TITLE
fix: show spinner for element ID property until it is retrieved

### DIFF
--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -90,7 +90,11 @@ const SelectedElement = (props) => {
     value,
     name: key,
   }));
-  dataSource.unshift({key: 'elementId', value: selectedElementId, name: 'elementId'});
+  dataSource.unshift({
+    key: 'elementId',
+    value: selectedElementSearchInProgress ? <Spin /> : selectedElementId,
+    name: 'elementId',
+  });
 
   // Get the columns for the strategies table
   let findColumns = [

--- a/app/renderer/reducers/Inspector.js
+++ b/app/renderer/reducers/Inspector.js
@@ -176,6 +176,7 @@ export default function inspector(state = INITIAL_STATE, action) {
         ...state,
         selectedElement: action.selectedElement,
         selectedElementPath: action.selectedElement.path,
+        selectedElementId: null,
         selectedElementSearchInProgress: true,
         elementInteractionsNotAvailable: false,
         findElementsExecutionTimes: [],


### PR DESCRIPTION
Quick fix for how the Element ID property is displayed in the Selected Element panel. Currently, the property value field starts empty, and is only populated once the element is found. Without a spinner it may be unclear that Appium is searching for the element in the background.
This also fixes the problem when, if an element is selected, and then a different one is selected (without unselecting the current one), the element ID value field keeps the ID of the previous element, until the new one is found. Now it is properly cleared first.