### PR TITLE
chore: use common logger class

### DIFF
--- a/app/common/actions/Inspector.js
+++ b/app/common/actions/Inspector.js
@@ -13,7 +13,7 @@ import {
   findJSONElementByPath,
   xmlToJSON,
 } from '../utils/source-parsing';
-import {log} from '../utils/other';
+import {log} from '../utils/logger';
 import {showError} from './Session';
 
 export const SET_SESSION_DETAILS = 'SET_SESSION_DETAILS';

--- a/app/common/actions/Inspector.js
+++ b/app/common/actions/Inspector.js
@@ -13,6 +13,7 @@ import {
   findJSONElementByPath,
   xmlToJSON,
 } from '../utils/source-parsing';
+import {log} from '../utils/other';
 import {showError} from './Session';
 
 export const SET_SESSION_DETAILS = 'SET_SESSION_DETAILS';
@@ -275,7 +276,7 @@ export function applyClientMethod(params) {
       window.dispatchEvent(new Event('resize'));
       return commandRes;
     } catch (error) {
-      console.log(error); // eslint-disable-line no-console
+      log.error(error);
       let methodName = params.methodName === 'click' ? 'tap' : params.methodName;
       showError(error, {methodName, secs: 10});
       dispatch({type: METHOD_CALL_DONE});
@@ -666,8 +667,7 @@ export function getActiveAppId(isIOS, isAndroid) {
         dispatch({type: SET_APP_ID, appId: appPackage});
       }
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.error(`Could not Retrieve Active App ID: ${err}`);
+      log.error(`Could not Retrieve Active App ID: ${err}`);
     }
   };
 }
@@ -745,7 +745,7 @@ export function runKeepAliveLoop() {
 
     const keepAliveInterval = setInterval(async () => {
       const {lastActiveMoment, showKeepAlivePrompt} = getState().inspector;
-      console.log('Pinging Appium server to keep session active'); // eslint-disable-line no-console
+      log.info('Pinging Appium server to keep session active');
       try {
         await driver.getTimeouts(); // Pings the Appium server to keep it alive
       } catch (ign) {}
@@ -805,8 +805,8 @@ export function callClientMethod(params) {
       params.skipRefresh = true;
     }
 
-    console.log(`Calling client method with params:`); // eslint-disable-line no-console
-    console.log(params); // eslint-disable-line no-console
+    log.info(`Calling client method with params:`);
+    log.info(params);
     const action = keepSessionAlive();
     action(dispatch, getState);
     const client = AppiumClient.instance(driver);
@@ -823,8 +823,8 @@ export function callClientMethod(params) {
       // ability to scroll etc...
       const result = JSON.stringify(commandRes, null, '  ');
       const truncatedResult = _.truncate(result, {length: 2000});
-      console.log(`Result of client command was:`); // eslint-disable-line no-console
-      console.log(truncatedResult); // eslint-disable-line no-console
+      log.info(`Result of client command was:`);
+      log.info(truncatedResult);
       setVisibleCommandResult(result, methodName)(dispatch);
     }
     res.elementId = res.id;

--- a/app/common/actions/Session.js
+++ b/app/common/actions/Session.js
@@ -26,7 +26,7 @@ import {
   getSetting,
   setSetting,
 } from '../shared/settings';
-import {addVendorPrefixes} from '../utils/other';
+import {addVendorPrefixes, log} from '../utils/other';
 import {quitSession, setSessionDetails} from './Inspector';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';
@@ -178,7 +178,7 @@ export function showError(e, params = {methodName: null, secs: 5, url: null}) {
     errMessage = i18n.t('couldNotConnect', {url});
   }
 
-  console.error(errMessage); // eslint-disable-line no-console
+  log.error(errMessage);
   notification.error({
     message: methodName ? i18n.t('callToMethodFailed', {methodName}) : i18n.t('Error'),
     description: errMessage,
@@ -585,9 +585,8 @@ export function newSession(caps, attachSessId = null) {
             });
             attachedSessionCaps = res.data.value;
           } catch (err) {
-            // rethrow the error as session not running, but first log the original error to
-            // console
-            console.error(err); // eslint-disable-line no-console
+            // rethrow the error as session not running, but first log the original error to console
+            log.error(err);
             throw new Error(i18n.t('attachSessionNotRunning', {attachSessId}));
           }
         }
@@ -963,7 +962,7 @@ export function getRunningSessions() {
       });
       dispatch({type: GET_SESSIONS_DONE, sessions: res.data.value});
     } catch (err) {
-      console.warn(`Ignoring error in getting list of active sessions: ${err}`); // eslint-disable-line no-console
+      log.warn(`Ignoring error in getting list of active sessions: ${err}`);
       dispatch({type: GET_SESSIONS_DONE});
     }
   };

