### PR TITLE
chore: move electron-settings to IPC

### DIFF
--- a/app/common/renderer/i18next.js
+++ b/app/common/renderer/i18next.js
@@ -2,14 +2,14 @@ import i18n from 'i18next';
 import _ from 'lodash';
 import {initReactI18next, withTranslation as wt} from 'react-i18next';
 
-import {commonI18NextOptions, fallbackLng} from '../shared/i18next.config';
+import {commonI18NextOptions} from '../shared/i18next.config';
 import {PREFERRED_LANGUAGE} from '../shared/setting-defs';
-import {i18NextBackend, i18NextBackendOptions, getSettingSync} from './polyfills';
+import {i18NextBackend, i18NextBackendOptions, getSetting} from './polyfills';
 
 const i18nextOptions = {
   ...commonI18NextOptions,
   backend: i18NextBackendOptions,
-  lng: getSettingSync(PREFERRED_LANGUAGE) || fallbackLng,
+  lng: await getSetting(PREFERRED_LANGUAGE),
 };
 
 const namespace = 'translation';

--- a/app/common/renderer/polyfills.js
+++ b/app/common/renderer/polyfills.js
@@ -18,10 +18,6 @@ export async function setSetting(setting, value) {
   await settings.set(setting, value);
 }
 
-export function getSettingSync(setting) {
-  return settings.getSync(setting);
-}
-
 export {
   copyToClipboard,
   openLink,

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -1,4 +1,5 @@
 import {clipboard, ipcMain, shell} from 'electron';
+import settings from 'electron-settings';
 import fs from 'fs';
 
 import i18n from './i18next';
@@ -6,6 +7,9 @@ import i18n from './i18next';
 export const isDev = process.env.NODE_ENV === 'development';
 
 export function setupIPCListeners() {
+  ipcMain.handle('settings:has', async (_evt, key) => await settings.has(key));
+  ipcMain.handle('settings:set', async (_evt, key, value) => await settings.set(key, value));
+  ipcMain.handle('settings:get', async (_evt, key) => await settings.get(key));
   ipcMain.on('electron:openLink', (_evt, link) => shell.openExternal(link));
   ipcMain.on('electron:copyToClipboard', (_evt, text) => clipboard.writeText(text));
   ipcMain.handle('sessionfile:open', async (_evt, filePath) => openSessionFile(filePath));

--- a/app/electron/renderer/polyfills.js
+++ b/app/electron/renderer/polyfills.js
@@ -1,5 +1,4 @@
 import {ipcRenderer} from 'electron';
-import settings from 'electron-settings';
 import i18NextBackend from 'i18next-fs-backend';
 import {join} from 'path';
 
@@ -20,6 +19,21 @@ const electronUtils = {
   openLink: (link) => ipcRenderer.send('electron:openLink', link),
 };
 
+class ElectronSettings {
+  async has(key) {
+    return await ipcRenderer.invoke('settings:has', key);
+  }
+
+  async set(key, val) {
+    return await ipcRenderer.invoke('settings:set', key, val);
+  }
+
+  async get(key) {
+    return await ipcRenderer.invoke('settings:get', key);
+  }
+}
+
+const settings = new ElectronSettings();
 const {copyToClipboard, openLink} = electronUtils;
 
 export {settings, copyToClipboard, openLink, ipcRenderer, i18NextBackend, i18NextBackendOptions};

--- a/app/web/polyfills.js
+++ b/app/web/polyfills.js
@@ -7,6 +7,16 @@ const localesPath =
     ? '/locales' // 'public' folder contents are served at '/'
     : '../locales'; // from 'dist-browser/assets/'
 
+const i18NextBackendOptions = {
+  backends: [LocalStorageBackend, HttpApi],
+  backendOptions: [
+    {},
+    {
+      loadPath: `${localesPath}/{{lng}}/{{ns}}.json`,
+    },
+  ],
+};
+
 const browserUtils = {
   copyToClipboard: (text) => navigator.clipboard.writeText(text),
   openLink: (url) => window.open(url, ''),
@@ -29,22 +39,9 @@ class BrowserSettings {
   get(key) {
     return JSON.parse(localStorage.getItem(key));
   }
-
-  getSync(key) {
-    return this.get(key);
-  }
 }
 
 const settings = new BrowserSettings();
 const {copyToClipboard, openLink, ipcRenderer} = browserUtils;
-const i18NextBackendOptions = {
-  backends: [LocalStorageBackend, HttpApi],
-  backendOptions: [
-    {},
-    {
-      loadPath: `${localesPath}/{{lng}}/{{ns}}.json`,
-    },
-  ],
-};
 
 export {settings, copyToClipboard, openLink, ipcRenderer, i18NextBackend, i18NextBackendOptions};

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,6 +9,7 @@ export default defineConfig({
     emptyOutDir: true,
     minify: false, // needed to avoid issues with web2driver
     reportCompressedSize: false,
+    target: 'es2022',
   },
   define: {
     'process.env': process.env,


### PR DESCRIPTION
This PR continues the move to IPC by migrating `electron-settings`.
Since the renderer process would now always need to wait for a response from the main process, the `getSettingSync` call for `i18next` was changed to `await getSetting`. However, top-level awaits are supported only by a subset of the default Vite browser target set, so the browser build target was changed to `es2022`. This should not affect most users - all major browsers have support for top-level await since September 2021.

Changes were tested to still work in Electron/browser production builds, as well as the packaged Electron app on macOS & Windows.