### PR TITLE
chore: remove bluebird dependency

### DIFF
--- a/app/common/renderer/constants/session-inspector.js
+++ b/app/common/renderer/constants/session-inspector.js
@@ -1,5 +1,6 @@
 export const MJPEG_STREAM_CHECK_INTERVAL = 1000;
 export const SESSION_EXPIRY_PROMPT_TIMEOUT = 60 * 60 * 1000; // Give user 1 hour to reply
+export const REFRESH_DELAY = 500;
 
 export const APP_MODE = {
   NATIVE: 'native',

--- a/app/common/renderer/constants/session-inspector.js
+++ b/app/common/renderer/constants/session-inspector.js
@@ -1,6 +1,6 @@
 export const MJPEG_STREAM_CHECK_INTERVAL = 1000;
 export const SESSION_EXPIRY_PROMPT_TIMEOUT = 60 * 60 * 1000; // Give user 1 hour to reply
-export const REFRESH_DELAY = 500;
+export const REFRESH_DELAY_MILLIS = 500;
 
 export const APP_MODE = {
   NATIVE: 'native',

--- a/app/common/renderer/lib/appium-client.js
+++ b/app/common/renderer/lib/appium-client.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 import {SCREENSHOT_INTERACTION_MODE} from '../constants/screenshot';
-import {APP_MODE, NATIVE_APP, REFRESH_DELAY} from '../constants/session-inspector';
+import {APP_MODE, NATIVE_APP, REFRESH_DELAY_MILLIS} from '../constants/session-inspector';
 import {log} from '../utils/logger';
 import {parseSource, setHtmlElementAttributes} from './webview-helpers';
 
@@ -130,7 +130,7 @@ export default class AppiumClient {
       windowSizeUpdate = {};
     if (!skipRefresh) {
       // Give the source/screenshot time to change before taking the screenshot
-      await new Promise((resolve) => setTimeout(resolve, REFRESH_DELAY));
+      await new Promise((resolve) => setTimeout(resolve, REFRESH_DELAY_MILLIS));
       if (!skipScreenshot) {
         screenshotUpdate = await this.getScreenshotUpdate();
       }

--- a/app/common/renderer/lib/appium-client.js
+++ b/app/common/renderer/lib/appium-client.js
@@ -1,8 +1,7 @@
-import Bluebird from 'bluebird';
 import _ from 'lodash';
 
 import {SCREENSHOT_INTERACTION_MODE} from '../constants/screenshot';
-import {APP_MODE, NATIVE_APP} from '../constants/session-inspector';
+import {APP_MODE, NATIVE_APP, REFRESH_DELAY} from '../constants/session-inspector';
 import {log} from '../utils/logger';
 import {parseSource, setHtmlElementAttributes} from './webview-helpers';
 
@@ -131,7 +130,7 @@ export default class AppiumClient {
       windowSizeUpdate = {};
     if (!skipRefresh) {
       // Give the source/screenshot time to change before taking the screenshot
-      await Bluebird.delay(500);
+      await new Promise((resolve) => setTimeout(resolve, REFRESH_DELAY));
       if (!skipScreenshot) {
         screenshotUpdate = await this.getScreenshotUpdate();
       }

--- a/app/common/renderer/utils/file-handling.js
+++ b/app/common/renderer/utils/file-handling.js
@@ -1,4 +1,3 @@
-import {Promise} from 'bluebird';
 import _ from 'lodash';
 
 import {CAPABILITY_TYPES, SERVER_TYPES} from '../constants/session-builder';

--- a/ci-jobs/crowdin-update-resources.mjs
+++ b/ci-jobs/crowdin-update-resources.mjs
@@ -1,4 +1,3 @@
-import B from 'bluebird';
 import {createReadStream} from 'node:fs';
 import path from 'node:path';
 
@@ -42,7 +41,7 @@ async function updateFile(fileId, storageId) {
 }
 
 async function main() {
-  const [storageId, fileId] = await B.all([uploadToStorage(), getFileId()]);
+  const [storageId, fileId] = await Promise.all([uploadToStorage(), getFileId()]);
   await updateFile(fileId, storageId);
   log.info('All done');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@xmldom/xmldom": "0.9.2",
         "antd": "4.24.16",
         "axios": "1.7.7",
-        "bluebird": "3.7.2",
         "cheerio": "1.0.0-rc.12",
         "electron-debug": "4.0.1",
         "electron-settings": "4.0.4",
@@ -5004,7 +5003,8 @@
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/bluebird-lst": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
   },
   "//dependencies": {
     "antd": "V5: significant rewrite required",
-    "bluebird": "Deprecated: recommended to replace with native promises",
     "cheerio": "V1: requires Node 18",
     "uuid": "V10: requires Node 16. Can also be replaced with crypto.randomUUID in Electron 14+"
   },
@@ -69,7 +68,6 @@
     "@xmldom/xmldom": "0.9.2",
     "antd": "4.24.16",
     "axios": "1.7.7",
-    "bluebird": "3.7.2",
     "cheerio": "1.0.0-rc.12",
     "electron-debug": "4.0.1",
     "electron-settings": "4.0.4",


### PR DESCRIPTION
This PR replaces all uses of `bluebird` with native JS promises. It has not been updated in nearly 5 years, and its readme recommends using native promises anyway.