### PR TITLE
chore: adjust xmldom wrappers for xmldom 0.9

### DIFF
--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -11,9 +11,9 @@ import {getSetting, setSetting} from '../polyfills';
 import {getOptimalXPath, getSuggestedLocators} from '../utils/locator-generation';
 import {readTextFromUploadedFiles} from '../utils/other';
 import {
-  domParser,
   findDOMNodeByPath,
   findJSONElementByPath,
+  xmlToDOM,
   xmlToJSON,
 } from '../utils/source-parsing';
 import {log} from '../utils/logger';
@@ -650,7 +650,7 @@ export function selectLocatedElement(sourceJSON, sourceXML, bounds, id) {
   // For each provided path, get its xpath and call Appium findElement
   // Return the path of the element whose ID matches the expected ID
   async function findElementWithMatchingId(foundPaths, dispatch, getState) {
-    const sourceDoc = domParser.parseFromString(sourceXML);
+    const sourceDoc = xmlToDOM(sourceXML);
     for (const path of foundPaths) {
       const domNode = findDOMNodeByPath(path, sourceDoc);
       const xpath = getOptimalXPath(sourceDoc, domNode);

--- a/app/common/renderer/utils/locator-generation.js
+++ b/app/common/renderer/utils/locator-generation.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import XPath from 'xpath';
 
 import {log} from './logger';
-import {childNodesOf, domParser, findDOMNodeByPath, xmlSerializer} from './source-parsing';
+import {childNodesOf, domParser, findDOMNodeByPath, serializeXMLToString} from './source-parsing';
 
 // Attributes on nodes that are likely to be unique to the node so we should consider first when
 // suggesting xpath locators. These are considered IN ORDER.
@@ -485,7 +485,7 @@ export function getOptimalUiAutomatorSelector(doc, domNode, path) {
     // then modify the path by changing the first index,
     // and finally recreate the domNode, since it still references the original parent
     const lastHierarchyChild = hierarchyChildren[lastHierarchyChildIndex];
-    const newXml = xmlSerializer.serializeToString(lastHierarchyChild);
+    const newXml = serializeXMLToString(lastHierarchyChild);
     // wrap the new XML in a dummy tag which will have the node type Document
     const newDoc = domParser.parseFromString(`<dummy>${newXml}</dummy>`);
     pathArray[0] = '0';

--- a/app/common/renderer/utils/locator-generation.js
+++ b/app/common/renderer/utils/locator-generation.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import XPath from 'xpath';
 
 import {log} from './logger';
-import {childNodesOf, domParser, findDOMNodeByPath, serializeXMLToString} from './source-parsing';
+import {childNodesOf, domToXML, findDOMNodeByPath, xmlToDOM} from './source-parsing';
 
 // Attributes on nodes that are likely to be unique to the node so we should consider first when
 // suggesting xpath locators. These are considered IN ORDER.
@@ -120,7 +120,7 @@ export function getComplexSuggestedLocators(path, sourceDoc, isNative, automatio
  * @returns {Array<[string, string]>} array of tuples, consisting of the locator strategy and selector
  */
 export function getSuggestedLocators(selectedElement, sourceXML, isNative, automationName) {
-  const sourceDoc = domParser.parseFromString(sourceXML);
+  const sourceDoc = xmlToDOM(sourceXML);
   const simpleLocators = getSimpleSuggestedLocators(
     selectedElement.attributes,
     sourceDoc,
@@ -485,9 +485,9 @@ export function getOptimalUiAutomatorSelector(doc, domNode, path) {
     // then modify the path by changing the first index,
     // and finally recreate the domNode, since it still references the original parent
     const lastHierarchyChild = hierarchyChildren[lastHierarchyChildIndex];
-    const newXml = serializeXMLToString(lastHierarchyChild);
+    const newXml = domToXML(lastHierarchyChild);
     // wrap the new XML in a dummy tag which will have the node type Document
-    const newDoc = domParser.parseFromString(`<dummy>${newXml}</dummy>`);
+    const newDoc = xmlToDOM(`<dummy>${newXml}</dummy>`);
     pathArray[0] = '0';
     const newPath = pathArray.join('.');
     const newDomNode = findDOMNodeByPath(newPath, newDoc);

--- a/app/common/renderer/utils/source-parsing.js
+++ b/app/common/renderer/utils/source-parsing.js
@@ -1,10 +1,11 @@
 import {DOMParser, XMLSerializer} from '@xmldom/xmldom';
 import _ from 'lodash';
 
-export const domParser = new DOMParser();
+const domParser = new DOMParser();
 const xmlSerializer = new XMLSerializer();
 
-export const serializeXMLToString = (xml) => xmlSerializer.serializeToString(xml);
+export const xmlToDOM = (string) => domParser.parseFromString(string, 'application/xml');
+export const domToXML = (dom) => xmlSerializer.serializeToString(dom);
 
 /**
  * Get the child nodes of a Node object
@@ -76,7 +77,7 @@ export function xmlToJSON(sourceXML) {
       path,
     };
   };
-  const sourceDoc = domParser.parseFromString(sourceXML);
+  const sourceDoc = xmlToDOM(sourceXML);
   // get the first child element node in the doc. some drivers write their xml differently so we
   // first try to find an element as a direct descendend of the doc, then look for one in
   // documentElement

--- a/app/common/renderer/utils/source-parsing.js
+++ b/app/common/renderer/utils/source-parsing.js
@@ -1,10 +1,10 @@
-import {DOMParser, XMLSerializer} from '@xmldom/xmldom';
+import {DOMParser, MIME_TYPE, XMLSerializer} from '@xmldom/xmldom';
 import _ from 'lodash';
 
 const domParser = new DOMParser();
 const xmlSerializer = new XMLSerializer();
 
-export const xmlToDOM = (string) => domParser.parseFromString(string, 'application/xml');
+export const xmlToDOM = (string) => domParser.parseFromString(string, MIME_TYPE.XML_TEXT);
 export const domToXML = (dom) => xmlSerializer.serializeToString(dom);
 
 /**

--- a/app/common/renderer/utils/source-parsing.js
+++ b/app/common/renderer/utils/source-parsing.js
@@ -2,7 +2,9 @@ import {DOMParser, XMLSerializer} from '@xmldom/xmldom';
 import _ from 'lodash';
 
 export const domParser = new DOMParser();
-export const xmlSerializer = new XMLSerializer();
+const xmlSerializer = new XMLSerializer();
+
+export const serializeXMLToString = (xml) => xmlSerializer.serializeToString(xml);
 
 /**
  * Get the child nodes of a Node object

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@reduxjs/toolkit": "2.2.7",
-        "@xmldom/xmldom": "0.8.10",
+        "@xmldom/xmldom": "0.9.0",
         "antd": "4.24.16",
         "axios": "1.7.5",
         "bluebird": "3.7.2",
@@ -333,6 +333,15 @@
       },
       "peerDependencies": {
         "appium": "^2.4.1"
+      }
+    },
+    "node_modules/@appium/fake-driver/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@appium/logger": {
@@ -4216,9 +4225,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.0.tgz",
+      "integrity": "sha512-Zb9MTlKGnUdxglDKF75cJwvsNp+EhPwzguLSTp/u1yeDU59lz7eA9e14S9z/sn5HHKX5NEQZaKjePl/69uqGhw==",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11649,6 +11658,15 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "2.2.7",
-    "@xmldom/xmldom": "0.8.10",
+    "@xmldom/xmldom": "0.9.0",
     "antd": "4.24.16",
     "axios": "1.7.5",
     "bluebird": "3.7.2",

--- a/test/unit/utils-locator-generation.spec.js
+++ b/test/unit/utils-locator-generation.spec.js
@@ -9,18 +9,13 @@ import {
   getOptimalXPath,
   getSimpleSuggestedLocators,
 } from '../../app/common/renderer/utils/locator-generation';
-import {domParser} from '../../app/common/renderer/utils/source-parsing';
+import {xmlToDOM} from '../../app/common/renderer/utils/source-parsing';
 
 // Helper that checks that the optimal xpath for a node is the one that we expect and also
 // checks that the XPath successfully locates the node in it's doc
 function testXPath(doc, node, expectedXPath) {
   expect(getOptimalXPath(doc, node)).toBe(expectedXPath);
   expect(xpath.select(expectedXPath, doc)[0]).toEqual(node);
-}
-
-// Helper for converting source from XML to Document format
-function xmlToDoc(sourceXML) {
-  return domParser.parseFromString(sourceXML);
 }
 
 describe('utils/locator-generation.js', function () {
@@ -30,7 +25,7 @@ describe('utils/locator-generation.js', function () {
         areAttrAndValueUnique(
           'id',
           'ID',
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
           <node id='ID'></node>
           <node id='ID'></node>
         </root>`),
@@ -43,7 +38,7 @@ describe('utils/locator-generation.js', function () {
         areAttrAndValueUnique(
           'id',
           'ID',
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
           <node id='ID'></node>
         </root>`),
         ),
@@ -52,7 +47,7 @@ describe('utils/locator-generation.js', function () {
         areAttrAndValueUnique(
           'id',
           'ID',
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
           <node></node>
           <node></node>
         </root>`),
@@ -78,7 +73,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {id: 'ID'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
             <node id='ID'></node>
             <node id='ID'></node>
           </root>`),
@@ -94,7 +89,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {name: 'Name'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
           <node content-desc='Name'></node>
         </root>`),
         )['accessibility id'],
@@ -110,7 +105,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {'content-desc': 'Content Desc'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
             <node content-desc='Content Desc'></node>
             <node content-desc='Content Desc'></node>
           </root>`),
@@ -122,7 +117,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {'content-desc': 'Content Desc 1'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
             <node content-desc='Content Desc 1'></node>
             <node content-desc='Content Desc 2'></node>
           </root>`),
@@ -137,7 +132,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {class: 'The Class'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
           <node type='The Class'></node>
         </root>`),
         )['class name'],
@@ -151,7 +146,7 @@ describe('utils/locator-generation.js', function () {
       expect(
         getSimpleSuggestedLocators(
           {class: 'The Class'},
-          xmlToDoc(`<root>
+          xmlToDOM(`<root>
             <node class='The Class'></node>
             <node class='The Class'></node>
           </root>`),
@@ -163,17 +158,17 @@ describe('utils/locator-generation.js', function () {
   describe('#getOptimalXPath', function () {
     describe('on XML with height == 1', function () {
       it('should set an absolute xpath if attrName "id" is set', function () {
-        const doc = xmlToDoc(`<node id='foo'></node>`);
+        const doc = xmlToDOM(`<node id='foo'></node>`);
         testXPath(doc, doc.getElementById('foo'), '//node[@id="foo"]');
       });
 
       it('should set an absolute xpath if unique attributes is set to "content-desc" and that attr is set', function () {
-        const doc = xmlToDoc(`<node content-desc='foo'></node>`);
+        const doc = xmlToDOM(`<node content-desc='foo'></node>`);
         testXPath(doc, doc.firstChild, '//node[@content-desc="foo"]');
       });
 
       it('should set relative xpath with tagname if no unique attributes are set', function () {
-        const doc = xmlToDoc(`<node non-unique-attr='foo'></node>`);
+        const doc = xmlToDOM(`<node non-unique-attr='foo'></node>`);
         testXPath(doc, doc.firstChild, '/node');
       });
     });
@@ -182,7 +177,7 @@ describe('utils/locator-generation.js', function () {
       let doc;
 
       it('should set first child node to relative xpath with tagname if the child node has no siblings', function () {
-        doc = xmlToDoc(`<xml>
+        doc = xmlToDOM(`<xml>
           <child-node non-unique-attr='hello'>Hello</child-node>
           <other-node>
             <child-node></child-node>
@@ -192,7 +187,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it('should set first child node to relative xpath with tagname and index', function () {
-        doc = xmlToDoc(`<xml>
+        doc = xmlToDOM(`<xml>
           <child-node non-unique-attr='hello'>Hello</child-node>
           <child-node non-unique-attr='world'>World</child-node>
         </xml>`);
@@ -201,7 +196,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it('should set first child node to absolute xpath if it has ID set', function () {
-        doc = xmlToDoc(`<xml>
+        doc = xmlToDOM(`<xml>
           <child-node content-desc='hello'>Hello</child-node>
           <child-node content-desc='world'>World</child-node>
         </xml>`);
@@ -218,7 +213,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it('should index children based on tagName', function () {
-        doc = xmlToDoc(`<xml>
+        doc = xmlToDOM(`<xml>
           <child>Hello</child>
           <child-node>World</child-node>
           <child>Foo</child>
@@ -229,7 +224,7 @@ describe('utils/locator-generation.js', function () {
         testXPath(doc, doc.getElementsByTagName('child-node')[0], '/xml/child-node[1]');
         testXPath(doc, doc.getElementsByTagName('child-node')[1], '/xml/child-node[2]');
 
-        doc = xmlToDoc(`<xml>
+        doc = xmlToDOM(`<xml>
           <child>Hello</child>
           <child-node>World</child-node>
           <other-child-node>asdfasdf</other-child-node>
@@ -246,7 +241,7 @@ describe('utils/locator-generation.js', function () {
       let doc;
 
       it('should use child as absolute and relative grandchild path if child has an ID set', function () {
-        doc = xmlToDoc(`<root>
+        doc = xmlToDOM(`<root>
           <child id='foo'>
             <grandchild>Hello</grandchild>
             <grandchild>World</grandchild>
@@ -264,8 +259,8 @@ describe('utils/locator-generation.js', function () {
         );
       });
 
-      it('should use indexes of children and grandchildren if no IDs are set', function () {
-        doc = xmlToDoc(`<root>
+      it('should use indices of children and grandchildren if no IDs are set', function () {
+        doc = xmlToDOM(`<root>
           <child>
             <grandchild>Hello</grandchild>
             <grandchild>World</grandchild>
@@ -283,7 +278,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it("should use indices if the unique attribute isn't actually unique", function () {
-        doc = xmlToDoc(`<root>
+        doc = xmlToDOM(`<root>
           <child id='foo'>
             <grandchild>Foo</grandchild>
             <grandchild>Bar</grandchild>
@@ -319,7 +314,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it('should return conjunctively unique xpath locators if they exist', function () {
-        doc = xmlToDoc(`<root>
+        doc = xmlToDOM(`<root>
           <child id='foo' text='bar'></child>
           <child text='yo'></child>
           <child id='foo' text='yo'></child>
@@ -344,7 +339,7 @@ describe('utils/locator-generation.js', function () {
         vi.spyOn(xpath, 'select').mockImplementation(() => {
           throw new Error('Exception');
         });
-        const doc = xmlToDoc(`<node id='foo'>
+        const doc = xmlToDOM(`<node id='foo'>
           <child id='a'></child>
           <child id='b'>
             <grandchild id='hello'></grandchild>
@@ -354,7 +349,7 @@ describe('utils/locator-generation.js', function () {
       });
 
       it('should return null if anything else throws an exception', function () {
-        const doc = xmlToDoc(`<node id='foo'>
+        const doc = xmlToDOM(`<node id='foo'>
           <child id='a'></child>
           <child id='b'>
             <grandchild id='hello'></grandchild>
@@ -373,7 +368,7 @@ describe('utils/locator-generation.js', function () {
     let doc;
 
     it('should use unique class chain attributes if the node has them', function () {
-      doc = xmlToDoc(`<xml>
+      doc = xmlToDOM(`<xml>
         <child-node label='hello'>Hello</child-node>
         <child-node label='world'>World</child-node>
       </xml>`);
@@ -383,7 +378,7 @@ describe('utils/locator-generation.js', function () {
     });
 
     it('should use unique class chain attributes of parent if the node does not have them', function () {
-      doc = xmlToDoc(`<root>
+      doc = xmlToDOM(`<root>
         <child name='foo'>
           <grandchild>Hello</grandchild>
           <grandchild>World</grandchild>
@@ -395,7 +390,7 @@ describe('utils/locator-generation.js', function () {
     });
 
     it('should use indices if neither the node nor its ancestors have any unique class chain attributes', function () {
-      doc = xmlToDoc(`<root>
+      doc = xmlToDOM(`<root>
         <child>
           <grandchild>Hello</grandchild>
           <grandchild>World</grandchild>
@@ -416,7 +411,7 @@ describe('utils/locator-generation.js', function () {
     let doc;
 
     it('should exist if the node has unique predicate string attributes', function () {
-      doc = xmlToDoc(`<xml>
+      doc = xmlToDOM(`<xml>
         <child-node label='hello'>Hello</child-node>
         <child-node label='world'>World</child-node>
       </xml>`);
@@ -426,7 +421,7 @@ describe('utils/locator-generation.js', function () {
     });
 
     it('should not exist if the node does not have unique predicate string attributes', function () {
-      doc = xmlToDoc(`<root>
+      doc = xmlToDOM(`<root>
         <child name='foo'>
           <grandchild>Hello</grandchild>
           <grandchild>World</grandchild>
@@ -442,7 +437,7 @@ describe('utils/locator-generation.js', function () {
     let doc;
 
     it('should use unique UiAutomator attributes if the node has them', function () {
-      doc = xmlToDoc(`<xml>
+      doc = xmlToDOM(`<xml>
         <parent-node>
           <child-node resource-id='hello'>Hello</child-node>
           <child-node resource-id='world'>World</child-node>
@@ -454,7 +449,7 @@ describe('utils/locator-generation.js', function () {
     });
 
     it('should use indices if the valid node attributes are not unique', function () {
-      doc = xmlToDoc(`<root>
+      doc = xmlToDOM(`<root>
         <child>
           <grandchild class='grandchild'>Hello</grandchild>
           <grandchild class='grandchild'>World</grandchild>
@@ -466,7 +461,7 @@ describe('utils/locator-generation.js', function () {
     });
 
     it('should return null if looking for element outside the last direct child of the hierarchy', function () {
-      doc = xmlToDoc(`<root>
+      doc = xmlToDOM(`<root>
         <child>
           <grandchild resource-id='hello'>Hello</grandchild>
           <grandchild resource-id='world'>World</grandchild>

--- a/test/unit/utils-source-parsing.spec.js
+++ b/test/unit/utils-source-parsing.spec.js
@@ -1,9 +1,9 @@
 import {describe, expect, it} from 'vitest';
 
 import {
-  domParser,
   findDOMNodeByPath,
   findJSONElementByPath,
+  xmlToDOM,
   xmlToJSON,
 } from '../../app/common/renderer/utils/source-parsing';
 
@@ -13,7 +13,7 @@ describe('utils/source-parsing.js', function () {
       expect(
         findDOMNodeByPath(
           '0.1.1',
-          domParser.parseFromString(`<hierarchy>
+          xmlToDOM(`<hierarchy>
           <root>
             <firstA>
               <secondA/>


### PR DESCRIPTION
`@xmldom/xmldom` `0.9.0` has a breaking change where it now requires the `mimeType` to be specified. This PR adds the MIME type, and also includes some additional refactoring for exporting only the DOMParser/XMLSerializer methods that are actually used, instead of their whole objects.
Tests were also confirmed to pass after updating to `@xmldom/xmldom` `0.9.0`.