### PR TITLE
chore: remove uuid dependency

### DIFF
--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import {v4 as UUID} from 'uuid';
 
 import {SAVED_FRAMEWORK, SET_SAVED_GESTURES} from '../../shared/setting-defs';
 import {POINTER_TYPES} from '../constants/gestures';
@@ -982,7 +981,7 @@ export function saveGesture(params) {
         continue;
       }
       // Adding a new gesture
-      param.id = UUID();
+      param.id = crypto.randomUUID();
       param.date = Date.now();
       savedGestures.push(param);
     }

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -2,7 +2,6 @@ import {notification} from 'antd';
 import axios from 'axios';
 import {includes, isPlainObject, isUndefined, toPairs, union, values, without} from 'lodash';
 import moment from 'moment';
-import {v4 as UUID} from 'uuid';
 import {Web2Driver} from 'web2driver';
 
 import {
@@ -662,7 +661,7 @@ export function saveSession(server, serverType, caps, params) {
 
     if (!uuid) {
       // If it's a new session, add it to the list
-      uuid = UUID();
+      uuid = crypto.randomUUID();
       let newSavedSession = {
         date: Date.now(),
         name,

--- a/docs/quickstart/requirements.md
+++ b/docs/quickstart/requirements.md
@@ -9,7 +9,7 @@ Since the Inspector has two versions, [a desktop app and a web app](../overview.
 requirements for these will differ.
 
 -   Web app
-    -   Works in Chrome/Edge/Firefox, released September 2021 or later
+    -   Works in Chrome/Edge/Firefox, released in 2022 or later
         ([Safari is not supported](../troubleshooting.md#browser-version-does-not-work-in-safari))
     -   Viewport size of at least **870 x 610** pixels is recommended
 -   Desktop app

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "react-icons": "5.3.0",
         "react-redux": "9.1.2",
         "react-router-dom": "6.26.1",
-        "uuid": "9.0.1",
         "web2driver": "3.0.4",
         "xpath": "0.0.34"
       },
@@ -15394,18 +15393,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
   "//dependencies": {
     "antd": "V5: significant rewrite required",
     "bluebird": "Deprecated: recommended to replace with native promises",
-    "cheerio": "V1: requires Node 18",
-    "uuid": "V10: requires Node 16. Can also be replaced with crypto.randomUUID in Electron 14+"
+    "cheerio": "V1: requires Node 18"
   },
   "dependencies": {
     "@reduxjs/toolkit": "2.2.7",
@@ -88,7 +87,6 @@
     "react-icons": "5.3.0",
     "react-redux": "9.1.2",
     "react-router-dom": "6.26.1",
-    "uuid": "9.0.1",
     "web2driver": "3.0.4",
     "xpath": "0.0.34"
   },


### PR DESCRIPTION
The recent update to Electron 31 also bumped the embedded Chromium version, and one of its new features is the `crypto.randomUUID()` method (added in Electron 14 / Chromium 92). This method can directly replace the v4 UUID generated by `uuid`.
As `crypto.randomUUID()` is a relatively recent addition, the system requirement docs have also been updated.

I tested saving new sessions in both the app and browser, and didn't see any differences from the current implementation.