### PR TITLE
feat: :sparkles: support element that has newline replace to \n (#1440)

### DIFF
--- a/app/renderer/components/Inspector/SelectedElement.js
+++ b/app/renderer/components/Inspector/SelectedElement.js
@@ -39,18 +39,19 @@ const SelectedElement = (props) => {
   const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
 
   const selectedElementTableCell = (text, copyToClipBoard) => {
+    const textString = String(text);
     if (copyToClipBoard) {
       return (
         <div className={styles['selected-element-table-cells']}>
           <Tooltip title={t('Copied!')} trigger="click">
-            <span className={styles['element-cell-copy']} onClick={() => clipboard.writeText(text)}>
-              {text}
+            <span className={styles['element-cell-copy']} onClick={() => clipboard.writeText(textString.replace(/(?:\r\n|\r|\n)/g, '\\n'))}>
+              {!textString ? textString : textString.replace(/(?:\r\n|\r|\n)/g, '\\n')}
             </span>
           </Tooltip>
         </div>
       );
     } else {
-      return <div className={styles['selected-element-table-cells']}>{text}</div>;
+      return <div className={styles['selected-element-table-cells']}>{textString}</div>;
     }
   };
 


### PR DESCRIPTION
I created a pull request for feature request #1440. I would appreciate if you could please review it and provide any suggestions.

<img width="1212" alt="Screenshot 2567-04-30 at 00 31 52" src="https://github.com/appium/appium-inspector/assets/12011082/7f5d218f-c487-4d78-9f5b-b370e31e722a">
