### PR TITLE
fix: do not add appium: for undefined

### DIFF
--- a/app/renderer/src/utils/other.js
+++ b/app/renderer/src/utils/other.js
@@ -22,7 +22,7 @@ export function withTranslation(componentCls, ...hocs) {
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
-    if (!VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
+    if (!_.isUndefined(cap.name) && !VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
       cap.name = `appium:${cap.name}`;
     }
     return cap;

--- a/app/renderer/src/utils/other.js
+++ b/app/renderer/src/utils/other.js
@@ -21,10 +21,11 @@ export function withTranslation(componentCls, ...hocs) {
 
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
+    if (_.isUndefined(cap.name)) {
+      return cap;
+    }
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
-    if (!_.isUndefined(cap.name) 
-        && !VALID_W3C_CAPS.includes(cap.name) 
-        && !_.includes(cap.name, ':')) {
+    if (!VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
       cap.name = `appium:${cap.name}`;
     }
     return cap;

--- a/app/renderer/src/utils/other.js
+++ b/app/renderer/src/utils/other.js
@@ -22,7 +22,11 @@ export function withTranslation(componentCls, ...hocs) {
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
-    if (!_.isUndefined(cap.name) && !VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
+    if (
+      !_.isUndefined(cap.name) &&
+      !VALID_W3C_CAPS.includes(cap.name) &&
+      !_.includes(cap.name, ':')
+    ) {
       cap.name = `appium:${cap.name}`;
     }
     return cap;

--- a/app/renderer/src/utils/other.js
+++ b/app/renderer/src/utils/other.js
@@ -22,7 +22,9 @@ export function withTranslation(componentCls, ...hocs) {
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
-    if (!_.isUndefined(cap.name) && !VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
+    if (!_.isUndefined(cap.name) 
+        && !VALID_W3C_CAPS.includes(cap.name) 
+        && !_.includes(cap.name, ':')) {
       cap.name = `appium:${cap.name}`;
     }
     return cap;

--- a/app/renderer/src/utils/other.js
+++ b/app/renderer/src/utils/other.js
@@ -21,11 +21,8 @@ export function withTranslation(componentCls, ...hocs) {
 
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
-    if (_.isUndefined(cap.name)) {
-      return cap;
-    }
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
-    if (!VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
+    if (!_.isUndefined(cap.name) && !VALID_W3C_CAPS.includes(cap.name) && !_.includes(cap.name, ':')) {
       cap.name = `appium:${cap.name}`;
     }
     return cap;


### PR DESCRIPTION
Current implementation adds `appium:` for no-input field as well like below:
<img width="576" alt="Screenshot 2024-05-28 at 11 41 39 PM" src="https://github.com/appium/appium-inspector/assets/5511591/af443b62-3cd1-4490-b675-7f9111605c83">

This change will not add `appium:` for undefined keys

<img width="484" alt="Screenshot 2024-05-28 at 11 16 41 PM" src="https://github.com/appium/appium-inspector/assets/5511591/1d40a98c-72fa-4390-a459-dd79e9586084">
