### PR TITLE
chore: refactor in preparation for session file handling changes

### DIFF
--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -8,8 +8,8 @@ import i18n from '../i18next';
 import AppiumClient from '../lib/appium-client';
 import frameworks from '../lib/client-frameworks';
 import {getSetting, setSetting} from '../polyfills';
+import {readTextFromUploadedFiles} from '../utils/file-handling';
 import {getOptimalXPath, getSuggestedLocators} from '../utils/locator-generation';
-import {readTextFromUploadedFiles} from '../utils/other';
 import {
   findDOMNodeByPath,
   findJSONElementByPath,

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -66,7 +66,7 @@ export const SET_ADD_VENDOR_PREFIXES = 'SET_ADD_VENDOR_PREFIXES';
 
 export const SET_CAPABILITY_NAME_ERROR = 'SET_CAPABILITY_NAME_ERROR';
 export const SET_STATE_FROM_URL = 'SET_STATE_FROM_URL';
-export const SET_STATE_FROM_SAVED = 'SET_STATE_FROM_SAVED';
+export const SET_STATE_FROM_FILE = 'SET_STATE_FROM_FILE';
 
 const APPIUM_SESSION_FILE_VERSION = '1.0';
 
@@ -863,7 +863,7 @@ export function setStateFromAppiumFile(newFilepath = null) {
       }
       const appiumJson = JSON.parse(await util.promisify(fs.readFile)(filePath, 'utf8'));
       sessionStorage.setItem(FILE_PATH_STORAGE_KEY, filePath);
-      dispatch({type: SET_STATE_FROM_SAVED, state: appiumJson, filePath});
+      dispatch({type: SET_STATE_FROM_FILE, state: appiumJson, filePath});
     } catch (e) {
       notification.error({
         message: `Cannot open file '${newFilepath}'.\n ${e.message}\n ${e.stack}`,

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -26,7 +26,7 @@ import {
 } from '../../constants/session-inspector';
 import {SCREENSHOT_INTERACTION_MODE} from '../../constants/screenshot';
 import {copyToClipboard} from '../../polyfills';
-import {downloadFile} from '../../utils/other';
+import {downloadFile} from '../../utils/file-handling';
 import Commands from './Commands.jsx';
 import GestureEditor from './GestureEditor.jsx';
 import HeaderButtons from './HeaderButtons.jsx';

--- a/app/common/renderer/components/Inspector/SavedGestures.jsx
+++ b/app/common/renderer/components/Inspector/SavedGestures.jsx
@@ -13,7 +13,8 @@ import React, {useEffect} from 'react';
 
 import {POINTER_TYPES, SAVED_GESTURE_PROPS} from '../../constants/gestures';
 import {SCREENSHOT_INTERACTION_MODE} from '../../constants/screenshot';
-import {downloadFile, percentageToPixels} from '../../utils/other';
+import {downloadFile} from '../../utils/file-handling';
+import {percentageToPixels} from '../../utils/other';
 import FileUploader from './FileUploader.jsx';
 import InspectorStyles from './Inspector.module.css';
 

--- a/app/common/renderer/components/Session/CapabilityControl.jsx
+++ b/app/common/renderer/components/Session/CapabilityControl.jsx
@@ -2,6 +2,7 @@ import {Input, Switch} from 'antd';
 import React from 'react';
 
 import {INPUT} from '../../constants/antd-types';
+import {CAPABILITY_TYPES} from '../../constants/session-builder';
 import SessionStyles from './Session.module.css';
 
 const CapabilityControl = ({
@@ -13,8 +14,8 @@ const CapabilityControl = ({
   t,
 }) => {
   switch (cap.type) {
-    case 'text':
-    case 'file':
+    case CAPABILITY_TYPES.TEXT:
+    case CAPABILITY_TYPES.FILE:
       return (
         <Input
           disabled={isEditingDesiredCaps}
@@ -26,7 +27,7 @@ const CapabilityControl = ({
           className={SessionStyles.capsBoxFont}
         />
       );
-    case 'boolean':
+    case CAPABILITY_TYPES.BOOL:
       return (
         <Switch
           disabled={isEditingDesiredCaps}
@@ -38,7 +39,7 @@ const CapabilityControl = ({
           onChange={(value) => onSetCapabilityParam(value)}
         />
       );
-    case 'number':
+    case CAPABILITY_TYPES.NUM:
       return (
         <Input
           disabled={isEditingDesiredCaps}
@@ -54,8 +55,8 @@ const CapabilityControl = ({
           className={SessionStyles.capsBoxFont}
         />
       );
-    case 'object':
-    case 'json_object':
+    case CAPABILITY_TYPES.OBJECT:
+    case CAPABILITY_TYPES.JSON_OBJECT:
       return (
         <Input
           disabled={isEditingDesiredCaps}

--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -3,6 +3,7 @@ import {Button, Checkbox, Col, Form, Input, Modal, Row, Select, Tooltip} from 'a
 import React, {useEffect, useRef} from 'react';
 
 import {ROW} from '../../constants/antd-types';
+import {CAPABILITY_TYPES} from '../../constants/session-builder';
 import CapabilityControl from './CapabilityControl.jsx';
 import FormattedCaps from './FormattedCaps.jsx';
 import SessionStyles from './Session.module.css';
@@ -25,7 +26,7 @@ const handleSetType = (setCapabilityParam, caps, index, type) => {
   // Translate the current value to the new type
   let translatedValue = caps[index].value;
   switch (type) {
-    case 'boolean':
+    case CAPABILITY_TYPES.BOOL:
       if (translatedValue === 'true') {
         translatedValue = true;
       } else if (translatedValue === 'false') {
@@ -34,12 +35,11 @@ const handleSetType = (setCapabilityParam, caps, index, type) => {
         translatedValue = !!translatedValue;
       }
       break;
-    case 'number':
+    case CAPABILITY_TYPES.NUM:
       translatedValue = parseInt(translatedValue, 10) || 0;
       break;
-    case 'text':
-    case 'json_object':
-    case 'object':
+    case CAPABILITY_TYPES.TEXT:
+    case CAPABILITY_TYPES.OBJECT:
       translatedValue = translatedValue + '';
       break;
     default:
@@ -113,10 +113,12 @@ const CapabilityEditor = (props) => {
                     defaultValue={cap.type}
                     onChange={(val) => handleSetType(setCapabilityParam, caps, index, val)}
                   >
-                    <Select.Option value="text">{t('text')}</Select.Option>
-                    <Select.Option value="boolean">{t('boolean')}</Select.Option>
-                    <Select.Option value="number">{t('number')}</Select.Option>
-                    <Select.Option value="object">{t('JSON object')}</Select.Option>
+                    <Select.Option value={CAPABILITY_TYPES.TEXT}>{t('text')}</Select.Option>
+                    <Select.Option value={CAPABILITY_TYPES.BOOL}>{t('boolean')}</Select.Option>
+                    <Select.Option value={CAPABILITY_TYPES.NUM}>{t('number')}</Select.Option>
+                    <Select.Option value={CAPABILITY_TYPES.OBJECT}>
+                      {t('JSON object')}
+                    </Select.Option>
                   </Select>
                 </Form.Item>
               </Col>

--- a/app/common/renderer/constants/session-builder.js
+++ b/app/common/renderer/constants/session-builder.js
@@ -41,6 +41,16 @@ export const PROVIDER_VALUES = {
 
 export const ADD_CLOUD_PROVIDER_TAB_KEY = 'addCloudProvider';
 
+export const CAPABILITY_TYPES = {
+  TEXT: 'text',
+  BOOL: 'boolean',
+  NUM: 'number',
+  OBJECT: 'object',
+  // historical
+  FILE: 'file',
+  JSON_OBJECT: 'json_object',
+};
+
 export const STANDARD_W3C_CAPS = [
   'platformName',
   'browserName',

--- a/app/common/renderer/reducers/Session.js
+++ b/app/common/renderer/reducers/Session.js
@@ -36,7 +36,7 @@ import {
   SET_SAVE_AS_TEXT,
   SET_SERVER,
   SET_SERVER_PARAM,
-  SET_STATE_FROM_SAVED,
+  SET_STATE_FROM_FILE,
   SET_STATE_FROM_URL,
   SHOW_DESIRED_CAPS_JSON_ERROR,
   SWITCHED_TABS,
@@ -372,12 +372,14 @@ export default function session(state = INITIAL_STATE, action) {
         },
         ...omit(action.state, ['server']),
       };
+
     case SET_CAPABILITY_NAME_ERROR:
       return {
         ...state,
         isDuplicateCapsName: true,
       };
-    case SET_STATE_FROM_SAVED:
+
+    case SET_STATE_FROM_FILE:
       if (!_.values(SERVER_TYPES).includes(action.state.serverType)) {
         notification.error({
           message: `Failed to load session: ${action.state.serverType} is not a valid server type`,

--- a/app/common/renderer/utils/file-handling.js
+++ b/app/common/renderer/utils/file-handling.js
@@ -1,0 +1,34 @@
+import {Promise} from 'bluebird';
+
+export function downloadFile(href, filename) {
+  let element = document.createElement('a');
+  element.setAttribute('href', href);
+  element.setAttribute('download', filename);
+  element.style.display = 'none';
+
+  document.body.appendChild(element);
+  element.click();
+
+  document.body.removeChild(element);
+}
+
+export async function readTextFromUploadedFiles(fileList) {
+  const fileReaderPromise = fileList.map((file) => {
+    const reader = new FileReader();
+    return new Promise((resolve) => {
+      reader.onload = (event) =>
+        resolve({
+          fileName: file.name,
+          content: event.target.result,
+        });
+      reader.onerror = (error) => {
+        resolve({
+          name: file.name,
+          error: error.message,
+        });
+      };
+      reader.readAsText(file);
+    });
+  });
+  return await Promise.all(fileReaderPromise);
+}

--- a/app/common/renderer/utils/other.js
+++ b/app/common/renderer/utils/other.js
@@ -1,4 +1,3 @@
-import {Promise} from 'bluebird';
 import _ from 'lodash';
 
 import {STANDARD_W3C_CAPS} from '../constants/session-builder';
@@ -46,37 +45,4 @@ export function parseCoordinates(element) {
   } else {
     return {};
   }
-}
-
-export function downloadFile(href, filename) {
-  let element = document.createElement('a');
-  element.setAttribute('href', href);
-  element.setAttribute('download', filename);
-  element.style.display = 'none';
-
-  document.body.appendChild(element);
-  element.click();
-
-  document.body.removeChild(element);
-}
-
-export async function readTextFromUploadedFiles(fileList) {
-  const fileReaderPromise = fileList.map((file) => {
-    const reader = new FileReader();
-    return new Promise((resolve) => {
-      reader.onload = (event) =>
-        resolve({
-          fileName: file.name,
-          content: event.target.result,
-        });
-      reader.onerror = (error) => {
-        resolve({
-          name: file.name,
-          error: error.message,
-        });
-      };
-      reader.readAsText(file);
-    });
-  });
-  return await Promise.all(fileReaderPromise);
 }

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -5,8 +5,8 @@ import i18n from './i18next';
 export const isDev = process.env.NODE_ENV === 'development';
 
 export function setupIPCListeners() {
-  ipcMain.on('electron-openLink', (_evt, link) => shell.openExternal(link));
-  ipcMain.on('electron-copyToClipboard', (_evt, text) => clipboard.writeText(text));
+  ipcMain.on('electron:openLink', (_evt, link) => shell.openExternal(link));
+  ipcMain.on('electron:copyToClipboard', (_evt, text) => clipboard.writeText(text));
 }
 
 export function getAppiumSessionFilePath(argv, isPackaged) {

--- a/app/electron/renderer/polyfills.js
+++ b/app/electron/renderer/polyfills.js
@@ -18,8 +18,8 @@ const i18NextBackendOptions = {
 };
 
 const electronUtils = {
-  copyToClipboard: (text) => ipcRenderer.send('electron-copyToClipboard', text),
-  openLink: (link) => ipcRenderer.send('electron-openLink', link),
+  copyToClipboard: (text) => ipcRenderer.send('electron:copyToClipboard', text),
+  openLink: (link) => ipcRenderer.send('electron:openLink', link),
 };
 
 const {copyToClipboard, openLink} = electronUtils;


### PR DESCRIPTION
This is a small refactor in preparation for adjustments to session file handling. These adjustments are already made in a separate branch, but the branch includes too many changes that could be extracted, therefore I made this PR.
Changes made:
* Adjust Electron IPC calls to include scope (basically just replace `-` with `:`)
* Rename redux event `SET_STATE_FROM_SAVED` to `SET_STATE_FROM_FILE`
* Add a dedicated constant for the types that a capability value can take
* Move file handler util methods from `other.js` to a new `file-handling.js` file