### PR TITLE
chore: move redux-logger import to top

### DIFF
--- a/app/common/store.js
+++ b/app/common/store.js
@@ -1,4 +1,5 @@
 import {configureStore} from '@reduxjs/toolkit';
+import {createLogger} from 'redux-logger';
 
 import actions from './actions';
 import createRootReducer from './reducers';
@@ -13,7 +14,6 @@ const store = configureStore({
     // Additional development tools
     if (process.env.NODE_ENV === 'development') {
       // Logging Middleware
-      const {createLogger} = require('redux-logger');
       const logger = createLogger({
         level: 'info',
         collapsed: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "@babel/register": "7.24.6",
         "@types/chai": "4.3.16",
         "@types/react": "18.3.3",
+        "@types/redux-logger": "3.0.13",
         "@types/sinon": "17.0.3",
         "asyncbox": "3.0.0",
         "chai": "4.4.1",
@@ -5657,6 +5658,15 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/redux-logger": {
+      "version": "3.0.13",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.13.tgz",
+      "integrity": "sha512-jylqZXQfMxahkuPcO8J12AKSSCQngdEWQrw7UiLUJzMBcv1r4Qg77P6mjGLjM27e5gFQDPD8vwUMJ9AyVxFSsg==",
+      "dev": true,
+      "dependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/@types/responselike": {

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@babel/register": "7.24.6",
     "@types/chai": "4.3.16",
     "@types/react": "18.3.3",
+    "@types/redux-logger": "3.0.13",
     "@types/sinon": "17.0.3",
     "asyncbox": "3.0.0",
     "chai": "4.4.1",


### PR DESCRIPTION
This changes the current conditional import for `redux-logger` to a top-level import. While the conditional import causes an error in Vite (`require is not defined`), it seems that it is not required in the first place, since the logging middleware initialisation is behind the development flag anyway. This behavior was confirmed in both dev and production Electron app versions.

Additionally, this PR adds the types for `redux-logger` for better DX.