### PR TITLE
chore: break up i18next config object

### DIFF
--- a/app/common/configs/i18next.common.js
+++ b/app/common/configs/i18next.common.js
@@ -25,12 +25,9 @@ export const languageList = [
   {name: 'Ukrainian', code: 'uk', original: 'Українська'},
 ];
 
-const config = {
-  platform: process.platform,
-  languages: languageList.map((language) => language.code),
-  fallbackLng: 'en',
-  namespace: 'translation',
-};
+export const namespace = 'translation';
+
+const fallbackLng = 'en';
 
 export function getI18NextOptions(backend) {
   return {
@@ -40,10 +37,8 @@ export function getI18NextOptions(backend) {
     interpolation: {
       escapeValue: false,
     },
-    lng: (settings && settings.getSync('PREFERRED_LANGUAGE')) || 'en',
-    fallbackLng: config.fallbackLng,
-    whitelist: config.languages,
+    lng: (settings && settings.getSync('PREFERRED_LANGUAGE')) || fallbackLng,
+    fallbackLng,
+    whitelist: languageList.map((language) => language.code),
   };
 }
-
-export default config;

--- a/app/common/utils/other.js
+++ b/app/common/utils/other.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import {withTranslation as wt} from 'react-i18next';
 
-import config from '../configs/i18next.common';
+import {namespace} from '../configs/i18next.common';
 
 const VALID_W3C_CAPS = [
   'platformName',
@@ -16,7 +16,7 @@ const VALID_W3C_CAPS = [
 ];
 
 export function withTranslation(componentCls, ...hocs) {
-  return _.flow(...hocs, wt(config.namespace))(componentCls);
+  return _.flow(...hocs, wt(namespace))(componentCls);
 }
 
 export function addVendorPrefixes(caps) {


### PR DESCRIPTION
This PR breaks up the `config` object defined in `i18next.common.js` due to the following reasons:
* The whole object is exported, but only the `namespace` property is used this way
* The `platform` property is never used, and breaks the Vite production build
* The `languages` property is only used once
* The `fallbackLng` property is used only once, but should be used twice, so it is extracted as a dedicated const