### PR TITLE
fix: disable Inspector tabs until screenshot has loaded

### DIFF
--- a/app/common/components/Inspector/Inspector.jsx
+++ b/app/common/components/Inspector/Inspector.jsx
@@ -304,6 +304,7 @@ const Inspector = (props) => {
             {
               label: t('Source'),
               key: INSPECTOR_TABS.SOURCE,
+              disabled: !showScreenshot,
               children: (
                 <div className="action-row">
                   <div className="action-col">
@@ -367,6 +368,7 @@ const Inspector = (props) => {
             {
               label: t('Commands'),
               key: INSPECTOR_TABS.COMMANDS,
+              disabled: !showScreenshot,
               children: (
                 <Card
                   title={
@@ -383,6 +385,7 @@ const Inspector = (props) => {
             {
               label: t('Gestures'),
               key: INSPECTOR_TABS.GESTURES,
+              disabled: !showScreenshot,
               children: isGestureEditorVisible ? (
                 <Card
                   title={
@@ -410,11 +413,13 @@ const Inspector = (props) => {
             {
               label: t('Recorder'),
               key: INSPECTOR_TABS.RECORDER,
+              disabled: !showScreenshot,
               children: <Recorder {...props} />,
             },
             {
               label: t('Session Information'),
               key: INSPECTOR_TABS.SESSION_INFO,
+              disabled: !showScreenshot,
               children: (
                 <Card
                   title={


### PR DESCRIPTION
This PR disables the ability to switch the Session Inspector tab until the screenshot has finished loading. It helps with situations where the screenshot takes a while to load, so the user may attempt to execute other Inspector actions, which may depend on the data retrieved alongside the screenshot (such as `windowSize`). Related to #1543.

It's likely that not all tabs actually depend on this data (such as Recorder), but for consistency it looks better if all of them are in the same state.

Functionality was tested to work fine in both normal and MJPEG modes.