### PR TITLE
chore: convert Electron modules to IPC

### DIFF
--- a/app/common/renderer/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import {clipboard} from '../../polyfills';
+import {copyToClipboard} from '../../polyfills';
 import ErrorMessage from './ErrorMessage.jsx';
 
 const copyTrace = (trace) => {
-  clipboard.writeText(trace);
+  copyToClipboard(trace);
 };
 
 export default class ErrorBoundary extends React.Component {

--- a/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import {ALERT} from '../../constants/antd-types';
 import {LINKS} from '../../constants/common';
 import {withTranslation} from '../../i18next';
-import {shell} from '../../polyfills';
+import {openLink} from '../../polyfills';
 import styles from './ErrorMessage.module.css';
 
 const ErrorMessage = ({error, copyTrace, t}) => (
@@ -21,7 +21,7 @@ const ErrorMessage = ({error, copyTrace, t}) => (
       description={
         <>
           {t('Please report this issue at:')}&nbsp;
-          <a onClick={(e) => e.preventDefault() || shell.openExternal(LINKS.CREATE_ISSUE)}>
+          <a onClick={(e) => e.preventDefault() || openLink(LINKS.CREATE_ISSUE)}>
             {LINKS.CREATE_ISSUE}
           </a>
           <br />

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -19,7 +19,7 @@ import {IoChevronBackOutline} from 'react-icons/io5';
 import {BUTTON} from '../../constants/antd-types';
 import {LINKS} from '../../constants/common';
 import {APP_MODE} from '../../constants/session-inspector';
-import {shell} from '../../polyfills';
+import {openLink} from '../../polyfills';
 import InspectorStyles from './Inspector.module.css';
 
 const HeaderButtons = (props) => {
@@ -145,9 +145,7 @@ const HeaderButtons = (props) => {
             title={
               <>
                 {t('contextDropdownInfo')}{' '}
-                <a
-                  onClick={(e) => e.preventDefault() || shell.openExternal(LINKS.HYBRID_MODE_DOCS)}
-                >
+                <a onClick={(e) => e.preventDefault() || openLink(LINKS.HYBRID_MODE_DOCS)}>
                   {LINKS.HYBRID_MODE_DOCS}
                 </a>
               </>

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -25,7 +25,7 @@ import {
   SESSION_EXPIRY_PROMPT_TIMEOUT,
 } from '../../constants/session-inspector';
 import {SCREENSHOT_INTERACTION_MODE} from '../../constants/screenshot';
-import {clipboard} from '../../polyfills';
+import {copyToClipboard} from '../../polyfills';
 import {downloadFile} from '../../utils/other';
 import Commands from './Commands.jsx';
 import GestureEditor from './GestureEditor.jsx';
@@ -325,7 +325,7 @@ const Inspector = (props) => {
                               type="text"
                               id="btnSourceXML"
                               icon={<CopyOutlined />}
-                              onClick={() => clipboard.writeText(sourceXML)}
+                              onClick={() => copyToClipboard(sourceXML)}
                             />
                           </Tooltip>
                           <Tooltip title={t('Download Source as .XML File')}>

--- a/app/common/renderer/components/Inspector/Recorder.jsx
+++ b/app/common/renderer/components/Inspector/Recorder.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import {BUTTON} from '../../constants/antd-types';
 import frameworks from '../../lib/client-frameworks';
-import {clipboard} from '../../polyfills';
+import {copyToClipboard} from '../../polyfills';
 import InspectorStyles from './Inspector.module.css';
 
 const Recorder = (props) => {
@@ -38,7 +38,7 @@ const Recorder = (props) => {
               />
             </Tooltip>
             <Tooltip title={t('Copy code to clipboard')}>
-              <Button icon={<CopyOutlined />} onClick={() => clipboard.writeText(code())} />
+              <Button icon={<CopyOutlined />} onClick={() => copyToClipboard(code())} />
             </Tooltip>
             <Tooltip title={t('Clear Actions')}>
               <Button icon={<ClearOutlined />} onClick={clearRecording} />

--- a/app/common/renderer/components/Inspector/SelectedElement.jsx
+++ b/app/common/renderer/components/Inspector/SelectedElement.jsx
@@ -13,7 +13,7 @@ import React, {useRef} from 'react';
 import {ALERT, ROW} from '../../constants/antd-types';
 import {LINKS} from '../../constants/common';
 import {NATIVE_APP} from '../../constants/session-inspector';
-import {clipboard, shell} from '../../polyfills';
+import {copyToClipboard, openLink} from '../../polyfills';
 import styles from './Inspector.module.css';
 
 /**
@@ -62,7 +62,7 @@ const SelectedElement = (props) => {
       return (
         <div className={styles['selected-element-table-cells']}>
           <Tooltip title={t('Copied!')} trigger="click">
-            <span className={styles['element-cell-copy']} onClick={() => clipboard.writeText(text)}>
+            <span className={styles['element-cell-copy']} onClick={() => copyToClipboard(text)}>
               {text}
             </span>
           </Tooltip>
@@ -77,7 +77,7 @@ const SelectedElement = (props) => {
     <span>
       {name}
       <strong>
-        <a onClick={(e) => e.preventDefault() || shell.openExternal(docsLink)}>
+        <a onClick={(e) => e.preventDefault() || openLink(docsLink)}>
           <br />
           (docs)
         </a>
@@ -232,7 +232,7 @@ const SelectedElement = (props) => {
               disabled={isDisabled}
               id="btnCopyAttributes"
               icon={<CopyOutlined />}
-              onClick={() => clipboard.writeText(JSON.stringify(dataSource))}
+              onClick={() => copyToClipboard(JSON.stringify(dataSource))}
             />
           </Tooltip>
           <Tooltip title={t('Get Timing')}>

--- a/app/common/renderer/components/Inspector/SessionCodeBox.jsx
+++ b/app/common/renderer/components/Inspector/SessionCodeBox.jsx
@@ -4,7 +4,7 @@ import hljs from 'highlight.js';
 import React from 'react';
 
 import frameworks from '../../lib/client-frameworks';
-import {clipboard} from '../../polyfills';
+import {copyToClipboard} from '../../polyfills';
 import InspectorStyles from './Inspector.module.css';
 
 const SessionCodeBox = ({actionFramework, setActionFramework, sessionDetails, t}) => {
@@ -22,7 +22,7 @@ const SessionCodeBox = ({actionFramework, setActionFramework, sessionDetails, t}
   const actionBar = () => (
     <Space size="middle">
       <Tooltip title={t('Copy code to clipboard')}>
-        <Button icon={<CopyOutlined />} onClick={() => clipboard.writeText(code())} />
+        <Button icon={<CopyOutlined />} onClick={() => copyToClipboard(code())} />
       </Tooltip>
       <Select
         defaultValue={actionFramework}

--- a/app/common/renderer/components/Session/Session.jsx
+++ b/app/common/renderer/components/Session/Session.jsx
@@ -11,7 +11,7 @@ import {
   SERVER_TYPES,
   ADD_CLOUD_PROVIDER_TAB_KEY,
 } from '../../constants/session-builder';
-import {ipcRenderer, shell} from '../../polyfills';
+import {ipcRenderer, openLink} from '../../polyfills';
 import {log} from '../../utils/logger';
 import AdvancedServerParams from './AdvancedServerParams.jsx';
 import AttachToSession from './AttachToSession.jsx';
@@ -159,7 +159,7 @@ const Session = (props) => {
 
         <div className={SessionStyles.sessionFooter}>
           <div className={SessionStyles.desiredCapsLink}>
-            <a href="#" onClick={(e) => e.preventDefault() || shell.openExternal(LINKS.CAPS_DOCS)}>
+            <a href="#" onClick={(e) => e.preventDefault() || openLink(LINKS.CAPS_DOCS)}>
               <LinkOutlined />
               &nbsp;
               {t('desiredCapabilitiesDocumentation')}

--- a/app/common/renderer/polyfills.js
+++ b/app/common/renderer/polyfills.js
@@ -23,8 +23,8 @@ export function getSettingSync(setting) {
 }
 
 export {
-  clipboard,
-  shell,
+  copyToClipboard,
+  openLink,
   ipcRenderer,
   i18NextBackend,
   i18NextBackendOptions,

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -1,6 +1,13 @@
+import {clipboard, ipcMain, shell} from 'electron';
+
 import i18n from './i18next';
 
 export const isDev = process.env.NODE_ENV === 'development';
+
+export function setupIPCListeners() {
+  ipcMain.on('electron-openLink', (_evt, link) => shell.openExternal(link));
+  ipcMain.on('electron-copyToClipboard', (_evt, text) => clipboard.writeText(text));
+}
 
 export function getAppiumSessionFilePath(argv, isPackaged) {
   if (isDev) {

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -2,7 +2,7 @@ import {app} from 'electron';
 import debug from 'electron-debug';
 
 // import {installExtensions} from './debug';
-import {getAppiumSessionFilePath, isDev} from './helpers';
+import {getAppiumSessionFilePath, isDev, setupIPCListeners} from './helpers';
 import {setupMainWindow} from './windows';
 
 export let openFilePath = getAppiumSessionFilePath(process.argv, app.isPackaged);
@@ -22,5 +22,6 @@ app.on('ready', () => {
     // await installExtensions();
   }
 
+  setupIPCListeners();
   setupMainWindow();
 });

--- a/app/electron/renderer/polyfills.js
+++ b/app/electron/renderer/polyfills.js
@@ -1,4 +1,4 @@
-import {clipboard, ipcRenderer, shell} from 'electron';
+import {ipcRenderer} from 'electron';
 import settings from 'electron-settings';
 import fs from 'fs';
 import i18NextBackend from 'i18next-fs-backend';
@@ -17,4 +17,20 @@ const i18NextBackendOptions = {
   jsonIndent: 2,
 };
 
-export {settings, clipboard, shell, ipcRenderer, i18NextBackend, i18NextBackendOptions, fs, util};
+const electronUtils = {
+  copyToClipboard: (text) => ipcRenderer.send('electron-copyToClipboard', text),
+  openLink: (link) => ipcRenderer.send('electron-openLink', link),
+};
+
+const {copyToClipboard, openLink} = electronUtils;
+
+export {
+  settings,
+  copyToClipboard,
+  openLink,
+  ipcRenderer,
+  i18NextBackend,
+  i18NextBackendOptions,
+  fs,
+  util,
+};

--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -7,13 +7,9 @@ const localesPath =
     ? '/locales' // 'public' folder contents are served at '/'
     : '../locales'; // from 'dist-browser/assets/'
 
-const browser = {
-  clipboard: {
-    writeText: (text) => navigator.clipboard.writeText(text),
-  },
-  shell: {
-    openExternal: (url) => window.open(url, ''),
-  },
+const browserUtils = {
+  copyToClipboard: (text) => navigator.clipboard.writeText(text),
+  openLink: (url) => window.open(url, ''),
   ipcRenderer: {
     on: (evt) => {
       console.warn(`Cannot listen for IPC event ${evt} in browser context`); // eslint-disable-line no-console
@@ -42,7 +38,7 @@ class BrowserSettings {
 }
 
 const settings = new BrowserSettings();
-const {clipboard, shell, ipcRenderer, fs, util} = browser;
+const {copyToClipboard, openLink, ipcRenderer, fs, util} = browserUtils;
 const i18NextBackendOptions = {
   backends: [LocalStorageBackend, HttpApi],
   backendOptions: [
@@ -53,4 +49,13 @@ const i18NextBackendOptions = {
   ],
 };
 
-export {settings, clipboard, shell, ipcRenderer, i18NextBackend, i18NextBackendOptions, fs, util};
+export {
+  settings,
+  copyToClipboard,
+  openLink,
+  ipcRenderer,
+  i18NextBackend,
+  i18NextBackendOptions,
+  fs,
+  util,
+};


### PR DESCRIPTION
This PR changes Electron's `shell` and `clipboard` modules to be only accessible through IPC. The goal of this change is to make these modules still operational without Electron's remote module, which is removed in Electron 14.
Note that these are not all of the modules that need to be converted: IPC will be required for most of the imports in `app/electron/renderer/polyfills.js`, and the remaining ones are as follows:
* `electron-settings`: possibly requires updating to v5
* Node's built-in `path`, `fs`, `util`: the latter two are only used for `.appiumsession` files, but they may not be required if session import/export is changed to match the import/export approach used for gestures
* `i18next-fs-backend`: not fully sure if this one needs IPC. May also require changing to [i18next-electron-fs-backend](https://github.com/reZach/i18next-electron-fs-backend)

Clipboard and link opening functionality was tested in both Electron and browser versions.