### PR TITLE
fix: do not add prefix to webSocketUrl capability

### DIFF
--- a/app/common/renderer/constants/session-builder.js
+++ b/app/common/renderer/constants/session-builder.js
@@ -40,3 +40,16 @@ export const PROVIDER_VALUES = {
 };
 
 export const ADD_CLOUD_PROVIDER_TAB_KEY = 'addCloudProvider';
+
+export const STANDARD_W3C_CAPS = [
+  'platformName',
+  'browserName',
+  'browserVersion',
+  'acceptInsecureCerts',
+  'pageLoadStrategy',
+  'proxy',
+  'setWindowRect',
+  'timeouts',
+  'unhandledPromptBehavior',
+  'webSocketUrl', // WebDriver BiDi
+];

--- a/app/common/renderer/utils/other.js
+++ b/app/common/renderer/utils/other.js
@@ -1,24 +1,14 @@
 import _ from 'lodash';
 import {Promise} from 'bluebird';
 
-const VALID_W3C_CAPS = [
-  'platformName',
-  'browserName',
-  'browserVersion',
-  'acceptInsecureCerts',
-  'pageLoadStrategy',
-  'proxy',
-  'setWindowRect',
-  'timeouts',
-  'unhandledPromptBehavior',
-];
+import {STANDARD_W3C_CAPS} from '../constants/session-builder';
 
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {
     // if we don't have a valid unprefixed cap or a cap with an existing prefix, update it
     if (
       !_.isUndefined(cap.name) &&
-      !VALID_W3C_CAPS.includes(cap.name) &&
+      !STANDARD_W3C_CAPS.includes(cap.name) &&
       !_.includes(cap.name, ':')
     ) {
       cap.name = `appium:${cap.name}`;


### PR DESCRIPTION
WebDriver BiDi defines an additional standard capability `webSocketUrl`, and Appium technically already supports BiDi since 2.4.0. This PR ensures that this capability does not get automatically prefixed with `appium:`.