### PR TITLE
fix: move redux-logger to main dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "react-icons": "5.2.1",
         "react-redux": "9.1.2",
         "react-router-dom": "6.25.0",
+        "redux-logger": "3.0.6",
         "uuid": "9.0.1",
         "web2driver": "3.0.4",
         "xpath": "0.0.34"
@@ -81,7 +82,6 @@
         "parcel-plugin-asset-copier": "1.1.1",
         "postcss-modules": "3.2.2",
         "prettier": "3.3.3",
-        "redux-logger": "3.0.6",
         "rimraf": "5.0.9",
         "sinon": "18.0.0",
         "spectron": "15.0.0"
@@ -10642,8 +10642,7 @@
     "node_modules/deep-diff": {
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-0.3.8.tgz",
-      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug==",
-      "dev": true
+      "integrity": "sha512-yVn6RZmHiGnxRKR9sJb3iVV2XTF1Ghh2DiWRZ3dMnGc43yUdWWF/kX6lQyk3+P84iprfWKU/8zFTrlkvtFm1ug=="
     },
     "node_modules/deep-eql": {
       "version": "4.1.3",
@@ -22123,7 +22122,6 @@
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/redux-logger/-/redux-logger-3.0.6.tgz",
       "integrity": "sha512-JoCIok7bg/XpqA1JqCqXFypuqBbQzGQySrhFzewB7ThcnysTO30l4VCst86AuB9T9tuT03MAA56Jw2PNhRSNCg==",
-      "dev": true,
       "dependencies": {
         "deep-diff": "^0.3.5"
       }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cheerio": "1.0.0-rc.11: errors with export namespace",
     "electron-settings": "V5: need to rewrite to IPC while keeping browser version working",
     "htmlparser2": "8.0.0: errors with export namespace",
+    "redux-logger": "Appears to be abandoned",
     "uuid": "Obsolete: can be replaced with crypto.randomUUID in Electron 14+"
   },
   "dependencies": {
@@ -97,6 +98,7 @@
     "react-icons": "5.2.1",
     "react-redux": "9.1.2",
     "react-router-dom": "6.25.0",
+    "redux-logger": "3.0.6",
     "uuid": "9.0.1",
     "web2driver": "3.0.4",
     "xpath": "0.0.34"
@@ -112,7 +114,6 @@
     "node-libs-browser": "Deprecated",
     "parcel-bundler": "V2: significant rewrite required",
     "postcss-modules": "V4: requires updating to Parcel v2",
-    "redux-logger": "Appears to be abandoned",
     "spectron": "Deprecated. Newer V16 also requires Electron 14"
   },
   "devDependencies": {
@@ -157,7 +158,6 @@
     "parcel-plugin-asset-copier": "1.1.1",
     "postcss-modules": "3.2.2",
     "prettier": "3.3.3",
-    "redux-logger": "3.0.6",
     "rimraf": "5.0.9",
     "sinon": "18.0.0",
     "spectron": "15.0.0"


### PR DESCRIPTION
This is a fix for the change in #1544. It seems like the full Electron app (built via `electron-builder`) returns an error that redux-logger cannot be found. Moving it to main dependencies was confirmed to fix the issue, and the actual logs were also confirmed to still not be shown, as their initialisation is behind the development flag. 