### PR TITLE
chore: comment out dev extension install

### DIFF
--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -19,7 +19,7 @@ app.on('window-all-closed', () => {
 app.on('ready', () => {
   if (isDev) {
     require('electron-debug')();
-    // TODO: uncomment this after upgrading to newer Electron
+    // TODO: uncomment this after upgrading to Electron 15+
     // await installExtensions();
   }
 

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -1,6 +1,6 @@
 import {app} from 'electron';
 
-import {installExtensions} from './debug';
+// import {installExtensions} from './debug';
 import {getAppiumSessionFilePath} from './helpers';
 import {setupMainWindow} from './windows';
 
@@ -16,10 +16,11 @@ app.on('window-all-closed', () => {
   app.quit();
 });
 
-app.on('ready', async () => {
+app.on('ready', () => {
   if (isDev) {
     require('electron-debug')();
-    await installExtensions();
+    // TODO: uncomment this after upgrading to newer Electron
+    // await installExtensions();
   }
 
   setupMainWindow({


### PR DESCRIPTION
Right now, building the dev version of the Electron app fails due to missing module `node:url`. This makes sense, since `node:` prefixes were only added in Node `14.18` (the app currently uses `14.16`).
The cause of this error is in `electron-extension-installer` -> `rimraf` -> `glob`, where this prefix was introduced in `10.3.13`.
I tried to add an override for `rimraf` to use `glob` `10.3.12`, however, this resulted in a similar error for `node:path` due to `path-scurry`, which in turn is a dependency of `glob`.
I suppose it's possible to add another override, but I think this is becoming a bit too hacky, so a simpler approach is to just uncomment uses of `electron-extension-installer` until we upgrade to Node `>=14.18`, that is, Electron `>=15`.
Closes #1511.