### PR TITLE
feat: add suggested selector for UiAutomator strategy

### DIFF
--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -136,7 +136,8 @@ const findElement = _.debounce(async function (strategyMap, dispatch, getState, 
 
 export function selectElement(path) {
   return async (dispatch, getState) => {
-    const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} = getState().inspector;
+    const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} =
+      getState().inspector;
     const isNative = currentContext === NATIVE_APP;
     // Set the selected element in the source tree
     const selectedElement = findJSONElementByPath(path, sourceJSON);

--- a/app/renderer/actions/Inspector.js
+++ b/app/renderer/actions/Inspector.js
@@ -136,7 +136,7 @@ const findElement = _.debounce(async function (strategyMap, dispatch, getState, 
 
 export function selectElement(path) {
   return async (dispatch, getState) => {
-    const {sourceJSON, sourceXML, expandedPaths, currentContext} = getState().inspector;
+    const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} = getState().inspector;
     const isNative = currentContext === NATIVE_APP;
     // Set the selected element in the source tree
     const selectedElement = findJSONElementByPath(path, sourceJSON);
@@ -156,7 +156,7 @@ export function selectElement(path) {
     dispatch({type: SET_EXPANDED_PATHS, paths: copiedExpandedPaths});
 
     // Calculate the recommended locator strategies
-    const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative);
+    const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative, automationName);
     dispatch({type: SET_OPTIMAL_LOCATORS, strategyMap});
 
     // Debounce find element so that if another element is selected shortly after, cancel the previous search

--- a/app/renderer/components/Inspector/Inspector.css
+++ b/app/renderer/components/Inspector/Inspector.css
@@ -427,6 +427,10 @@
   justify-content: center;
 }
 
+.selectedElemContentRow {
+  display: block;
+}
+
 .sourceTag {
   color: #7d2020;
   font-weight: normal;

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -64,7 +64,10 @@ const SelectedElement = (props) => {
     <span>
       {name}
       <strong>
-        <a onClick={(e) => e.preventDefault() || shell.openExternal(docsLink)}><br/>(docs)</a>
+        <a onClick={(e) => e.preventDefault() || shell.openExternal(docsLink)}>
+          <br />
+          (docs)
+        </a>
       </strong>
     </span>
   );
@@ -231,7 +234,7 @@ const SelectedElement = (props) => {
               columns={findColumns}
               dataSource={findDataSource}
               size="small"
-              scroll={{ x: 'max-content' }}
+              scroll={{x: 'max-content'}}
               pagination={false}
             />
           </Spin>
@@ -250,7 +253,7 @@ const SelectedElement = (props) => {
             columns={attributeColumns}
             dataSource={dataSource}
             size="small"
-            scroll={{ x: 'max-content' }}
+            scroll={{x: 'max-content'}}
             pagination={false}
           />
         </Row>

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -64,7 +64,7 @@ const SelectedElement = (props) => {
     <span>
       {name}
       <strong>
-        <a onClick={(e) => e.preventDefault() || shell.openExternal(docsLink)}>&nbsp;(docs)</a>
+        <a onClick={(e) => e.preventDefault() || shell.openExternal(docsLink)}><br/>(docs)</a>
       </strong>
     </span>
   );
@@ -75,7 +75,7 @@ const SelectedElement = (props) => {
       title: t('Attribute'),
       dataIndex: 'name',
       key: 'name',
-      width: 100,
+      fixed: 'left',
       render: (text) => selectedElementTableCell(text, false),
     },
     {
@@ -100,7 +100,7 @@ const SelectedElement = (props) => {
       title: t('Find By'),
       dataIndex: 'find',
       key: 'find',
-      width: 100,
+      fixed: 'left',
       render: (text) => selectedElementTableCell(text, false),
     },
     {
@@ -116,8 +116,7 @@ const SelectedElement = (props) => {
       title: t('Time'),
       dataIndex: 'time',
       key: 'time',
-      align: 'right',
-      width: 100,
+      fixed: 'right',
       render: (text) => selectedElementTableCell(text, false),
     });
   }
@@ -226,13 +225,13 @@ const SelectedElement = (props) => {
         </Button.Group>
       </Row>
       {findDataSource.length > 0 && (
-        <Row>
+        <Row className={styles.selectedElemContentRow}>
           <Spin spinning={isFindingElementsTimes}>
             <Table
               columns={findColumns}
               dataSource={findDataSource}
               size="small"
-              tableLayout="fixed"
+              scroll={{ x: 'max-content' }}
               pagination={false}
             />
           </Spin>
@@ -246,11 +245,12 @@ const SelectedElement = (props) => {
         </div>
       )}
       {dataSource.length > 0 && (
-        <Row>
+        <Row className={styles.selectedElemContentRow}>
           <Table
             columns={attributeColumns}
             dataSource={dataSource}
             size="small"
+            scroll={{ x: 'max-content' }}
             pagination={false}
           />
         </Row>

--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -19,6 +19,8 @@ const CLASS_CHAIN_DOCS_URL =
   'https://github.com/facebookarchive/WebDriverAgent/wiki/Class-Chain-Queries-Construction-Rules';
 const PREDICATE_DOCS_URL =
   'https://github.com/facebookarchive/WebDriverAgent/wiki/Predicate-Queries-Construction-Rules';
+const UIAUTOMATOR_DOCS_URL =
+  'https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/uiautomator-uiselector.md';
 
 /**
  * Shows details of the currently selected element and shows methods that can
@@ -135,6 +137,9 @@ const SelectedElement = (props) => {
         break;
       case '-ios predicate string':
         locator.find = locatorStrategyDocsLink(locator.key, PREDICATE_DOCS_URL);
+        break;
+      case '-android uiautomator':
+        locator.find = locatorStrategyDocsLink(locator.key, UIAUTOMATOR_DOCS_URL);
         break;
     }
   }

--- a/app/renderer/utils/locator-generation.js
+++ b/app/renderer/utils/locator-generation.js
@@ -78,10 +78,11 @@ export function getSimpleSuggestedLocators(attributes, sourceDoc, isNative = tru
  *
  * @param {string} path a dot-separated string of indices
  * @param {Document} sourceDoc
+ * @param {boolean} isNative whether native context is active
  * @param {string} automationName
  * @returns {Object.<string, string>} mapping of strategies to selectors
  */
-export function getComplexSuggestedLocators(path, sourceDoc, automationName) {
+export function getComplexSuggestedLocators(path, sourceDoc, isNative, automationName) {
   let complexLocators = {};
   const domNode = findDOMNodeByPath(path, sourceDoc);
   if (domNode.tagName.includes('XCUIElement')) {
@@ -89,7 +90,7 @@ export function getComplexSuggestedLocators(path, sourceDoc, automationName) {
     const optimalClassChain = getOptimalClassChain(sourceDoc, domNode);
     complexLocators['-ios class chain'] = optimalClassChain ? '**' + optimalClassChain : null;
     complexLocators['-ios predicate string'] = getOptimalPredicateString(sourceDoc, domNode);
-  } else if (automationName.toLowerCase() === 'uiautomator2') {
+  } else if (automationName.toLowerCase() === 'uiautomator2' && isNative) {
     complexLocators['-android uiautomator'] = getOptimalUiAutomatorSelector(
       sourceDoc,
       domNode,
@@ -121,6 +122,7 @@ export function getSuggestedLocators(selectedElement, sourceXML, isNative, autom
   const complexLocators = getComplexSuggestedLocators(
     selectedElement.path,
     sourceDoc,
+    isNative,
     automationName,
   );
   return _.toPairs({...simpleLocators, ...complexLocators});

--- a/app/renderer/utils/locator-generation.js
+++ b/app/renderer/utils/locator-generation.js
@@ -493,8 +493,7 @@ export function getOptimalUiAutomatorSelector(doc, domNode, path) {
     const newDomNode = findDOMNodeByPath(newPath, newDoc);
 
     // BASE CASE #4: Check all attributes and try to find unique ones
-    let uiSelector, othersWithAttr, mostUniqueSelector;
-    let othersWithAttrMinCount = 99;
+    let uiSelector, othersWithAttr, othersWithAttrMinCount, mostUniqueSelector;
 
     for (const [attrName, attrTranslation] of CHECKED_UIAUTOMATOR_ATTRIBUTES) {
       const attrValue = newDomNode.getAttribute(attrName);
@@ -516,7 +515,7 @@ export function getOptimalUiAutomatorSelector(doc, domNode, path) {
       // but only if it returns the least number of elements
       if (othersWithAttr.length === 1) {
         return uiSelector;
-      } else if (othersWithAttr.length < othersWithAttrMinCount) {
+      } else if (!othersWithAttrMinCount || othersWithAttr.length < othersWithAttrMinCount) {
         othersWithAttrMinCount = othersWithAttr.length;
         mostUniqueSelector = `${uiSelector}.instance(${othersWithAttr.indexOf(newDomNode)})`;
       }

--- a/app/renderer/utils/locator-generation.js
+++ b/app/renderer/utils/locator-generation.js
@@ -312,12 +312,8 @@ export function getOptimalXPath(doc, domNode) {
     // Make a recursive call to this nodes parents and prepend it to this xpath
     return getOptimalXPath(doc, domNode.parentNode) + xpath;
   } catch (error) {
-    // If there's an unexpected exception, abort and don't get an XPath
-    log.error(
-      `The most optimal XPATH could not be determined ` +
-        `because an error was thrown: '${JSON.stringify(error, null, 2)}'`,
-    );
-
+    // If there's an unexpected exception, abort
+    logLocatorError('XPath', error);
     return null;
   }
 }
@@ -385,12 +381,8 @@ export function getOptimalClassChain(doc, domNode) {
     // Make a recursive call to this nodes parents and prepend it to this xpath
     return getOptimalClassChain(doc, domNode.parentNode) + classChain;
   } catch (error) {
-    // If there's an unexpected exception, abort and don't get an XPath
-    log.error(
-      `The most optimal '-ios class chain' could not be determined ` +
-        `because an error was thrown: '${JSON.stringify(error, null, 2)}'`,
-    );
-
+    // If there's an unexpected exception, abort
+    logLocatorError('class chain', error);
     return null;
   }
 }
@@ -439,12 +431,8 @@ export function getOptimalPredicateString(doc, domNode) {
       }
     }
   } catch (error) {
-    // If there's an unexpected exception, abort and don't get an XPath
-    log.error(
-      `The most optimal '-ios predicate string' could not be determined ` +
-        `because an error was thrown: '${JSON.stringify(error, null, 2)}'`,
-    );
-
+    // If there's an unexpected exception, abort
+    logLocatorError('predicate string', error);
     return null;
   }
 }
@@ -526,11 +514,13 @@ export function getOptimalUiAutomatorSelector(doc, domNode, path) {
     }
   } catch (error) {
     // If there's an unexpected exception, abort
-    log.error(
-      `The most optimal '-android uiautomator' could not be determined ` +
-        `because an error was thrown: '${JSON.stringify(error, null, 2)}'`,
-    );
-
+    logLocatorError('uiautomator selector', error);
     return null;
   }
+}
+
+function logLocatorError(strategy, error) {
+  log.error(
+    `The most optimal ${strategy} could not be determined because an error was thrown: '${error}'`,
+  );
 }

--- a/app/renderer/utils/source-parsing.js
+++ b/app/renderer/utils/source-parsing.js
@@ -1,7 +1,8 @@
-import {DOMParser} from '@xmldom/xmldom';
+import {DOMParser, XMLSerializer} from '@xmldom/xmldom';
 import _ from 'lodash';
 
 export const domParser = new DOMParser();
+export const xmlSerializer = new XMLSerializer();
 
 /**
  * Get the child nodes of a Node object
@@ -9,7 +10,7 @@ export const domParser = new DOMParser();
  * @param {Node} domNode
  * @returns {Array<Node|null>} list of Nodes
  */
-function childNodesOf(domNode) {
+export function childNodesOf(domNode) {
   if (!domNode || !domNode.hasChildNodes()) {
     return [];
   }

--- a/test/unit/utils-locator-generation-specs.js
+++ b/test/unit/utils-locator-generation-specs.js
@@ -6,6 +6,7 @@ import {
   areAttrAndValueUnique,
   getOptimalClassChain,
   getOptimalPredicateString,
+  getOptimalUiAutomatorSelector,
   getOptimalXPath,
   getSimpleSuggestedLocators,
 } from '../../app/renderer/utils/locator-generation';
@@ -424,6 +425,48 @@ describe('utils/locator-generation.js', function () {
         </child>
       </root>`);
       should.not.exist(getOptimalPredicateString(doc, doc.getElementsByTagName('grandchild')[0]));
+    });
+  });
+
+  describe('#getOptimalUiAutomatorSelector', function () {
+    let doc;
+
+    it('should use unique UiAutomator attributes if the node has them', function () {
+      doc = xmlToDoc(`<xml>
+        <parent-node>
+          <child-node resource-id='hello'>Hello</child-node>
+          <child-node resource-id='world'>World</child-node>
+        </parent-node>
+      </xml>`);
+      getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('child-node')[0], '0.0').should.equal(
+        'new UiSelector().resourceId("hello")',
+      );
+    });
+
+    it('should use indices if the valid node attributes are not unique', function () {
+      doc = xmlToDoc(`<root>
+        <child>
+          <grandchild class='grandchild'>Hello</grandchild>
+          <grandchild class='grandchild'>World</grandchild>
+        </child>
+      </root>`);
+      getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('grandchild')[0], '0.0').should.equal(
+        'new UiSelector().className("grandchild").instance(0)',
+      );
+    });
+
+    it('should not exist if looking for element outside the last direct child of the hierarchy', function () {
+      doc = xmlToDoc(`<root>
+        <child>
+          <grandchild resource-id='hello'>Hello</grandchild>
+          <grandchild resource-id='world'>World</grandchild>
+        </child>
+        <child>
+          <grandchild resource-id='foo'>Foo</grandchild>
+          <grandchild resource-id='bar'>Bar</grandchild>
+        </child>
+      </root>`);
+      should.not.exist(getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('grandchild')[0], '0.0'));
     });
   });
 });

--- a/test/unit/utils-locator-generation-specs.js
+++ b/test/unit/utils-locator-generation-specs.js
@@ -438,9 +438,11 @@ describe('utils/locator-generation.js', function () {
           <child-node resource-id='world'>World</child-node>
         </parent-node>
       </xml>`);
-      getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('child-node')[0], '0.0').should.equal(
-        'new UiSelector().resourceId("hello")',
-      );
+      getOptimalUiAutomatorSelector(
+        doc,
+        doc.getElementsByTagName('child-node')[0],
+        '0.0',
+      ).should.equal('new UiSelector().resourceId("hello")');
     });
 
     it('should use indices if the valid node attributes are not unique', function () {
@@ -450,9 +452,11 @@ describe('utils/locator-generation.js', function () {
           <grandchild class='grandchild'>World</grandchild>
         </child>
       </root>`);
-      getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('grandchild')[0], '0.0').should.equal(
-        'new UiSelector().className("grandchild").instance(0)',
-      );
+      getOptimalUiAutomatorSelector(
+        doc,
+        doc.getElementsByTagName('grandchild')[0],
+        '0.0',
+      ).should.equal('new UiSelector().className("grandchild").instance(0)');
     });
 
     it('should not exist if looking for element outside the last direct child of the hierarchy', function () {
@@ -466,7 +470,9 @@ describe('utils/locator-generation.js', function () {
           <grandchild resource-id='bar'>Bar</grandchild>
         </child>
       </root>`);
-      should.not.exist(getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('grandchild')[0], '0.0'));
+      should.not.exist(
+        getOptimalUiAutomatorSelector(doc, doc.getElementsByTagName('grandchild')[0], '0.0'),
+      );
     });
   });
 });


### PR DESCRIPTION
This PR adds generation of suggested selectors for the UiAutomator locator strategy, when using the UiAutomator2 driver.
While it does not cover the full breadth of capabilities for this strategy (e.g. no UiScrollable or child selectors), it can still assemble selectors out of 4 attributes (`resource-id`, `text`, `content-desc`, `class`), and add indices, which should cover most use cases.

It is also oftentimes faster than the `id` strategy... 👀 
![image](https://github.com/appium/appium-inspector/assets/37242620/1011ec08-a6b2-4c56-9f5f-1f72ce76cf1c)

⚠️ Important to note that this strategy seems to only find elements _in the last direct child of the hierarchy_ - elements under any other direct child are not visible. I assume this is some sort of limitation (whether intentional or not) from Google's end. This is why the implementation requires recalculating the full DOM Document, the DOM node, and path.

There is another related change in this PR: when reading the suggested locator table, the entry `-android uiautomator (docs)` was quite lengthy and difficult to read, therefore the presentation of entries in the selected element tables was adjusted. Until now, some columns had a fixed width, and others took up the remaining width, potentially resulting in linebreaks - this could look very unreadable at small window sizes:
![image](https://github.com/appium/appium-inspector/assets/37242620/e21cec81-67a4-43e7-8fb6-fbcd97c9445f)
Now the rows support horizontal scrolling, while still keeping the previously-fixed-width columns in place:
![image](https://github.com/appium/appium-inspector/assets/37242620/9636a3b5-8317-412f-89b1-5095f374440f)
This does mean that very long selectors (e.g. complex xpaths/class chains) will require scrolling even for large screen sizes. I think this is still acceptable.