### PR TITLE
chore(renovate): adjust Renovate config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,10 +59,11 @@
   "//dependencies": {
     "antd": "V5: significant rewrite required",
     "bluebird": "Deprecated: recommended to replace with native promises",
+    "cheerio": "V1: requires Node 18",
     "electron-debug": "V4: requires Electron 30",
     "electron-settings": "V5: need to rewrite to IPC while keeping browser version working",
     "redux-logger": "Appears to be abandoned",
-    "uuid": "Obsolete: can be replaced with crypto.randomUUID in Electron 14+"
+    "uuid": "V10: requires Node 16. Can also be replaced with crypto.randomUUID in Electron 14+"
   },
   "dependencies": {
     "@reduxjs/toolkit": "2.2.7",
@@ -96,7 +97,8 @@
   },
   "//devDependencies": {
     "electron": "V14: breaks electron-settings",
-    "eslint": "V9: need to move to flat config"
+    "eslint": "V9: need to move to flat config",
+    "rimraf": "V6: requires Node 20"
   },
   "devDependencies": {
     "@appium/docutils": "1.0.19",

--- a/renovate.json
+++ b/renovate.json
@@ -8,14 +8,26 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["antd", "electron", "electron-debug", "eslint"],
+      "matchPackageNames": [
+        "antd",
+        "cheerio",
+        "electron",
+        "electron-debug",
+        "eslint",
+        "rimraf",
+        "uuid"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
+    },
+    {
+      "matchPackageNames": ["appium", "@appium/**"],
+      "groupName": "Appium-related packages",
+      "groupSlug": "appium"
     }
   ],
   "baseBranches": ["main"],
   "semanticCommits": "enabled",
-  "schedule": ["after 10pm and before 5:00am"],
-  "timezone": "America/Vancouver",
-  "transitiveRemediation": true
+  "schedule": ["after 10pm", "before 5:00am"],
+  "timezone": "America/Vancouver"
 }


### PR DESCRIPTION
Few changes to the Renovate config:
* Remove `transitiveRemediation` option since it has been removed in Renovate 38
* Split `schedule` into individual time points
* Add `cheerio`, `rimraf` and `uuid` to blocked major releases list
* Add group slug for Appium-related packages