### PR TITLE
chore: refactor session file handling

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -294,5 +294,6 @@
   "gestureRequiredFieldsError": "Values '{{fields}}' are required for '{{eventType}}' event",
   "gestureNameCannotBeEmptyError": "Gesture name cannot be empty",
   "gestureInvalidJsonError": "Invalid JSON file. Unable to parse the file content",
-  "gestureImportedFrom": "Gesture imported from '{{fileName}}'"
+  "gestureImportedFrom": "Gesture imported from '{{fileName}}'",
+  "invalidSessionFile": "Invalid session file"
 }

--- a/app/common/renderer/components/Session/Session.jsx
+++ b/app/common/renderer/components/Session/Session.jsx
@@ -71,7 +71,7 @@ const Session = (props) => {
       setVisibleProviders,
       bindWindowClose,
       initFromQueryString,
-      saveFile,
+      saveSessionAsFile,
     } = props;
     (async () => {
       try {
@@ -84,7 +84,7 @@ const Session = (props) => {
         initFromQueryString(loadNewSession);
         await setStateFromAppiumFile();
         ipcRenderer.on('open-file', (_, filePath) => setStateFromAppiumFile(filePath));
-        ipcRenderer.on('save-file', (_, filePath) => saveFile(filePath));
+        ipcRenderer.on('sessionfile:download', () => saveSessionAsFile());
       } catch (e) {
         log.error(e);
       }

--- a/app/common/renderer/components/Session/Session.jsx
+++ b/app/common/renderer/components/Session/Session.jsx
@@ -68,6 +68,7 @@ const Session = (props) => {
       getSavedSessions,
       setSavedServerParams,
       setStateFromAppiumFile,
+      setStateFromSessionFile,
       setVisibleProviders,
       bindWindowClose,
       initFromQueryString,
@@ -83,7 +84,9 @@ const Session = (props) => {
         await setLocalServerParams();
         initFromQueryString(loadNewSession);
         await setStateFromAppiumFile();
-        ipcRenderer.on('open-file', (_, filePath) => setStateFromAppiumFile(filePath));
+        ipcRenderer.on('sessionfile:apply', (_, sessionFileString) =>
+          setStateFromSessionFile(sessionFileString),
+        );
         ipcRenderer.on('sessionfile:download', () => saveSessionAsFile());
       } catch (e) {
         log.error(e);

--- a/app/common/renderer/components/Session/Session.jsx
+++ b/app/common/renderer/components/Session/Session.jsx
@@ -67,7 +67,7 @@ const Session = (props) => {
       setLocalServerParams,
       getSavedSessions,
       setSavedServerParams,
-      setStateFromAppiumFile,
+      initFromSessionFile,
       setStateFromSessionFile,
       setVisibleProviders,
       bindWindowClose,
@@ -83,7 +83,7 @@ const Session = (props) => {
         await setSavedServerParams();
         await setLocalServerParams();
         initFromQueryString(loadNewSession);
-        await setStateFromAppiumFile();
+        await initFromSessionFile();
         ipcRenderer.on('sessionfile:apply', (_, sessionFileString) =>
           setStateFromSessionFile(sessionFileString),
         );

--- a/app/common/renderer/polyfills.js
+++ b/app/common/renderer/polyfills.js
@@ -28,6 +28,4 @@ export {
   ipcRenderer,
   i18NextBackend,
   i18NextBackendOptions,
-  fs,
-  util,
 } from '#local-polyfills'; // eslint-disable-line import/no-unresolved

--- a/app/common/renderer/reducers/Session.js
+++ b/app/common/renderer/reducers/Session.js
@@ -1,4 +1,3 @@
-import {notification} from 'antd';
 import _, {omit} from 'lodash';
 
 import {
@@ -380,23 +379,15 @@ export default function session(state = INITIAL_STATE, action) {
       };
 
     case SET_STATE_FROM_FILE:
-      if (!_.values(SERVER_TYPES).includes(action.state.serverType)) {
-        notification.error({
-          message: `Failed to load session: ${action.state.serverType} is not a valid server type`,
-        });
-        return state;
-      }
-      if (
-        ![...state.visibleProviders, SERVER_TYPES.LOCAL, SERVER_TYPES.REMOTE].includes(
-          action.state.serverType,
-        )
-      ) {
-        state.visibleProviders.push(action.state.serverType);
-      }
       return {
         ...state,
-        ...action.state,
-        filePath: action.filePath,
+        caps: action.sessionJSON.caps || [],
+        server: {
+          ...state.server,
+          ...action.sessionJSON.server,
+        },
+        serverType: action.sessionJSON.serverType,
+        visibleProviders: action.sessionJSON.visibleProviders || [],
       };
 
     default:

--- a/app/common/renderer/utils/file-handling.js
+++ b/app/common/renderer/utils/file-handling.js
@@ -1,4 +1,7 @@
 import {Promise} from 'bluebird';
+import _ from 'lodash';
+
+import {CAPABILITY_TYPES, SERVER_TYPES} from '../constants/session-builder';
 
 export function downloadFile(href, filename) {
   let element = document.createElement('a');
@@ -31,4 +34,34 @@ export async function readTextFromUploadedFiles(fileList) {
     });
   });
   return await Promise.all(fileReaderPromise);
+}
+
+export function parseSessionFileContents(sessionFileString) {
+  try {
+    const sessionJSON = JSON.parse(sessionFileString);
+    for (const sessionProp of ['version', 'caps', 'serverType']) {
+      if (!(sessionProp in sessionJSON)) {
+        return null;
+      }
+    }
+    if (!_.values(SERVER_TYPES).includes(sessionJSON.serverType)) {
+      return null;
+    } else if (!_.isArray(sessionJSON.caps)) {
+      return null;
+    } else {
+      for (const cap of sessionJSON.caps) {
+        for (const capProp of ['type', 'name', 'value']) {
+          if (!(capProp in cap)) {
+            return null;
+          }
+        }
+        if (!_.values(CAPABILITY_TYPES).includes(cap.type)) {
+          return null;
+        }
+      }
+    }
+    return sessionJSON;
+  } catch (e) {
+    return null;
+  }
 }

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -8,21 +8,7 @@ export const isDev = process.env.NODE_ENV === 'development';
 export function setupIPCListeners() {
   ipcMain.on('electron:openLink', (_evt, link) => shell.openExternal(link));
   ipcMain.on('electron:copyToClipboard', (_evt, text) => clipboard.writeText(text));
-}
-
-export function getAppiumSessionFilePath(argv, isPackaged) {
-  if (isDev) {
-    // do not use file launcher in dev mode because argv is different
-    // then it is in production
-    return false;
-  }
-  if (process.platform === 'darwin' && !isDev) {
-    // packaged macOS apps do not receive args from process.argv, they
-    // receive the filepath argument from the `electron.app.on('open-file', cb)` event
-    return false;
-  }
-  const argvIndex = isPackaged ? 1 : 2;
-  return argv[argvIndex];
+  ipcMain.handle('sessionfile:open', async (_evt, filePath) => openSessionFile(filePath));
 }
 
 // Open an .appiumsession file from the specified path and return its contents

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -1,4 +1,5 @@
 import {clipboard, ipcMain, shell} from 'electron';
+import fs from 'fs';
 
 import i18n from './i18next';
 
@@ -23,6 +24,9 @@ export function getAppiumSessionFilePath(argv, isPackaged) {
   const argvIndex = isPackaged ? 1 : 2;
   return argv[argvIndex];
 }
+
+// Open an .appiumsession file from the specified path and return its contents
+export const openSessionFile = (filePath) => fs.readFileSync(filePath, 'utf8');
 
 export const t = (string, params = null) => i18n.t(string, params);
 

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -10,6 +10,7 @@ import {setupMainWindow} from './windows';
 // and this flow only makes sense for the installed Inspector app anyway
 export let openFilePath = process.platform === 'darwin' || isDev ? null : process.argv[1];
 
+// Used when opening Inspector through an .appiumsession file (macOS)
 app.on('open-file', (event, filePath) => {
   event.preventDefault();
   openFilePath = filePath;

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -2,12 +2,16 @@ import {app} from 'electron';
 import debug from 'electron-debug';
 
 // import {installExtensions} from './debug';
-import {getAppiumSessionFilePath, isDev, setupIPCListeners} from './helpers';
+import {isDev, setupIPCListeners} from './helpers';
 import {setupMainWindow} from './windows';
 
-export let openFilePath = getAppiumSessionFilePath(process.argv, app.isPackaged);
+// Used when opening Inspector through an .appiumsession file (Windows/Linux).
+// This value is not set in dev mode, since accessing argv[1] there throws an error,
+// and this flow only makes sense for the installed Inspector app anyway
+export let openFilePath = process.platform === 'darwin' || isDev ? null : process.argv[1];
 
 app.on('open-file', (event, filePath) => {
+  event.preventDefault();
   openFilePath = filePath;
 });
 

--- a/app/electron/main/menus.js
+++ b/app/electron/main/menus.js
@@ -36,14 +36,8 @@ async function openFile(mainWindow) {
   }
 }
 
-async function saveAs(mainWindow) {
-  const {canceled, filePath} = await dialog.showSaveDialog({
-    title: t('saveAs'),
-    filters: [{name: 'Appium', extensions: [APPIUM_SESSION_EXTENSION]}],
-  });
-  if (!canceled) {
-    mainWindow.webContents.send('save-file', filePath);
-  }
+function saveAs(mainWindow) {
+  mainWindow.webContents.send('sessionfile:download');
 }
 
 function getLanguagesMenu() {

--- a/app/electron/main/menus.js
+++ b/app/electron/main/menus.js
@@ -3,7 +3,7 @@ import {Menu, app, dialog, shell} from 'electron';
 import {languageList} from '../../common/shared/i18next.config';
 import i18n from './i18next';
 import {checkForUpdates} from './updater';
-import {APPIUM_SESSION_EXTENSION, isDev, t} from './helpers';
+import {APPIUM_SESSION_EXTENSION, openSessionFile, isDev, t} from './helpers';
 import {launchNewSessionWindow} from './windows';
 
 const INSPECTOR_DOCS_URL = 'https://appium.github.io/appium-inspector';
@@ -32,7 +32,8 @@ async function openFile(mainWindow) {
   });
   if (!canceled) {
     const filePath = filePaths[0];
-    mainWindow.webContents.send('open-file', filePath);
+    const sessionFileString = openSessionFile(filePath);
+    mainWindow.webContents.send('sessionfile:apply', sessionFileString);
   }
 }
 

--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -1,11 +1,11 @@
-import {BrowserWindow, Menu, dialog, ipcMain, webContents} from 'electron';
+import {BrowserWindow, Menu, webContents} from 'electron';
 import settings from 'electron-settings';
 import {join} from 'path';
 
 import {PREFERRED_LANGUAGE} from '../../common/shared/setting-defs';
 import i18n from './i18next';
 import {openFilePath} from './main';
-import {APPIUM_SESSION_EXTENSION, isDev} from './helpers';
+import {isDev} from './helpers';
 import {rebuildMenus} from './menus';
 
 const mainPath = isDev
@@ -29,7 +29,7 @@ function buildSplashWindow() {
 }
 
 function buildSessionWindow() {
-  const window = new BrowserWindow({
+  return new BrowserWindow({
     show: false,
     width: 1100,
     height: 710,
@@ -45,18 +45,6 @@ function buildSessionWindow() {
       additionalArguments: openFilePath ? [`filename=${openFilePath}`] : [],
     },
   });
-
-  ipcMain.on('save-file-as', async () => {
-    const {canceled, filePath} = await dialog.showSaveDialog(mainWindow, {
-      title: 'Save Appium File',
-      filters: [{name: 'Appium Session Files', extensions: [APPIUM_SESSION_EXTENSION]}],
-    });
-    if (!canceled) {
-      mainWindow.webContents.send('save-file', filePath);
-    }
-  });
-
-  return window;
 }
 
 export function setupMainWindow() {

--- a/app/electron/renderer/polyfills.js
+++ b/app/electron/renderer/polyfills.js
@@ -1,9 +1,7 @@
 import {ipcRenderer} from 'electron';
 import settings from 'electron-settings';
-import fs from 'fs';
 import i18NextBackend from 'i18next-fs-backend';
 import {join} from 'path';
-import util from 'util';
 
 const localesPath =
   process.env.NODE_ENV === 'development'
@@ -24,13 +22,4 @@ const electronUtils = {
 
 const {copyToClipboard, openLink} = electronUtils;
 
-export {
-  settings,
-  copyToClipboard,
-  openLink,
-  ipcRenderer,
-  i18NextBackend,
-  i18NextBackendOptions,
-  fs,
-  util,
-};
+export {settings, copyToClipboard, openLink, ipcRenderer, i18NextBackend, i18NextBackendOptions};

--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -15,8 +15,6 @@ const browserUtils = {
       console.warn(`Cannot listen for IPC event ${evt} in browser context`); // eslint-disable-line no-console
     },
   },
-  fs: null,
-  util: null,
 };
 
 class BrowserSettings {
@@ -38,7 +36,7 @@ class BrowserSettings {
 }
 
 const settings = new BrowserSettings();
-const {copyToClipboard, openLink, ipcRenderer, fs, util} = browserUtils;
+const {copyToClipboard, openLink, ipcRenderer} = browserUtils;
 const i18NextBackendOptions = {
   backends: [LocalStorageBackend, HttpApi],
   backendOptions: [
@@ -49,13 +47,4 @@ const i18NextBackendOptions = {
   ],
 };
 
-export {
-  settings,
-  copyToClipboard,
-  openLink,
-  ipcRenderer,
-  i18NextBackend,
-  i18NextBackendOptions,
-  fs,
-  util,
-};
+export {settings, copyToClipboard, openLink, ipcRenderer, i18NextBackend, i18NextBackendOptions};

--- a/test/unit/utils-file-handling.spec.js
+++ b/test/unit/utils-file-handling.spec.js
@@ -1,0 +1,150 @@
+import {describe, expect, it} from 'vitest';
+
+import {parseSessionFileContents} from '../../app/common/renderer/utils/file-handling';
+
+describe('utils/file-handling.js', function () {
+  describe('#parseSessionFileContents', function () {
+    it('should parse a fully formed session file', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": [
+          {
+            "type": "text",
+            "name": "platformName",
+            "value": "Android"
+          }
+        ],
+        "server": {
+          "local": {},
+          "remote": {
+            "path": ""
+          },
+          "sauce": {
+            "dataCenter": "us-west-1"
+          },
+          "headspin": {},
+          "browserstack": {},
+          "lambdatest": {},
+          "advanced": {},
+          "bitbar": {},
+          "kobiton": {},
+          "perfecto": {},
+          "pcloudy": {},
+          "testingbot": {},
+          "experitest": {},
+          "roboticmobi": {},
+          "remotetestkit": {}
+        },
+        "serverType": "remote",
+        "visibleProviders": []
+      }`;
+      const expectedSessionJSON = {
+        version: '1.0',
+        caps: [
+          {
+            type: 'text',
+            name: 'platformName',
+            value: 'Android',
+          },
+        ],
+        server: {
+          local: {},
+          remote: {
+            path: '',
+          },
+          sauce: {
+            dataCenter: 'us-west-1',
+          },
+          headspin: {},
+          browserstack: {},
+          lambdatest: {},
+          advanced: {},
+          bitbar: {},
+          kobiton: {},
+          perfecto: {},
+          pcloudy: {},
+          testingbot: {},
+          experitest: {},
+          roboticmobi: {},
+          remotetestkit: {},
+        },
+        serverType: 'remote',
+        visibleProviders: [],
+      };
+      expect(parseSessionFileContents(sessionString)).toEqual(expectedSessionJSON);
+    });
+
+    it('should parse a minimum valid session file', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": [],
+        "serverType": "remote"
+      }`;
+      const expectedSessionJSON = {
+        version: '1.0',
+        caps: [],
+        serverType: 'remote',
+      };
+      expect(parseSessionFileContents(sessionString)).toEqual(expectedSessionJSON);
+    });
+
+    it('should not parse invalid JSON', function () {
+      const sessionString = 'this is not JSON';
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+
+    it('should not parse if any required session file property is missing', function () {
+      const sessionString = `{
+        "caps": [],
+        "serverType": "remote"
+      }`;
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+
+    it('should not parse if sessionType is invalid', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": [],
+        "serverType": "some other server"
+      }`;
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+
+    it('should not parse if caps is not an array', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": 9999,
+        "serverType": "remote"
+      }`;
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+
+    it('should not parse if any required cap property is missing', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": [
+          {
+            "name": "single cap"
+          }
+        ],
+        "serverType": "remote"
+      }`;
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+
+    it('should not parse if any capability type is not valid', function () {
+      const sessionString = `{
+        "version": "1.0",
+        "caps": [
+          {
+            "type": "invalid type",
+            "name": "single cap",
+            "value": "single cap value"
+          }
+        ],
+        "serverType": "remote"
+      }`;
+      expect(parseSessionFileContents(sessionString)).toBeNull();
+    });
+  });
+});

--- a/test/unit/utils-file-handling.spec.js
+++ b/test/unit/utils-file-handling.spec.js
@@ -101,7 +101,7 @@ describe('utils/file-handling.js', function () {
       expect(parseSessionFileContents(sessionString)).toBeNull();
     });
 
-    it('should not parse if sessionType is invalid', function () {
+    it('should not parse if serverType is invalid', function () {
       const sessionString = `{
         "version": "1.0",
         "caps": [],
@@ -119,7 +119,7 @@ describe('utils/file-handling.js', function () {
       expect(parseSessionFileContents(sessionString)).toBeNull();
     });
 
-    it('should not parse if any required cap property is missing', function () {
+    it('should not parse if any required capability property is missing', function () {
       const sessionString = `{
         "version": "1.0",
         "caps": [


### PR DESCRIPTION
This PR includes a few refactors for handling `.appiumsession` files. Currently there are 3 main flows related to them:
* saving the current session details into a downloadable `.appiumsession` file
* selecting an `.appiumsession` file from the File menu and loading its contents
* if the app is not running, opening an `.appiumsession` file directly, which opens the Inspector with the session file contents loaded

The changes in this PR do not attempt to overhaul these flows, but only refactor their implementation, with the main goal of removing the `fs` and `util` polyfills from the renderer process, as this would simplify the eventual Electron upgrade.
However, there are still a few improvements to the importing flows:
* enhanced validation when importing a session file (plus tests for this validation functionality)
  * unlike gesture JSON files, the session files are not intended to be manually editable, therefore validation does not return the details for any errors
* importing a session file now switches to the capability builder tab, to make the session details immediately visible
* importing the same session file a second time now loads the file contents again. Previously this action was ignored.

All 3 flows were tested to still work on Windows and macOS.