### PR TITLE
fix: fallback to default server tab when unselecting current provider

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -1065,8 +1065,12 @@ export function addVisibleProvider(provider) {
 
 export function removeVisibleProvider(provider) {
   return async (dispatch, getState) => {
-    let currentProviders = getState().session.visibleProviders;
-    const providers = without(currentProviders, provider);
+    const {serverType, visibleProviders} = getState().session;
+    if (serverType === provider) {
+      const action = changeServerType('remote');
+      await action(dispatch, getState);
+    }
+    const providers = without(visibleProviders, provider);
     await setSetting(VISIBLE_PROVIDERS, providers);
     dispatch({type: SET_PROVIDERS, providers});
   };


### PR DESCRIPTION
Small fix for the cloud provider selection modal for the following user flow:
1. Open the cloud provider selection and enable one or more providers
1. Close the selection and switch to any provider tab
1. Open the cloud provider selection again and disable the currently selected provider

Currently this behavior results in the server details disappearing altogether, though it can be fixed by explicitly selecting the default server tab.
This change makes it so that the app automatically switches to the default tab in this situation.