--- a/app/common/actions/Session.js
+++ b/app/common/actions/Session.js
@@ -26,7 +26,8 @@ import {
   getSetting,
   setSetting,
 } from '../shared/settings';
-import {addVendorPrefixes, log} from '../utils/other';
+import {log} from '../utils/logger';
+import {addVendorPrefixes} from '../utils/other';
 import {quitSession, setSessionDetails} from './Inspector';
 
 export const NEW_SESSION_REQUESTED = 'NEW_SESSION_REQUESTED';

--- a/app/common/components/Session/CapabilityControl.jsx
+++ b/app/common/components/Session/CapabilityControl.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {INPUT} from '../../constants/antd-types';
 import {remote} from '../../shared/polyfills';
-import {log} from '../../utils/other';
+import {log} from '../../utils/logger';
 import SessionStyles from './Session.module.css';
 
 const getLocalFilePath = async () => {

--- a/app/common/components/Session/CapabilityControl.jsx
+++ b/app/common/components/Session/CapabilityControl.jsx
@@ -4,7 +4,8 @@ import _ from 'lodash';
 import React from 'react';
 
 import {INPUT} from '../../constants/antd-types';
-import {log, remote} from '../../shared/polyfills';
+import {remote} from '../../shared/polyfills';
+import {log} from '../../utils/other';
 import SessionStyles from './Session.module.css';
 
 const getLocalFilePath = async () => {

--- a/app/common/components/Session/Session.jsx
+++ b/app/common/components/Session/Session.jsx
@@ -8,7 +8,7 @@ import {BUTTON} from '../../constants/antd-types';
 import {LINKS} from '../../constants/common';
 import {ADD_CLOUD_PROVIDER_TAB_KEY} from '../../constants/session-builder';
 import {ipcRenderer, shell} from '../../shared/polyfills';
-import {log} from '../../utils/other';
+import {log} from '../../utils/logger';
 import AdvancedServerParams from './AdvancedServerParams.jsx';
 import AttachToSession from './AttachToSession.jsx';
 import CapabilityEditor from './CapabilityEditor.jsx';

--- a/app/common/components/Session/Session.jsx
+++ b/app/common/components/Session/Session.jsx
@@ -8,6 +8,7 @@ import {BUTTON} from '../../constants/antd-types';
 import {LINKS} from '../../constants/common';
 import {ADD_CLOUD_PROVIDER_TAB_KEY} from '../../constants/session-builder';
 import {ipcRenderer, shell} from '../../shared/polyfills';
+import {log} from '../../utils/other';
 import AdvancedServerParams from './AdvancedServerParams.jsx';
 import AttachToSession from './AttachToSession.jsx';
 import CapabilityEditor from './CapabilityEditor.jsx';
@@ -83,7 +84,7 @@ const Session = (props) => {
         ipcRenderer.on('open-file', (_, filePath) => setStateFromAppiumFile(filePath));
         ipcRenderer.on('save-file', (_, filePath) => saveFile(filePath));
       } catch (e) {
-        console.error(e); // eslint-disable-line no-console
+        log.error(e);
       }
     })();
   }, []);

--- a/app/common/lib/appium-client.js
+++ b/app/common/lib/appium-client.js
@@ -3,6 +3,7 @@ import _ from 'lodash';
 
 import {SCREENSHOT_INTERACTION_MODE} from '../constants/screenshot';
 import {APP_MODE, NATIVE_APP} from '../constants/session-inspector';
+import {log} from '../utils/other';
 import {parseSource, setHtmlElementAttributes} from './webview-helpers';
 
 const {TAP, SWIPE, GESTURE} = SCREENSHOT_INTERACTION_MODE;
