### PR TITLE
fix: retrieve disableIdLocatorAutocompletion from settings

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -131,7 +131,7 @@
   "usingXPathNotRecommended": "Using XPath locators is not recommended and can lead to fragile tests. Ask your development team to provide unique accessibility locators instead!",
   "noAdditionalContextsFound": "No additional contexts have been detected",
   "contextDropdownInfo": "Multiple contexts detected; certain elements might only be accessible after switching to a different context. Note that webview inspection in Appium Inspector is less accurate than the DevTools of Chrome or Safari. For more information, see:",
-  "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This Appium session has package name autocompletion enabled, which may be the reason why no elements were found. To disable this behavior, relaunch this session with the capability 'appium:disableIdLocatorAutocompletion' set to 'true'.",
+  "idAutocompletionCanBeDisabled": "The requested id selector does not have a package name prefix. This Appium session has package name autocompletion enabled, which may be the reason why no elements were found. To disable this behavior, change the 'disableIdLocatorAutocompletion' setting to 'true'.",
   "missingAutomationNameForStrategies": "Additional locator strategies may be available. To view them, add the capability 'appium:automationName' when launching the session. Note that this capability is mandatory in Appium 2.",
   "Tap": "Tap",
   "Gathering initial app source…": "Gathering initial app source…",

--- a/app/common/renderer/components/Inspector/LocatedElements.jsx
+++ b/app/common/renderer/components/Inspector/LocatedElements.jsx
@@ -17,7 +17,6 @@ const LocatedElements = (props) => {
     selectLocatedElement,
     sourceJSON,
     sourceXML,
-    driver,
     locatorTestStrategy,
     locatorTestValue,
     t,
@@ -26,14 +25,12 @@ const LocatedElements = (props) => {
   const sendKeys = useRef(null);
 
   const showIdAutocompleteInfo = () => {
-    const {automationName} = props;
-    const idLocatorAutocompletionDisabled =
-      driver.client.capabilities.disableIdLocatorAutocompletion;
+    const {automationName, sessionSettings} = props;
     if (
       automationName === 'uiautomator2' &&
       locatorTestStrategy === 'id' &&
       !locatorTestValue.includes(':id/') &&
-      !idLocatorAutocompletionDisabled
+      !sessionSettings.disableIdLocatorAutocompletion
     ) {
       return (
         <Row>


### PR DESCRIPTION
This is a fix for the info message added in #885.
The current implementation relies on the `disableIdLocatorAutocompletion` _capability_, not _setting_. This PR changes the check (and the info message) to use the setting instead.