### PR TITLE
chore: update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,11 +4,20 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "matchDepTypes": ["dependencies", "devDependencies"],
+      "matchCurrentVersion": "!/^0/",
       "automerge": true
     },
     {
-      "matchPackageNames": [],
+      "matchPackageNames": [
+        "antd",
+        "chai",
+        "electron",
+        "electron-log",
+        "eslint",
+        "htmlparser2",
+        "postcss-modules",
+        "spectron"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     }


### PR DESCRIPTION
Minor adjustments to the Renovate config:
* Allow automerge for GH Action dependencies
* Prevent automerge for pre-release packages
* Disable major updates for several packages that require additional code changes. The goal is to eventually remove them from this list.