### PR TITLE
fix: allow dismissing notifications on macOS

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.less
+++ b/app/common/renderer/assets/stylesheets/main.less
@@ -63,6 +63,7 @@ body::-webkit-scrollbar-corner {
 .ant-notification {
   width: 80%;
   margin-right: 10%;
+  -webkit-app-region: no-drag;
   > div {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Small fix for another issue I noticed in regards to the macOS draggable regions change in Electron 23. All the notifications shown in the Inspector partially overlap with the app header, and the header's draggable region takes priority over the notification (including its close button). This issue prevented closing any permanent notifications, and is fixed by this PR.