### PR TITLE
feat: replace native confirmation popups with antd popconfirms

### DIFF
--- a/app/common/renderer/components/Inspector/SavedGestures.jsx
+++ b/app/common/renderer/components/Inspector/SavedGestures.jsx
@@ -1,5 +1,5 @@
 import {DeleteOutlined, EditOutlined, PlayCircleOutlined, PlusOutlined} from '@ant-design/icons';
-import {Button, Space, Table, Tooltip} from 'antd';
+import {Button, Popconfirm, Space, Table, Tooltip} from 'antd';
 import _ from 'lodash';
 import moment from 'moment';
 import React, {useEffect, useRef} from 'react';
@@ -31,7 +31,7 @@ const getGestureByID = (savedGestures, id, t) => {
 };
 
 const SavedGestures = (props) => {
-  const {savedGestures, showGestureEditor, removeGestureDisplay, t} = props;
+  const {savedGestures, deleteSavedGesture, showGestureEditor, removeGestureDisplay, t} = props;
 
   const drawnGestureRef = useRef(null);
 
@@ -51,13 +51,6 @@ const SavedGestures = (props) => {
     removeGestureDisplay();
     setLoadedGesture(gesture);
     showGestureEditor();
-  };
-
-  const handleDelete = (id) => {
-    const {deleteSavedGesture} = props;
-    if (window.confirm(t('confirmDeletion'))) {
-      deleteSavedGesture(id);
-    }
   };
 
   const onDraw = (gesture) => {
@@ -113,7 +106,15 @@ const SavedGestures = (props) => {
                 />
               </Tooltip>
               <Button icon={<EditOutlined />} onClick={() => loadSavedGesture(gesture)} />
-              <Button icon={<DeleteOutlined />} onClick={() => handleDelete(gesture.id)} />
+              <Popconfirm
+                title={t('confirmDeletion')}
+                placement="topRight"
+                okText={t('OK')}
+                cancelText={t('Cancel')}
+                onConfirm={() => deleteSavedGesture(gesture.id)}
+              >
+                <Button icon={<DeleteOutlined />} />
+              </Popconfirm>
             </Button.Group>
           );
         },

--- a/app/common/renderer/components/Session/SavedSessions.jsx
+++ b/app/common/renderer/components/Session/SavedSessions.jsx
@@ -1,5 +1,5 @@
 import {DeleteOutlined, EditOutlined} from '@ant-design/icons';
-import {Button, Col, Row, Table, Tooltip} from 'antd';
+import {Button, Col, Popconfirm, Row, Table, Tooltip} from 'antd';
 import moment from 'moment';
 import React from 'react';
 
@@ -28,7 +28,7 @@ const getSessionById = (savedSessions, id, t) => {
 };
 
 const SavedSessions = (props) => {
-  const {savedSessions, capsUUID, switchTabs, t} = props;
+  const {savedSessions, deleteSavedSession, capsUUID, switchTabs, t} = props;
 
   const handleCapsAndServer = (uuid) => {
     const {
@@ -61,13 +61,6 @@ const SavedSessions = (props) => {
     );
   };
 
-  const handleDelete = (uuid) => {
-    const {deleteSavedSession} = props;
-    if (window.confirm(t('confirmDeletion'))) {
-      deleteSavedSession(uuid);
-    }
-  };
-
   const columns = [
     {
       title: t('Name'),
@@ -86,7 +79,7 @@ const SavedSessions = (props) => {
       width: SAVED_SESSIONS_TABLE_VALUES.ACTIONS_COLUMN_WIDTH,
       render: (_, record) => (
         <Button.Group>
-          <Tooltip title={t('Edit')}>
+          <Tooltip zIndex={2} title={t('Edit')}>
             <Button
               icon={<EditOutlined />}
               onClick={() => {
@@ -95,8 +88,16 @@ const SavedSessions = (props) => {
               }}
             />
           </Tooltip>
-          <Tooltip title={t('Delete')}>
-            <Button icon={<DeleteOutlined />} onClick={() => handleDelete(record.key)} />
+          <Tooltip zIndex={2} title={t('Delete')}>
+            <Popconfirm
+              zIndex={3}
+              title={t('confirmDeletion')}
+              okText={t('OK')}
+              cancelText={t('Cancel')}
+              onConfirm={() => deleteSavedSession(record.key)}
+            >
+              <Button icon={<DeleteOutlined />} />
+            </Popconfirm>
           </Tooltip>
         </Button.Group>
       ),


### PR DESCRIPTION
This PR is a style change for the confirmation dialogs that appear when deleting a saved capability set or gesture.
* The current implementation uses the native browser alert/Electron full window popup, which blocks all interaction with the application until either of the two prompt options are selected.
* The proposed implementation switches to the `antd` `Popconfirm` component, which offers several benefits:
  * More lightweight UX
  * Consistent style with the rest of the app
  * Automatically dismissed upon any action outside the dialog
  * i18n support

![Screenshot 2024-08-16 at 16 32 28](https://github.com/user-attachments/assets/868e8ec9-120c-422c-9e9e-57abce3fff51)

Note: antd does not auto-hide tooltips on click, so for saved capability sets, the `zIndex` prop was used to place the tooltip behind the popconfirm.

