### PR TITLE
chore: fix i18next warnings

### DIFF
--- a/app/common/shared/i18next.config.js
+++ b/app/common/shared/i18next.config.js
@@ -36,6 +36,7 @@ export function getI18NextOptions(backend) {
       escapeValue: false,
     },
     lng: (settings && settings.getSync('PREFERRED_LANGUAGE')) || fallbackLng,
+    load: 'currentOnly',
     fallbackLng,
     supportedLngs: languageList.map((language) => language.code),
   };

--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -93,7 +93,17 @@ export function setupMainWindow() {
     ]).popup(mainWindow);
   });
 
+  i18n.on('initialized', () => {
+    rebuildMenus(mainWindow);
+    i18n.off('initialized');
+  });
+
   i18n.on('languageChanged', async (languageCode) => {
+    // this event gets called before the i18n initialization event,
+    // so add a guard condition
+    if (!i18n.isInitialized) {
+      return;
+    }
     rebuildMenus(mainWindow);
     await settings.set('PREFERRED_LANGUAGE', languageCode);
     webContents.getAllWebContents().forEach((wc) => {
@@ -102,8 +112,6 @@ export function setupMainWindow() {
       });
     });
   });
-
-  rebuildMenus(mainWindow);
 }
 
 export function launchNewSessionWindow() {


### PR DESCRIPTION
I noticed that i18next was returning some warnings when running it in debug mode. This PR fixes these warnings by ensuring that i18next has finished loading before it is used.