@@ -57,8 +58,7 @@ export default class AppiumClient {
     let res = {};
     if (methodName) {
       if (elementId) {
-        // eslint-disable-next-line no-console
-        console.log(
+        log.info(
           `Handling client method request with method '${methodName}', ` +
             `args ${JSON.stringify(args)} and elementId ${elementId}`,
         );
@@ -71,8 +71,7 @@ export default class AppiumClient {
           appMode,
         });
       } else {
-        // eslint-disable-next-line no-console
-        console.log(
+        log.info(
           `Handling client method request with method '${methodName}' ` +
             `and args ${JSON.stringify(args)}`,
         );
@@ -80,12 +79,10 @@ export default class AppiumClient {
       }
     } else if (strategy && selector) {
       if (fetchArray) {
-        // eslint-disable-next-line no-console
-        console.log(`Fetching elements with selector '${selector}' and strategy ${strategy}`);
+        log.info(`Fetching elements with selector '${selector}' and strategy ${strategy}`);
         res = await this.fetchElements({strategy, selector});
       } else {
-        // eslint-disable-next-line no-console
-        console.log(`Fetching an element with selector '${selector}' and strategy ${strategy}`);
+        log.info(`Fetching an element with selector '${selector}' and strategy ${strategy}`);
         res = await this.fetchElement({strategy, selector});
       }
     }

--- a/app/common/lib/appium-client.js
+++ b/app/common/lib/appium-client.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 import {SCREENSHOT_INTERACTION_MODE} from '../constants/screenshot';
 import {APP_MODE, NATIVE_APP} from '../constants/session-inspector';
-import {log} from '../utils/other';
+import {log} from '../utils/logger';
 import {parseSource, setHtmlElementAttributes} from './webview-helpers';
 
 const {TAP, SWIPE, GESTURE} = SCREENSHOT_INTERACTION_MODE;

--- a/app/common/shared/polyfills.js
+++ b/app/common/shared/polyfills.js
@@ -1,5 +1,4 @@
-let log,
-  settings,
+let settings,
   clipboard,
   shell,
   remote,
@@ -23,7 +22,6 @@ function buildForBrowser() {
 
 if (buildForBrowser()) {
   ({
-    log,
     settings,
     clipboard,
     shell,
@@ -36,7 +34,6 @@ if (buildForBrowser()) {
   } = require('../../web/polyfills'));
 } else {
   ({
-    log,
     settings,
     clipboard,
     shell,
@@ -50,7 +47,6 @@ if (buildForBrowser()) {
 }
 
 export {
-  log,
   clipboard,
   shell,
   remote,

--- a/app/common/utils/locator-generation.js
+++ b/app/common/utils/locator-generation.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import XPath from 'xpath';
 
-import {log} from '../shared/polyfills';
+import {log} from '../utils/other';
 import {childNodesOf, domParser, findDOMNodeByPath, xmlSerializer} from './source-parsing';
 
 // Attributes on nodes that are likely to be unique to the node so we should consider first when

--- a/app/common/utils/locator-generation.js
+++ b/app/common/utils/locator-generation.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import XPath from 'xpath';
 
-import {log} from '../utils/other';
+import {log} from '../utils/logger';
 import {childNodesOf, domParser, findDOMNodeByPath, xmlSerializer} from './source-parsing';
 
 // Attributes on nodes that are likely to be unique to the node so we should consider first when

--- a/app/common/utils/logger.js
+++ b/app/common/utils/logger.js
@@ -1,0 +1,15 @@
+class Logger {
+  info(...args) {
+    console.info(...args); // eslint-disable-line no-console
+  }
+
+  warn(...args) {
+    console.warn(...args); // eslint-disable-line no-console
+  }
+
+  error(...args) {
+    console.error(...args); // eslint-disable-line no-console
+  }
+}
+
+export const log = new Logger();

--- a/app/common/utils/other.js
+++ b/app/common/utils/other.js
@@ -15,6 +15,22 @@ const VALID_W3C_CAPS = [
   'unhandledPromptBehavior',
 ];
 
+class Logger {
+  info(...args) {
+    console.info(...args); // eslint-disable-line no-console
+  }
+
+  warn(...args) {
+    console.warn(...args); // eslint-disable-line no-console
+  }
+
+  error(...args) {
+    console.error(...args); // eslint-disable-line no-console
+  }
+}
+
+export const log = new Logger();
+
 export function withTranslation(componentCls, ...hocs) {
   return _.flow(...hocs, wt(config.namespace))(componentCls);
 }

--- a/app/common/utils/other.js
+++ b/app/common/utils/other.js
@@ -15,22 +15,6 @@ const VALID_W3C_CAPS = [
   'unhandledPromptBehavior',
 ];
 
-class Logger {
-  info(...args) {
-    console.info(...args); // eslint-disable-line no-console
-  }
-
-  warn(...args) {
-    console.warn(...args); // eslint-disable-line no-console
-  }
-
-  error(...args) {
-    console.error(...args); // eslint-disable-line no-console
-  }
-}
-
-export const log = new Logger();
-
 export function withTranslation(componentCls, ...hocs) {
   return _.flow(...hocs, wt(config.namespace))(componentCls);
 }

--- a/app/electron/renderer/polyfills.js
+++ b/app/electron/renderer/polyfills.js
@@ -1,5 +1,4 @@
 import {clipboard, ipcRenderer, remote, shell} from 'electron';
-import log from 'electron-log';
 import settings from 'electron-settings';
 import fs from 'fs';
 import i18NextBackend from 'i18next-fs-backend';
@@ -13,7 +12,6 @@ const i18NextBackendOptions = {
 };
 
 export {
-  log,
   clipboard,
   shell,
   remote,

--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -41,7 +41,6 @@ class BrowserSettings {
   }
 }
 
-const log = console;
 const settings = new BrowserSettings();
 const {clipboard, shell, remote, ipcRenderer} = browser;
 const i18NextBackendOptions = {
@@ -55,7 +54,6 @@ const i18NextBackendOptions = {
 };
 
 export {
-  log,
   settings,
   clipboard,
   shell,

--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -53,12 +53,4 @@ const i18NextBackendOptions = {
   ],
 };
 
-export {
-  settings,
-  clipboard,
-  shell,
-  remote,
-  ipcRenderer,
-  i18NextBackend,
-  i18NextBackendOptions,
-};
+export {settings, clipboard, shell, remote, ipcRenderer, i18NextBackend, i18NextBackendOptions};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "axios": "1.7.2",
         "bluebird": "3.7.2",
         "cheerio": "1.0.0-rc.10",
-        "electron-log": "4.4.8",
         "electron-settings": "4.0.4",
         "electron-updater": "6.2.1",
         "highlight.js": "11.9.0",
@@ -11963,11 +11962,6 @@
         "keyboardevent-from-electron-accelerator": "^2.0.0",
         "keyboardevents-areequal": "^0.2.1"
       }
-    },
-    "node_modules/electron-log": {
-      "version": "4.4.8",
-      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
-      "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
     },
     "node_modules/electron-publish": {
       "version": "24.13.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "antd": "V5: significant rewrite required",
     "bluebird": "Deprecated: recommended to replace with native promises",
     "cheerio": "1.0.0-rc.11: errors with export namespace",
-    "electron-log": "V5: rewrite required to only call in main process",
     "electron-settings": "V5: need to rewrite to IPC while keeping browser version working",
     "htmlparser2": "8.0.0: errors with export namespace",
     "uuid": "Obsolete: can be replaced with crypto.randomUUID in Electron 14+"
@@ -81,7 +80,6 @@
     "axios": "1.7.2",
     "bluebird": "3.7.2",
     "cheerio": "1.0.0-rc.10",
-    "electron-log": "4.4.8",
     "electron-settings": "4.0.4",
     "electron-updater": "6.2.1",
     "highlight.js": "11.9.0",

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,6 @@
         "chai",
         "electron",
         "electron-debug",
-        "electron-log",
         "eslint",
         "htmlparser2",
         "postcss-modules",


### PR DESCRIPTION
This PR adds a basic `Logger` class for abstracting away some logging implementations for better maintenance. The class itself still executes basic `console` calls under the hood, but this can be improved in the future.
The following logging implementations have been replaced with `Logger`:
* All uses of `console` in `common` files
* All uses of the `log` method imported from the shared `polyfills` file (there were only 2 such instances)
  * The browser polyfill still used `console`, so there is no difference
  * The Electron polyfill used `electron-log`, so this dependency has been removed

The actual main goal of this PR is to remove `electron-log`, as it is only being called in the renderer process anyway, and also it was causing issues for the Vite migration.