### PR TITLE
fix: allow creating sessions for Selenium Grid devices

### DIFF
--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -95,6 +95,14 @@ export function setupMainWindow() {
     ]).popup(mainWindow);
   });
 
+  // Override the 'content-type' header to allow connecting to Selenium Grid devices
+  // eslint-disable-next-line promise/prefer-await-to-callbacks
+  mainWindow.webContents.session.webRequest.onBeforeSendHeaders((details, callback) => {
+    details.requestHeaders['content-type'] = 'application/json; charset=utf-8';
+    // eslint-disable-next-line promise/prefer-await-to-callbacks
+    callback({requestHeaders: details.requestHeaders});
+  });
+
   i18n.on('languageChanged', async (languageCode) => {
     // this event gets called before the i18n initialization event,
     // so add a guard condition


### PR DESCRIPTION
There is a known issue #286, where it is not possible to start a new session on a device accessed through Selenium Grid. This fixes the issue for the desktop app, by modifying the request header.
I'm also not sure whether this flow currently works through the browser version, because I was only getting CORS errors (even though I launched Appium, Selenium hub & Selenium node all with the allow-cors flag)

Thanks to @broetchenrackete36 for the code example in the linked issue, which was used as the basis for this fix.

Resolves #286.