### PR TITLE
chore(deps): replace babel proposal plugin with built-in version

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -3,8 +3,8 @@ function makeBabelConfig(electronVersion) {
     api.cache(true);
     return {
       plugins: [
-        '@babel/plugin-proposal-class-properties',
         '@babel/plugin-syntax-jsx',
+        '@babel/plugin-transform-class-properties',
         '@babel/plugin-transform-react-jsx',
         '@babel/plugin-transform-runtime',
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@babel/core": "7.24.7",
         "@babel/eslint-parser": "7.24.7",
         "@babel/eslint-plugin": "7.24.7",
-        "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-transform-runtime": "7.24.7",
         "@babel/preset-env": "7.24.7",
         "@babel/preset-react": "7.24.7",
@@ -1685,23 +1684,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
-      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-class-properties instead.",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.18.6",
-        "@babel/helper-plugin-utils": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "@babel/core": "7.24.7",
     "@babel/eslint-parser": "7.24.7",
     "@babel/eslint-plugin": "7.24.7",
-    "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-transform-runtime": "7.24.7",
     "@babel/preset-env": "7.24.7",
     "@babel/preset-react": "7.24.7",


### PR DESCRIPTION
This replaces `@babel/plugin-proposal-class-properties` with `@babel/plugin-transform-class-properties`, since the former is deprecated. The latter is already imported as part of `@babel/preset-env`.