### PR TITLE
docs: tune gesture builder docs

### DIFF
--- a/docs/session-inspector/gestures.md
+++ b/docs/session-inspector/gestures.md
@@ -9,19 +9,21 @@ tab shows the Saved Gestures screen.
 
 ## Saved Gestures
 
-The default saved gestures list is empty, but can be populated by creating and saving new gestures.
-New gestures can either be created manually or can be imported from JSON files that were previously downloaded from the saved gestures section.
+The default saved gestures list is empty, but can be populated by either manually creating and saving
+new gestures, or importing gesture files in JSON format.
 
--   New gesture can be created by pressing the `+` button in the bottom left, which will open the [Gesture Builder](#gesture-builder) screen.
--   Gestures downloaded as JSON files can be uploaded on clicking the `upload icon`. This opens a file browser window, allowing multiple gestures to be uploaded simultaneously.
+-   New gestures can be created by pressing the `+` button in the bottom left, which will open the
+[Gesture Builder](#gesture-builder) screen.
+-   Gesture files in JSON format can be uploaded on clicking the `upload icon`. This opens a file
+browser window, allowing multiple gestures to be uploaded simultaneously.
 
-Once a gesture has been created and saved, clicking its entry in the saved gestures list will show
-its expected actions as an overlay over the [screenshot](./screenshot.md). There are also 4 buttons
-for each gesture:
+Once a gesture has been created and saved, hovering over its entry in the saved gestures list will
+show its actions as an overlay over the [screenshot](./screenshot.md). There are also 4
+buttons for each gesture:
 
 -   Execute the gesture
 -   Edit the gesture (will open it in the [Gesture Builder](#gesture-builder))
--   Download the gesture as JSON file
+-   Download the gesture as a JSON file
 -   Delete the gesture
 
 ## Gesture Builder


### PR DESCRIPTION
Slight adjustment for the gesture docs - I noticed I had not updated them as part of #1623 (the gesture is now drawn on hover, not click).