### PR TITLE
chore: update electron-debug, highlight.js, rimraf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,10 +16,10 @@
         "axios": "1.7.7",
         "bluebird": "3.7.2",
         "cheerio": "1.0.0-rc.12",
-        "electron-debug": "3.2.0",
+        "electron-debug": "4.0.1",
         "electron-settings": "4.0.4",
         "electron-updater": "6.3.4",
-        "highlight.js": "11.9.0",
+        "highlight.js": "11.10.0",
         "i18next": "23.14.0",
         "i18next-chained-backend": "4.6.2",
         "i18next-fs-backend": "2.3.2",
@@ -57,14 +57,14 @@
         "eslint-plugin-react-native": "4.1.0",
         "less": "4.2.0",
         "prettier": "3.3.3",
-        "rimraf": "5.0.10",
+        "rimraf": "6.0.1",
         "vite": "5.4.3",
         "vite-plugin-electron-renderer": "0.14.5",
         "vitest": "2.0.5"
       },
       "engines": {
-        "node": ">=18.x",
-        "npm": ">=8.x"
+        "node": ">=20.x",
+        "npm": ">=10.x"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7072,12 +7072,15 @@
       }
     },
     "node_modules/electron-debug": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-3.2.0.tgz",
-      "integrity": "sha512-7xZh+LfUvJ52M9rn6N+tPuDw6oRAjxUj9SoxAZfJ0hVCXhZCsdkrSt7TgXOiWiEOBgEV8qwUIO/ScxllsPS7ow==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/electron-debug/-/electron-debug-4.0.1.tgz",
+      "integrity": "sha512-PdUG3SvcK70P05z99PFLUzn0+lPZl5c4quG1bXI7OtPaXxidwh8UONcdRLsr+6J9kf5y1FycJD5nBd80dYrcsA==",
       "dependencies": {
-        "electron-is-dev": "^1.1.0",
-        "electron-localshortcut": "^3.1.0"
+        "electron-is-dev": "^3.0.1",
+        "electron-localshortcut": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -7089,9 +7092,15 @@
       "integrity": "sha512-fLGSAjXZtdn1sbtZxx52+krefmtNuVwnJCV2gNiVt735/ARUboMl8jnNC9fZEqQdlAv2ZrETfmBUsoQci5evJA=="
     },
     "node_modules/electron-is-dev": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-1.2.0.tgz",
-      "integrity": "sha512-R1oD5gMBPS7PVU8gJwH6CtT0e6VSoD0+SzSnYpNm+dBkcijgA+K7VAMHDfnRq/lkKPZArpzplTW6jfiMYosdzw=="
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/electron-is-dev/-/electron-is-dev-3.0.1.tgz",
+      "integrity": "sha512-8TjjAh8Ec51hUi3o4TaU0mD3GMTOESi866oRNavj9A3IQJ7pmv+MJVmdZBFGw4GFT36X7bkqnuDNYvkQgvyI8Q==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/electron-localshortcut": {
       "version": "3.2.1",
@@ -9315,9 +9324,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.9.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.9.0.tgz",
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==",
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
+      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -13635,16 +13644,100 @@
       }
     },
     "node_modules/rimraf": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-5.0.10.tgz",
-      "integrity": "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
-        "glob": "^10.3.7"
+        "glob": "^11.0.0",
+        "package-json-from-dist": "^1.0.0"
       },
       "bin": {
         "rimraf": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.0.tgz",
+      "integrity": "sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^4.0.1",
+        "minimatch": "^10.0.0",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/jackspeak": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.1.tgz",
+      "integrity": "sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/lru-cache": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+      "dev": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/path-scurry": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "antd": "V5: significant rewrite required",
     "bluebird": "Deprecated: recommended to replace with native promises",
     "cheerio": "V1: requires Node 18",
-    "electron-debug": "V4: requires Electron 30",
     "uuid": "V10: requires Node 16. Can also be replaced with crypto.randomUUID in Electron 14+"
   },
   "dependencies": {
@@ -72,10 +71,10 @@
     "axios": "1.7.7",
     "bluebird": "3.7.2",
     "cheerio": "1.0.0-rc.12",
-    "electron-debug": "3.2.0",
+    "electron-debug": "4.0.1",
     "electron-settings": "4.0.4",
     "electron-updater": "6.3.4",
-    "highlight.js": "11.9.0",
+    "highlight.js": "11.10.0",
     "i18next": "23.14.0",
     "i18next-chained-backend": "4.6.2",
     "i18next-fs-backend": "2.3.2",
@@ -94,8 +93,7 @@
     "xpath": "0.0.34"
   },
   "//devDependencies": {
-    "eslint": "V9: need to move to flat config",
-    "rimraf": "V6: requires Node 20"
+    "eslint": "V9: need to move to flat config"
   },
   "devDependencies": {
     "@appium/docutils": "1.0.19",
@@ -114,17 +112,13 @@
     "eslint-plugin-react-native": "4.1.0",
     "less": "4.2.0",
     "prettier": "3.3.3",
-    "rimraf": "5.0.10",
+    "rimraf": "6.0.1",
     "vite": "5.4.3",
     "vite-plugin-electron-renderer": "0.14.5",
     "vitest": "2.0.5"
   },
-  "devEngines": {
-    "node": ">=18.x",
-    "npm": ">=8.x"
-  },
   "engines": {
-    "node": ">=18.x",
-    "npm": ">=8.x"
+    "node": ">=20.x",
+    "npm": ">=10.x"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["antd", "cheerio", "electron-debug", "eslint", "rimraf", "uuid"],
+      "matchPackageNames": ["antd", "cheerio", "eslint", "uuid"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
This is a simple bump for dependencies whose updates were blocked solely due to them dropping Node 14.
Since `rimraf` now requires Node 20, the `engines` field was adjusted accordingly. The `devEngines` field was also removed since it is not standard and requires additional scripts to be useful.