### PR TITLE
fix: rename TestingBot key and secret to username and accessKey

### DIFF
--- a/app/renderer/actions/Session.js
+++ b/app/renderer/actions/Session.js
@@ -422,13 +422,12 @@ export function newSession(caps, attachSessId = null) {
         if (!desiredCapabilities['tb:options']) {
           desiredCapabilities['tb:options'] = {};
         }
-        desiredCapabilities['tb:options'].key = session.server.testingbot.key || process.env.TB_KEY;
-        desiredCapabilities['tb:options'].secret =
-          session.server.testingbot.secret || process.env.TB_SECRET;
-        if (
-          !(session.server.testingbot.key || process.env.TB_KEY) ||
-          !(session.server.testingbot.secret || process.env.TB_SECRET)
-        ) {
+        username = session.server.testingbot.username || process.env.TB_KEY;
+        accessKey = session.server.testingbot.accessKey || process.env.TB_SECRET;
+        desiredCapabilities['tb:options'].key = username;
+        desiredCapabilities['tb:options'].secret = accessKey;
+        desiredCapabilities['tb:options'].source = 'appiumdesktop';
+        if (!username || !accessKey) {
           showError(new Error(i18n.t('testingbotCredentialsRequired')));
           return false;
         }

--- a/app/renderer/components/Session/ServerTabTestingbot.js
+++ b/app/renderer/components/Session/ServerTabTestingbot.js
@@ -3,14 +3,14 @@ import React from 'react';
 
 import {INPUT} from '../AntdTypes';
 
-const testingbotKeyPlaceholder = (t) => {
+const testingbotUsernamePlaceholder = (t) => {
   if (process.env.TB_KEY) {
     return t('usingDataFoundIn', {environmentVariable: 'TB_KEY'});
   }
   return t('yourUsername');
 };
 
-const testingbotSecretPlaceholder = (t) => {
+const testingbotAccessKeyPlaceholder = (t) => {
   if (process.env.TB_SECRET) {
     return t('usingDataFoundIn', {environmentVariable: 'TB_SECRET'});
   }
@@ -24,10 +24,10 @@ const ServerTabTestingbot = ({server, setServerParam, t}) => (
         <Form.Item>
           <Input
             id="testingbotKey"
-            placeholder={testingbotKeyPlaceholder(t)}
+            placeholder={testingbotUsernamePlaceholder(t)}
             addonBefore={t('TestingBot Key')}
-            value={server.testingbot.key}
-            onChange={(e) => setServerParam('key', e.target.value)}
+            value={server.testingbot.username}
+            onChange={(e) => setServerParam('username', e.target.value)}
           />
         </Form.Item>
       </Col>
@@ -36,10 +36,10 @@ const ServerTabTestingbot = ({server, setServerParam, t}) => (
           <Input
             id="testingbotSecret"
             type={INPUT.PASSWORD}
-            placeholder={testingbotSecretPlaceholder(t)}
+            placeholder={testingbotAccessKeyPlaceholder(t)}
             addonBefore={t('TestingBot Secret')}
-            value={server.testingbot.secret}
-            onChange={(e) => setServerParam('secret', e.target.value)}
+            value={server.testingbot.accessKey}
+            onChange={(e) => setServerParam('accessKey', e.target.value)}
           />
         </Form.Item>
       </Col>


### PR DESCRIPTION
This PR renames the TestingBot `key` and `secret` params to `username` and `accessKey`.

The reason for this change is because `getRunningSessions` checks if both `username` and `accessKey` are set to determine if an `Authorization` header needs to be sent with the Axios GET request to `/sessions`.

https://github.com/appium/appium-inspector/blob/main/app/renderer/actions/Session.js#L935-L944