### PR TITLE
chore(renovate): tune Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["config:base", ":semanticCommitTypeAll(chore)", ":pinAllExceptPeerDependencies"],
+  "extends": [
+    "config:recommended",
+    ":semanticCommitTypeAll(chore)",
+    ":pinAllExceptPeerDependencies"
+  ],
   "labels": ["dependencies"],
   "packageRules": [
     {


### PR DESCRIPTION
One more minor adjustment for the Renovate config. Saw in the logs that `config:base` was changed to `config:recommended`. The former does not exist in the docs anymore, so it has been replaced with the latter.