### PR TITLE
chore: tune Electron window setups

### DIFF
--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -1,6 +1,8 @@
 import i18n from './i18next';
 
-export function getAppiumSessionFilePath(argv, isPackaged, isDev) {
+export const isDev = process.env.NODE_ENV === 'development';
+
+export function getAppiumSessionFilePath(argv, isPackaged) {
   if (isDev) {
     // do not use file launcher in dev mode because argv is different
     // then it is in production

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -1,12 +1,10 @@
 import {app} from 'electron';
 
 // import {installExtensions} from './debug';
-import {getAppiumSessionFilePath} from './helpers';
+import {getAppiumSessionFilePath, isDev} from './helpers';
 import {setupMainWindow} from './windows';
 
-const isDev = process.env.NODE_ENV === 'development';
-
-export let openFilePath = getAppiumSessionFilePath(process.argv, app.isPackaged, isDev);
+export let openFilePath = getAppiumSessionFilePath(process.argv, app.isPackaged);
 
 app.on('open-file', (event, filePath) => {
   openFilePath = filePath;

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -21,9 +21,5 @@ app.on('ready', () => {
     // await installExtensions();
   }
 
-  setupMainWindow({
-    mainUrl: `file://${__dirname}/index.html`,
-    splashUrl: `file://${__dirname}/splash.html`,
-    isDev,
-  });
+  setupMainWindow();
 });

--- a/app/electron/main/menus.js
+++ b/app/electron/main/menus.js
@@ -3,7 +3,7 @@ import {Menu, app, dialog, shell} from 'electron';
 import {languageList} from '../../common/configs/i18next.common';
 import i18n from './i18next';
 import {checkForUpdates} from './updater';
-import {APPIUM_SESSION_EXTENSION, t} from './helpers';
+import {APPIUM_SESSION_EXTENSION, isDev, t} from './helpers';
 import {launchNewSessionWindow} from './windows';
 
 const INSPECTOR_DOCS_URL = 'https://appium.github.io/appium-inspector';
@@ -120,7 +120,7 @@ function dropdownEdit() {
   };
 }
 
-function dropdownView(isDev) {
+function dropdownView() {
   const submenu = [
     {label: t('Toggle Full Screen'), role: 'togglefullscreen'},
     {label: t('Reset Zoom Level'), role: 'resetZoom'},
@@ -172,21 +172,21 @@ function dropdownHelp() {
   };
 }
 
-function menuTemplate(mainWindow, isMac, isDev) {
+function menuTemplate(mainWindow, isMac) {
   return [
     ...(isMac ? [dropdownApp()] : []),
     dropdownFile(mainWindow, isMac),
     dropdownEdit(),
-    dropdownView(isDev),
+    dropdownView(),
     ...(isMac ? [dropdownWindow()] : []),
     dropdownHelp(),
   ];
 }
 
-export function rebuildMenus(mainWindow, isDev) {
+export function rebuildMenus(mainWindow) {
   const isMac = process.platform === 'darwin';
 
-  const menu = Menu.buildFromTemplate(menuTemplate(mainWindow, isMac, isDev));
+  const menu = Menu.buildFromTemplate(menuTemplate(mainWindow, isMac));
 
   if (isMac) {
     Menu.setApplicationMenu(menu);

--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -6,6 +6,9 @@ import {openFilePath} from './main';
 import {APPIUM_SESSION_EXTENSION, isDev} from './helpers';
 import {rebuildMenus} from './menus';
 
+const mainUrl = `file://${__dirname}/index.html`;
+const splashUrl = `file://${__dirname}/splash.html`;
+
 let mainWindow = null;
 
 function buildSplashWindow() {
@@ -47,7 +50,7 @@ function buildSessionWindow() {
   return window;
 }
 
-export function setupMainWindow({splashUrl, mainUrl}) {
+export function setupMainWindow() {
   const splashWindow = buildSplashWindow();
   mainWindow = buildSessionWindow();
 
@@ -97,8 +100,7 @@ export function setupMainWindow({splashUrl, mainUrl}) {
 }
 
 export function launchNewSessionWindow() {
-  const url = `file://${__dirname}/index.html`;
   const win = buildSessionWindow();
-  win.loadURL(url);
+  win.loadURL(mainUrl);
   win.show();
 }

--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -3,7 +3,7 @@ import {BrowserWindow, Menu, dialog, ipcMain, webContents} from 'electron';
 import settings from '../../common/shared/settings';
 import i18n from './i18next';
 import {openFilePath} from './main';
-import {APPIUM_SESSION_EXTENSION} from './helpers';
+import {APPIUM_SESSION_EXTENSION, isDev} from './helpers';
 import {rebuildMenus} from './menus';
 
 let mainWindow = null;
@@ -47,7 +47,7 @@ function buildSessionWindow() {
   return window;
 }
 
-export function setupMainWindow({splashUrl, mainUrl, isDev}) {
+export function setupMainWindow({splashUrl, mainUrl}) {
   const splashWindow = buildSplashWindow();
   mainWindow = buildSessionWindow();
 
@@ -84,7 +84,7 @@ export function setupMainWindow({splashUrl, mainUrl, isDev}) {
   });
 
   i18n.on('languageChanged', async (languageCode) => {
-    rebuildMenus(mainWindow, isDev);
+    rebuildMenus(mainWindow);
     await settings.set('PREFERRED_LANGUAGE', languageCode);
     webContents.getAllWebContents().forEach((wc) => {
       wc.send('appium-language-changed', {
@@ -93,7 +93,7 @@ export function setupMainWindow({splashUrl, mainUrl, isDev}) {
     });
   });
 
-  rebuildMenus(mainWindow, isDev);
+  rebuildMenus(mainWindow);
 }
 
 export function launchNewSessionWindow() {


### PR DESCRIPTION
A few more relatively minor changes to prepare for Vite:
* Move the defined window URL paths from `main.js` to `windows.js` since they are not used anywhere else
  * Also replace duplication in `launchNewSessionWindow`
* Move `isDev()` from `main.js` to `helpers.js`