### PR TITLE
fix: resolve some screenshot Coordinates Mode issues

### DIFF
--- a/app/common/renderer/components/Inspector/Screenshot.jsx
+++ b/app/common/renderer/components/Inspector/Screenshot.jsx
@@ -21,6 +21,7 @@ const Screenshot = (props) => {
     screenshotInteractionMode,
     coordStart,
     coordEnd,
+    clearCoordAction,
     scaleRatio,
     selectedTick,
     selectedInspectorTab,
@@ -47,7 +48,7 @@ const Screenshot = (props) => {
   };
 
   const handleScreenshotUp = async () => {
-    const {setCoordEnd, clearCoordAction} = props;
+    const {setCoordEnd} = props;
     if (screenshotInteractionMode === TAP_SWIPE) {
       await setCoordEnd(x, y);
       if (Math.abs(coordStart.x - x) < 5 && Math.abs(coordStart.y - y) < 5) {
@@ -55,7 +56,7 @@ const Screenshot = (props) => {
       } else {
         await handleDoSwipe({x, y}); // Pass coordEnd because otherwise it is not retrieved
       }
-      clearCoordAction();
+      await clearCoordAction();
     }
   };
 
@@ -97,7 +98,7 @@ const Screenshot = (props) => {
     });
   };
 
-  const handleMouseMove = (e) => {
+  const handleScreenshotCoordsUpdate = (e) => {
     if (screenshotInteractionMode !== SELECT) {
       const offsetX = e.nativeEvent.offsetX;
       const offsetY = e.nativeEvent.offsetY;
@@ -106,6 +107,12 @@ const Screenshot = (props) => {
       setX(Math.round(newX));
       setY(Math.round(newY));
     }
+  };
+
+  const handleScreenshotLeave = async () => {
+    setX(null);
+    setY(null);
+    await clearCoordAction();
   };
 
   // retrieve and format gesture for svg drawings
@@ -167,7 +174,9 @@ const Screenshot = (props) => {
           style={screenshotStyle}
           onMouseDown={handleScreenshotDown}
           onMouseUp={handleScreenshotUp}
-          onMouseMove={handleMouseMove}
+          onMouseMove={handleScreenshotCoordsUpdate}
+          onMouseOver={handleScreenshotCoordsUpdate}
+          onMouseLeave={handleScreenshotLeave}
           onClick={handleScreenshotClick}
           className={styles.screenshotBox}
         >


### PR DESCRIPTION
This PR fixes some issues when using the screenshot Coordinates Mode:
* If the user taps or swipes on the screenshot, then, while the action is being executed, moves a mouse to another location and attempts a tap or swipe again, the new mouse position was not updated
* If the user clicks and holds to start a swipe action, then moves the mouse outside the screenshot bounds, the swipe action was not canceled
* If the user moves the mouse outside the screenshot bounds, the coordinates overlay values were not cleared

A side-effect of these changes is that the circle/line drawn over the screenshot as part of the tap/swipe action is now dismissed as soon as the screenshot loading overlay appears, instead of after the action finishes. This does not affect MJPEG mode since the loading overlay is not shown there.

Resolves #1682.