### PR TITLE
fix: open most recent server type tab on app launch

### DIFF
--- a/app/common/renderer/components/Session/Session.jsx
+++ b/app/common/renderer/components/Session/Session.jsx
@@ -78,9 +78,9 @@ const Session = (props) => {
         bindWindowClose();
         switchTabs(SESSION_BUILDER_TABS.CAPS_BUILDER);
         await getSavedSessions();
+        await setVisibleProviders();
         await setSavedServerParams();
         await setLocalServerParams();
-        await setVisibleProviders();
         initFromQueryString(loadNewSession);
         await setStateFromAppiumFile();
         ipcRenderer.on('open-file', (_, filePath) => setStateFromAppiumFile(filePath));


### PR DESCRIPTION
This small fix resolves an issue where the last opened server type tab was not being saved upon relaunching the app.
The reason is that `setSavedServerParams` checks the state variable `visibleProviders`, but this variable is empty until `setVisibleProviders` is called.