### PR TITLE
chore: add missing web polyfill exports

### DIFF
--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -37,7 +37,7 @@ class BrowserSettings {
 }
 
 const settings = new BrowserSettings();
-const {clipboard, shell, ipcRenderer} = browser;
+const {clipboard, shell, ipcRenderer, fs, util} = browser;
 const i18NextBackendOptions = {
   backends: [LocalStorageBackend, HttpApi],
   backendOptions: [
@@ -48,4 +48,4 @@ const i18NextBackendOptions = {
   ],
 };
 
-export {settings, clipboard, shell, ipcRenderer, i18NextBackend, i18NextBackendOptions};
+export {settings, clipboard, shell, ipcRenderer, i18NextBackend, i18NextBackendOptions, fs, util};


### PR DESCRIPTION
This adds the `fs` and `util` exports for web polyfills, which are already exported for Electron. While they are not actually used for web, Vite requires that they are exported properly.