### PR TITLE
fix: prevent deletion of default pointer in gesture

### DIFF
--- a/app/common/renderer/components/Inspector/GestureEditor.jsx
+++ b/app/common/renderer/components/Inspector/GestureEditor.jsx
@@ -687,6 +687,7 @@ const GestureEditor = (props) => {
       </Tooltip>
     ),
     key: pointer.id,
+    closable: pointer.id !== '1',
     children: pointerTicksGrid(pointer),
   }));
 


### PR DESCRIPTION
Currently the gesture editor allows deletion of the default pointer in a gesture, which causes an odd-looking state (although it is easily recoverable). This PR simply prevents deleting the default pointer.

This works even if the user has a gesture where the default pointer had been previously deleted, since the `deletePointer` method automatically adjusts pointer IDs to always start at 1.