### PR TITLE
docs: add note about CORS in dev mode

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,6 +32,13 @@ npm run dev:browser
 npm run dev:electron
 ```
 
+!!! tip
+
+    Development mode runs in a separate dev server, so all Inspector sessions are subject to
+    [cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS)
+    issues. In order to avoid this, before requesting a new session in dev mode, ensure your Appium
+    server has been launched with the `--allow-cors` flag.
+
 Run tests:
 
 ```bash


### PR DESCRIPTION
While working on #1632, I noticed that I was unable to connect to Selenium Grid devices in the Inspector's dev mode, but it worked fine in production mode. The error I got in dev mode seemed to be related to CORS, so I got curious and tried to connect to a regular Appium server with CORS disabled - and I got the same error. Tried again with CORS enabled, and it worked as expected.
As this behavior is not immediately obvious, this PR adds a note in the contributing docs about the requirement to launch Appium with `--allow-cors` when in dev mode.

(I'm still unsure what additional configuration is needed for Selenium Grid, though - I launched Appium, Selenium Grid hub, and Selenium Grid node, all with CORS enabled, yet I was still getting the same error...)