### PR TITLE
chore: store session settings in Redux

### DIFF
--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -19,6 +19,7 @@ import {showError} from './Session';
 
 export const SET_SESSION_DETAILS = 'SET_SESSION_DETAILS';
 export const SET_SOURCE_AND_SCREENSHOT = 'SET_SOURCE_AND_SCREENSHOT';
+export const STORE_SESSION_SETTINGS = 'STORE_SESSION_SETTINGS';
 export const SESSION_DONE = 'SESSION_DONE';
 export const SELECT_ELEMENT = 'SELECT_ELEMENT';
 export const UNSELECT_ELEMENT = 'UNSELECT_ELEMENT';
@@ -365,6 +366,20 @@ export function toggleShowBoilerplate() {
 export function setSessionDetails({driver, sessionDetails, mode, mjpegScreenshotUrl}) {
   return (dispatch) => {
     dispatch({type: SET_SESSION_DETAILS, driver, sessionDetails, mode, mjpegScreenshotUrl});
+  };
+}
+
+export function storeSessionSettings(sessionSettings = null) {
+  return async (dispatch, getState) => {
+    if (sessionSettings === null) {
+      const action = applyClientMethod({
+        methodName: 'getSettings',
+        skipRefresh: true,
+        ignoreResult: true,
+      });
+      sessionSettings = await action(dispatch, getState);
+    }
+    dispatch({type: STORE_SESSION_SETTINGS, sessionSettings});
   };
 }
 

--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -371,16 +371,14 @@ export function setSessionDetails({driver, sessionDetails, mode, mjpegScreenshot
 
 export function storeSessionSettings(updatedSessionSettings = null) {
   return async (dispatch, getState) => {
-    let sessionSettings;
-    if (updatedSessionSettings === null) {
+    let sessionSettings = updatedSessionSettings;
+    if (sessionSettings === null) {
       const action = applyClientMethod({
         methodName: 'getSettings',
         skipRefresh: true,
         ignoreResult: true,
       });
       sessionSettings = await action(dispatch, getState);
-    } else {
-      sessionSettings = updatedSessionSettings;
     }
     dispatch({type: STORE_SESSION_SETTINGS, sessionSettings});
   };

--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -369,15 +369,18 @@ export function setSessionDetails({driver, sessionDetails, mode, mjpegScreenshot
   };
 }
 
-export function storeSessionSettings(sessionSettings = null) {
+export function storeSessionSettings(updatedSessionSettings = null) {
   return async (dispatch, getState) => {
-    if (sessionSettings === null) {
+    let sessionSettings;
+    if (updatedSessionSettings === null) {
       const action = applyClientMethod({
         methodName: 'getSettings',
         skipRefresh: true,
         ignoreResult: true,
       });
       sessionSettings = await action(dispatch, getState);
+    } else {
+      sessionSettings = updatedSessionSettings;
     }
     dispatch({type: STORE_SESSION_SETTINGS, sessionSettings});
   };

--- a/app/common/renderer/components/Inspector/Commands.jsx
+++ b/app/common/renderer/components/Inspector/Commands.jsx
@@ -25,6 +25,7 @@ const Commands = (props) => {
     setCommandArg,
     applyClientMethod,
     automationName,
+    storeSessionSettings,
     t,
   } = props;
 
@@ -115,6 +116,10 @@ const Commands = (props) => {
         skipRefresh: !refresh,
         ignoreResult: false,
       });
+      // if updating settings, store the updated values
+      if (commandName === 'updateSettings') {
+        storeSessionSettings(...copiedArgs);
+      }
     }
 
     cancelPendingCommand();

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -175,7 +175,13 @@ const Inspector = (props) => {
   };
 
   useEffect(() => {
-    const {applyClientMethod, getSavedActionFramework, runKeepAliveLoop, setSessionTime} = props;
+    const {
+      applyClientMethod,
+      getSavedActionFramework,
+      runKeepAliveLoop,
+      setSessionTime,
+      storeSessionSettings,
+    } = props;
     const curHeight = window.innerHeight;
     const curWidth = window.innerWidth;
     const needsResize =
@@ -190,6 +196,7 @@ const Inspector = (props) => {
     }
     didInitialResize.current = true;
     applyClientMethod({methodName: 'getPageSource', ignoreResult: true});
+    storeSessionSettings();
     getSavedActionFramework();
     runKeepAliveLoop();
     setSessionTime(Date.now());

--- a/app/common/renderer/reducers/Inspector.js
+++ b/app/common/renderer/reducers/Inspector.js
@@ -75,6 +75,7 @@ import {
   SHOW_LOCATOR_TEST_MODAL,
   SHOW_SIRI_COMMAND_MODAL,
   START_RECORDING,
+  STORE_SESSION_SETTINGS,
   TOGGLE_REFRESHING_STATE,
   TOGGLE_SHOW_ATTRIBUTES,
   UNSELECT_CENTROID,
@@ -103,6 +104,7 @@ const INITIAL_STATE = {
   recordedActions: [],
   actionFramework: DEFAULT_FRAMEWORK,
   sessionDetails: {},
+  sessionSettings: {},
   isGestureEditorVisible: false,
   isLocatorTestModalVisible: false,
   isSiriCommandModalVisible: false,
@@ -316,6 +318,12 @@ export default function inspector(state = INITIAL_STATE, action) {
         mjpegScreenshotUrl: action.mjpegScreenshotUrl,
       };
     }
+
+    case STORE_SESSION_SETTINGS:
+      return {
+        ...state,
+        sessionSettings: {...state.sessionSettings, ...action.sessionSettings},
+      };
 
     case SHOW_LOCATOR_TEST_MODAL:
       return {


### PR DESCRIPTION
This PR adds a new Redux state property `sessionSettings`, which stores the Appium settings for the currently active session. The stored settings are also updated if the user changes them through the Commands tab.
This information can be used for new features in the future (for example, to show an info bubble if the currently selected element is at `snapshotMaxDepth`).