### PR TITLE
fix: Add validation for duplicate capability name

### DIFF
--- a/app/renderer/src/actions/Session.js
+++ b/app/renderer/src/actions/Session.js
@@ -76,6 +76,7 @@ export const SET_PROVIDERS = 'SET_PROVIDERS';
 
 export const SET_ADD_VENDOR_PREFIXES = 'SET_ADD_VENDOR_PREFIXES';
 
+export const SET_CAPABILITY_NAME_ERROR = 'SET_CAPABILITY_NAME_ERROR';
 export const SET_STATE_FROM_URL = 'SET_STATE_FROM_URL';
 export const SET_STATE_FROM_SAVED = 'SET_STATE_FROM_SAVED';
 
@@ -662,8 +663,15 @@ export function newSession(caps, attachSessId = null) {
 export function saveSession(server, serverType, caps, params) {
   return async (dispatch) => {
     let {name, uuid} = params;
-    dispatch({type: SAVE_SESSION_REQUESTED});
     let savedSessions = (await getSetting(SAVED_SESSIONS)) || [];
+    let isDuplicateName = savedSessions.find(
+      (session) => session.name?.toLowerCase() === name?.toLowerCase(),
+    );
+    if (isDuplicateName) {
+      return dispatch({type: SET_CAPABILITY_NAME_ERROR});
+    }
+    dispatch({type: SAVE_SESSION_REQUESTED});
+
     if (!uuid) {
       // If it's a new session, add it to the list
       uuid = UUID();

--- a/app/renderer/src/actions/Session.js
+++ b/app/renderer/src/actions/Session.js
@@ -665,7 +665,7 @@ export function saveSession(server, serverType, caps, params) {
     let {name, uuid} = params;
     let savedSessions = (await getSetting(SAVED_SESSIONS)) || [];
     let duplicateSessions = savedSessions.filter((session) => session.name === name);
-    // We need to save the details if user is updating an already saved capability set
+    // Ignore the check if the user is updating an existing capability set with duplicate names
     let isEditingExistingCapability = duplicateSessions.find((session) => session.uuid === uuid);
     if (duplicateSessions.length > 0 && !isEditingExistingCapability) {
       return dispatch({type: SET_CAPABILITY_NAME_ERROR});

--- a/app/renderer/src/actions/Session.js
+++ b/app/renderer/src/actions/Session.js
@@ -664,10 +664,10 @@ export function saveSession(server, serverType, caps, params) {
   return async (dispatch) => {
     let {name, uuid} = params;
     let savedSessions = (await getSetting(SAVED_SESSIONS)) || [];
-    let duplicateSession = savedSessions.find(
-      (session) => session.name?.toLowerCase() === name?.toLowerCase(),
-    );
-    if (duplicateSession && (!uuid || duplicateSession.uuid !== uuid)) {
+    let duplicateSessions = savedSessions.filter((session) => session.name === name);
+    // We need to save the details if user is updating an already saved capability set
+    let isEditingExistingCapability = duplicateSessions.find((session) => session.uuid === uuid);
+    if (duplicateSessions.length > 0 && !isEditingExistingCapability) {
       return dispatch({type: SET_CAPABILITY_NAME_ERROR});
     }
     dispatch({type: SAVE_SESSION_REQUESTED});

--- a/app/renderer/src/actions/Session.js
+++ b/app/renderer/src/actions/Session.js
@@ -664,10 +664,10 @@ export function saveSession(server, serverType, caps, params) {
   return async (dispatch) => {
     let {name, uuid} = params;
     let savedSessions = (await getSetting(SAVED_SESSIONS)) || [];
-    let isDuplicateName = savedSessions.find(
+    let duplicateSession = savedSessions.find(
       (session) => session.name?.toLowerCase() === name?.toLowerCase(),
     );
-    if (isDuplicateName) {
+    if (duplicateSession && (!uuid || duplicateSession.uuid !== uuid)) {
       return dispatch({type: SET_CAPABILITY_NAME_ERROR});
     }
     dispatch({type: SAVE_SESSION_REQUESTED});

--- a/app/renderer/src/assets/locales/en/translation.json
+++ b/app/renderer/src/assets/locales/en/translation.json
@@ -282,5 +282,5 @@
   "invalidCapType": "Invalid capability type: {{type}}",
   "whitespaceDetected": "Text Starts and/or Ends With Whitespace",
   "pcloudyCredentialsRequired": "pCloudy username and api key are required!",
-  "duplicateCapabilityNameError": "Capability Set with the same name already present"
+  "duplicateCapabilityNameError": "A capability set with the same name already exists"
 }

--- a/app/renderer/src/assets/locales/en/translation.json
+++ b/app/renderer/src/assets/locales/en/translation.json
@@ -281,5 +281,6 @@
   "noResultsFound": "No results found",
   "invalidCapType": "Invalid capability type: {{type}}",
   "whitespaceDetected": "Text Starts and/or Ends With Whitespace",
-  "pcloudyCredentialsRequired": "pCloudy username and api key are required!"
+  "pcloudyCredentialsRequired": "pCloudy username and api key are required!",
+  "duplicateCapabilityNameError": "Capability with the same name already present"
 }

--- a/app/renderer/src/assets/locales/en/translation.json
+++ b/app/renderer/src/assets/locales/en/translation.json
@@ -282,5 +282,5 @@
   "invalidCapType": "Invalid capability type: {{type}}",
   "whitespaceDetected": "Text Starts and/or Ends With Whitespace",
   "pcloudyCredentialsRequired": "pCloudy username and api key are required!",
-  "duplicateCapabilityNameError": "Capability with the same name already present"
+  "duplicateCapabilityNameError": "Capability Set with the same name already present"
 }

--- a/app/renderer/src/components/Session/CapabilityEditor.jsx
+++ b/app/renderer/src/components/Session/CapabilityEditor.jsx
@@ -68,7 +68,7 @@ const CapabilityEditor = (props) => {
     addVendorPrefixes,
     server,
     serverType,
-    isDuplicateCapsName
+    isDuplicateCapsName,
   } = props;
 
   const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
@@ -192,7 +192,9 @@ const CapabilityEditor = (props) => {
             onPressEnter={onSaveAsOk}
             status={isDuplicateCapsName ? 'error' : ''}
           />
-          {isDuplicateCapsName && <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>}
+          {isDuplicateCapsName && (
+            <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>
+          )}
         </Modal>
       </Col>
     </Row>

--- a/app/renderer/src/components/Session/CapabilityEditor.jsx
+++ b/app/renderer/src/components/Session/CapabilityEditor.jsx
@@ -68,6 +68,7 @@ const CapabilityEditor = (props) => {
     addVendorPrefixes,
     server,
     serverType,
+    isDuplicateCapsName
   } = props;
 
   const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
@@ -189,7 +190,9 @@ const CapabilityEditor = (props) => {
             addonBefore={t('Name')}
             value={saveAsText}
             onPressEnter={onSaveAsOk}
+            status={isDuplicateCapsName ? 'error' : ''}
           />
+          {isDuplicateCapsName && <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>}
         </Modal>
       </Col>
     </Row>

--- a/app/renderer/src/components/Session/FormattedCaps.jsx
+++ b/app/renderer/src/components/Session/FormattedCaps.jsx
@@ -1,5 +1,5 @@
 import {CloseOutlined, EditOutlined, SaveOutlined} from '@ant-design/icons';
-import {Alert, Button, Card, Tooltip} from 'antd';
+import {Alert, Button, Card, Input, Row, Tooltip} from 'antd';
 import hljs from 'highlight.js';
 import React from 'react';
 
@@ -21,6 +21,7 @@ const FormattedCaps = (props) => {
     rawDesiredCaps,
     isValidCapsJson,
     invalidCapsJsonReason,
+    isDuplicateCapsName,
     t,
   } = props;
 
@@ -30,18 +31,23 @@ const FormattedCaps = (props) => {
   };
 
   const setCapsTitle = () => {
-    const {setDesiredCapsName} = props;
+    const {setDesiredCapsName, saveDesiredCapsName} = props;
     if (!title) {
       return t('JSON Representation');
     } else if (!isEditingDesiredCapsName) {
       return title;
     } else {
       return (
-        <input
+        <Row>
+          <Input
           onChange={(e) => setDesiredCapsName(e.target.value)}
           value={desiredCapsName}
           className={SessionStyles.capsEditorTitle}
+          onPressEnter={saveDesiredCapsName}
+          status={isDuplicateCapsName ? 'error' : ''}
         />
+        {isDuplicateCapsName && <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>}
+        </Row>
       );
     }
   };

--- a/app/renderer/src/components/Session/FormattedCaps.jsx
+++ b/app/renderer/src/components/Session/FormattedCaps.jsx
@@ -40,13 +40,15 @@ const FormattedCaps = (props) => {
       return (
         <Row>
           <Input
-          onChange={(e) => setDesiredCapsName(e.target.value)}
-          value={desiredCapsName}
-          className={SessionStyles.capsEditorTitle}
-          onPressEnter={saveDesiredCapsName}
-          status={isDuplicateCapsName ? 'error' : ''}
-        />
-        {isDuplicateCapsName && <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>}
+            onChange={(e) => setDesiredCapsName(e.target.value)}
+            value={desiredCapsName}
+            className={SessionStyles.capsEditorTitle}
+            onPressEnter={saveDesiredCapsName}
+            status={isDuplicateCapsName ? 'error' : ''}
+          />
+          {isDuplicateCapsName && (
+            <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>
+          )}
         </Row>
       );
     }

--- a/app/renderer/src/components/Session/Session.module.css
+++ b/app/renderer/src/components/Session/Session.module.css
@@ -149,10 +149,16 @@
 .formattedCapsBody {
   height: 100%;
 }
+.formattedCaps :global(.ant-row){
+  width: 100%;
+}
 
 .formattedCaps :global(.ant-card-head-title) {
-  height: 54px;
   padding-right: 10px;
+  height: 65px;
+  width: 100%;
+  display: flex;
+  align-items: center;
 }
 
 .formattedCaps :global(.ant-card-body) {
@@ -308,4 +314,10 @@
   display: table-cell;
   padding-top: 4px;
   padding-left: 11px;
+}
+
+.errorMessage {
+  padding-top: 1px;
+  color: #ff4d4f;
+  font-size: 12px;
 }

--- a/app/renderer/src/components/Session/Session.module.css
+++ b/app/renderer/src/components/Session/Session.module.css
@@ -149,7 +149,7 @@
 .formattedCapsBody {
   height: 100%;
 }
-.formattedCaps :global(.ant-row){
+.formattedCaps :global(.ant-row) {
   width: 100%;
 }
 

--- a/app/renderer/src/reducers/Session.js
+++ b/app/renderer/src/reducers/Session.js
@@ -27,6 +27,7 @@ import {
   SAVE_SESSION_REQUESTED,
   SET_ADD_VENDOR_PREFIXES,
   SET_ATTACH_SESS_ID,
+  SET_CAPABILITY_NAME_ERROR,
   SET_CAPABILITY_PARAM,
   SET_CAPS_AND_SERVER,
   SET_DESIRED_CAPS_NAME,
@@ -89,6 +90,7 @@ const INITIAL_STATE = {
   ],
 
   isCapsDirty: true,
+  isDuplicateCapsName: false,
   gettingSessions: false,
   runningAppiumSessions: [],
   isEditingDesiredCapsName: false,
@@ -178,7 +180,12 @@ export default function session(state = INITIAL_STATE, action) {
       return omit(nextState, 'showSaveAsModal');
 
     case SAVE_SESSION_DONE:
-      return omit(state, ['saveSessionRequested', 'saveAsText']);
+      nextState = {
+        ...state,
+        isEditingDesiredCapsName: false,
+        isDuplicateCapsName: false,
+      };
+      return omit(nextState, ['saveSessionRequested', 'saveAsText']);
 
     case GET_SAVED_SESSIONS_REQUESTED:
       return {
@@ -220,7 +227,11 @@ export default function session(state = INITIAL_STATE, action) {
       };
 
     case HIDE_SAVE_AS_MODAL_REQUESTED:
-      return omit(state, ['saveAsText', 'showSaveAsModal']);
+      nextState = {
+        ...state,
+        isDuplicateCapsName: false,
+      };
+      return omit(nextState, ['saveAsText', 'showSaveAsModal']);
 
     case SET_SAVE_AS_TEXT:
       return {
@@ -308,13 +319,13 @@ export default function session(state = INITIAL_STATE, action) {
       return {
         ...state,
         isEditingDesiredCapsName: false,
+        isDuplicateCapsName: false,
         desiredCapsName: null,
       };
 
     case SAVE_DESIRED_CAPS_NAME:
       return {
         ...state,
-        isEditingDesiredCapsName: false,
         capsName: action.name,
       };
 
@@ -403,7 +414,11 @@ export default function session(state = INITIAL_STATE, action) {
         },
         ...omit(action.state, ['server']),
       };
-
+    case SET_CAPABILITY_NAME_ERROR:
+      return {
+        ...state,
+        isDuplicateCapsName: true,
+      };
     case SET_STATE_FROM_SAVED:
       if (!Object.keys(ServerTypes).includes(action.state.serverType)) {
         notification.error({


### PR DESCRIPTION
Fix #1196

Added validations for duplicate capability set names upon saving.

1. In Save As modal

<img width="606" alt="Screenshot 2024-06-02 at 3 25 54 AM" src="https://github.com/appium/appium-inspector/assets/20136913/44d94a80-4050-4225-96be-7e8a9d209a50">

2. In Inline editor:

<img width="846" alt="Screenshot 2024-06-02 at 3 26 30 AM" src="https://github.com/appium/appium-inspector/assets/20136913/95333f4e-8013-49f7-95f6-522f6136d467">
