### PR TITLE
fix: avoid overlap for add/delete capability button tooltips

### DIFF
--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -136,7 +136,7 @@ const CapabilityEditor = (props) => {
               <Col span={2}>
                 <div className={SessionStyles.btnDeleteCap}>
                   <Form.Item>
-                    <Tooltip title={t('Delete')}>
+                    <Tooltip title={t('Delete')} placement="right">
                       <Button
                         {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
                         icon={<DeleteOutlined />}
@@ -161,7 +161,7 @@ const CapabilityEditor = (props) => {
             </Col>
             <Col span={2}>
               <Form.Item>
-                <Tooltip title={t('Add')}>
+                <Tooltip title={t('Add')} placement="right">
                   <Button
                     disabled={isEditingDesiredCaps}
                     id="btnAddDesiredCapability"


### PR DESCRIPTION
Minor adjustment for #1597 - the tooltips for add/delete buttons were drawn over the delete buttons for other caps. This makes it inconvenient to delete multiple capabilites in a row, so the tooltip was changed to be shown on the right side of the buttons.