### PR TITLE
fix: adjust saved session JSON height to fit in container

### DIFF
--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -162,7 +162,7 @@
 }
 
 .formattedCaps :global(.ant-card-body) {
-  height: calc(100% - 54px);
+  height: calc(100% - 66px);
   padding: 0 14px 0 24px;
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
There is a minor regression in 2024.6.1 where the capability set JSON contents can extend outside its container. This PR resolves this issue.