### PR TITLE
fix: adjust tooltip for quit session button

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -103,7 +103,6 @@
   "Copy XML Source to Clipboard": "Copy XML Source to Clipboard",
   "Download Source as .XML File": "Download Source as .XML File",
   "Copy Attributes to Clipboard": "Copy Attributes to Clipboard",
-  "quitSessionAndClose": "Quit Session & Close Inspector",
   "Session Inactive": "Session Inactive",
   "Keep Session Running": "Keep Session Running",
   "Quit Session": "Quit Session",

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -214,7 +214,7 @@ const HeaderButtons = (props) => {
   );
 
   const quitSessionButton = (
-    <Tooltip title={t('quitSessionAndClose')}>
+    <Tooltip title={t('Quit Session')}>
       <Button id="btnClose" icon={<CloseOutlined />} onClick={quitCurrentSession} />
     </Tooltip>
   );


### PR DESCRIPTION
The tooltip for the quit session button incorrectly mentions that clicking it will also close the Inspector, but this is not the case. This PR removes this mention from the tooltip text.