### PR TITLE
fix: add missing tooltips in session builder

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -198,6 +198,7 @@
   "Bitbar API Key": "Bitbar API Key",
   "RemoteTestKit AccessToken": "RemoteTestKit AccessToken",
   "RobotQA Token": "RobotQA Token",
+  "Add": "Add",
   "Name": "Name",
   "Description": "Description",
   "Created": "Created",

--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -136,11 +136,13 @@ const CapabilityEditor = (props) => {
               <Col span={2}>
                 <div className={SessionStyles.btnDeleteCap}>
                   <Form.Item>
-                    <Button
-                      {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
-                      icon={<DeleteOutlined />}
-                      onClick={() => removeCapability(index)}
-                    />
+                    <Tooltip title={t('Delete')}>
+                      <Button
+                        {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
+                        icon={<DeleteOutlined />}
+                        onClick={() => removeCapability(index)}
+                      />
+                    </Tooltip>
                   </Form.Item>
                 </div>
               </Col>
@@ -159,13 +161,15 @@ const CapabilityEditor = (props) => {
             </Col>
             <Col span={2}>
               <Form.Item>
-                <Button
-                  disabled={isEditingDesiredCaps}
-                  id="btnAddDesiredCapability"
-                  icon={<PlusOutlined />}
-                  onClick={addCapability}
-                  className={SessionStyles['add-desired-capability-button']}
-                />
+                <Tooltip title={t('Add')}>
+                  <Button
+                    disabled={isEditingDesiredCaps}
+                    id="btnAddDesiredCapability"
+                    icon={<PlusOutlined />}
+                    onClick={addCapability}
+                    className={SessionStyles['add-desired-capability-button']}
+                  />
+                </Tooltip>
               </Form.Item>
             </Col>
           </Row>

--- a/app/common/renderer/components/Session/SavedSessions.jsx
+++ b/app/common/renderer/components/Session/SavedSessions.jsx
@@ -1,5 +1,5 @@
 import {DeleteOutlined, EditOutlined} from '@ant-design/icons';
-import {Button, Col, Row, Table} from 'antd';
+import {Button, Col, Row, Table, Tooltip} from 'antd';
 import moment from 'moment';
 import React from 'react';
 
@@ -85,17 +85,20 @@ const SavedSessions = (props) => {
       key: 'action',
       width: SAVED_SESSIONS_TABLE_VALUES.ACTIONS_COLUMN_WIDTH,
       render: (_, record) => (
-        <div>
-          <Button
-            icon={<EditOutlined />}
-            onClick={() => {
-              handleCapsAndServer(record.key);
-              switchTabs('new');
-            }}
-            className={SessionStyles.editSession}
-          />
-          <Button icon={<DeleteOutlined />} onClick={() => handleDelete(record.key)} />
-        </div>
+        <Button.Group>
+          <Tooltip title={t('Edit')}>
+            <Button
+              icon={<EditOutlined />}
+              onClick={() => {
+                handleCapsAndServer(record.key);
+                switchTabs('new');
+              }}
+            />
+          </Tooltip>
+          <Tooltip title={t('Delete')}>
+            <Button icon={<DeleteOutlined />} onClick={() => handleDelete(record.key)} />
+          </Tooltip>
+        </Button.Group>
       ),
     },
   ];

--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -283,10 +283,6 @@
   float: right;
 }
 
-.editSession {
-  margin-right: 10px;
-}
-
 .btnReload {
   float: right;
   margin-left: 8px;


### PR DESCRIPTION
Small PR to add a few missing button tooltips in the Session Builder screen:
* Deleting a single capability
* Adding a new capability
* Editing a capability set
* Deleting a capability set

The two buttons for capability set actions have also been merged using a button group, removing the space between them.