### PR TITLE
fix: resolve issue with incorrect app menu bar

### DIFF
--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -68,6 +68,7 @@ export function setupMainWindow() {
   mainWindow[pathLoadMethod](mainPath);
 
   mainWindow.webContents.on('did-finish-load', () => {
+    rebuildMenus(mainWindow);
     splashWindow.destroy();
     mainWindow.show();
     mainWindow.focus();
@@ -92,11 +93,6 @@ export function setupMainWindow() {
         },
       },
     ]).popup(mainWindow);
-  });
-
-  i18n.on('initialized', () => {
-    rebuildMenus(mainWindow);
-    i18n.off('initialized');
   });
 
   i18n.on('languageChanged', async (languageCode) => {

--- a/docs/session-inspector/gestures.md
+++ b/docs/session-inspector/gestures.md
@@ -13,9 +13,9 @@ The default saved gestures list is empty, but can be populated by either manuall
 new gestures, or importing gesture files in JSON format.
 
 -   New gestures can be created by pressing the `+` button in the bottom left, which will open the
-[Gesture Builder](#gesture-builder) screen.
+    [Gesture Builder](#gesture-builder) screen.
 -   Gesture files in JSON format can be uploaded on clicking the `upload icon`. This opens a file
-browser window, allowing multiple gestures to be uploaded simultaneously.
+    browser window, allowing multiple gestures to be uploaded simultaneously.
 
 Once a gesture has been created and saved, hovering over its entry in the saved gestures list will
 show its actions as an overlay over the [screenshot](./screenshot.md). There are also 4


### PR DESCRIPTION
Accidentally noticed an issue where the customized macOS menu bar was sometimes not being loaded properly, which, among other things, would prevent changing the app language. I could not observe this in the dev or preview builds, only the full packaged app.
The problem is caused by the changes in #1574, but it is odd:
* before that PR, the menu was being built before i18n had finished, yet it worked fine
* after that PR, the menu was built after i18n had finished, but it seems to be having issues
* with this PR, the menu is built after the main Electron webcontents have finished (which happens after i18n finishes), and it somehow works fine again ¯\\\_(ツ)_/¯