### PR TITLE
fix: adjust calculation of element highlighter positions

### DIFF
--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -79,7 +79,6 @@ const Inspector = (props) => {
     t,
   } = props;
 
-  const screenAndSourceEl = useRef(null);
   const screenshotContainerEl = useRef(null);
   const mjpegStreamCheckInterval = useRef(null);
 
@@ -95,12 +94,12 @@ const Inspector = (props) => {
     // If the screenshot has too much space to the right or bottom, adjust the max width
     // of its container, so the source tree always fills the remaining space.
     // This keeps everything looking tight.
-    if (!screenAndSourceEl.current) {
+    if (!screenshotContainerEl.current) {
       return;
     }
 
-    const screenshotBox = screenAndSourceEl.current.querySelector('#screenshotContainer');
-    const img = screenAndSourceEl.current.querySelector('#screenshotContainer img#screenshot');
+    const screenshotBox = screenshotContainerEl.current;
+    const img = screenshotContainerEl.current.querySelector('#screenshot');
 
     if (!img) {
       return;
@@ -264,7 +263,7 @@ const Inspector = (props) => {
   );
 
   const main = (
-    <div className={InspectorStyles['inspector-main']} ref={screenAndSourceEl}>
+    <div className={InspectorStyles['inspector-main']}>
       <div
         id="screenshotContainer"
         className={InspectorStyles['screenshot-container']}

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -121,8 +121,7 @@ const Inspector = (props) => {
 
     // Calculate the ratio for scaling items overlaid on the screenshot
     // (highlighter rectangles/circles, gestures, etc.)
-    const itemScaleRatio = windowSize.width / imgRect.width;
-    debounce(() => setScaleRatio(itemScaleRatio), 500)();
+    setScaleRatio(windowSize.width / imgRect.width);
   };
 
   const updateScreenshotScaleDebounced = debounce(updateScreenshotScale, 50);

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -120,7 +120,8 @@ const Inspector = (props) => {
 
     // Calculate the ratio for scaling items overlaid on the screenshot
     // (highlighter rectangles/circles, gestures, etc.)
-    setScaleRatio(windowSize.width / imgRect.width);
+    const newImgWidth = img.getBoundingClientRect().width;
+    setScaleRatio(windowSize.width / newImgWidth);
   };
 
   const updateScreenshotScaleDebounced = debounce(updateScreenshotScale, 50);

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -94,33 +94,32 @@ const Inspector = (props) => {
     // If the screenshot has too much space to the right or bottom, adjust the max width
     // of its container, so the source tree always fills the remaining space.
     // This keeps everything looking tight.
-    if (!screenshotContainerEl.current) {
+    const screenshotContainer = screenshotContainerEl.current;
+    if (!screenshotContainer) {
       return;
     }
 
-    const screenshotBox = screenshotContainerEl.current;
-    const img = screenshotContainerEl.current.querySelector('#screenshot');
-
-    if (!img) {
+    const screenshotImg = screenshotContainer.querySelector('#screenshot');
+    if (!screenshotImg) {
       return;
     }
 
-    const imgRect = img.getBoundingClientRect();
-    const screenshotRect = screenshotBox.getBoundingClientRect();
-    if (imgRect.height < screenshotRect.height) {
+    const imgRect = screenshotImg.getBoundingClientRect();
+    const containerRect = screenshotContainer.getBoundingClientRect();
+    if (imgRect.height < containerRect.height) {
       // get the expected image width if the image would fill the screenshot box height
-      const attemptedImgWidth = (screenshotRect.height / imgRect.height) * imgRect.width;
+      const attemptedImgWidth = (containerRect.height / imgRect.height) * imgRect.width;
       // get the maximum image width as a fraction of the current window width
       const maxImgWidth = window.innerWidth * WINDOW_DIMENSIONS.MAX_IMAGE_WIDTH_FRACTION;
       const curMaxImgWidth = Math.min(maxImgWidth, attemptedImgWidth);
-      screenshotBox.style.maxWidth = `${curMaxImgWidth}px`;
-    } else if (imgRect.width < screenshotRect.width) {
-      screenshotBox.style.maxWidth = `${imgRect.width}px`;
+      screenshotContainer.style.maxWidth = `${curMaxImgWidth}px`;
+    } else if (imgRect.width < containerRect.width) {
+      screenshotContainer.style.maxWidth = `${imgRect.width}px`;
     }
 
     // Calculate the ratio for scaling items overlaid on the screenshot
     // (highlighter rectangles/circles, gestures, etc.)
-    const newImgWidth = img.getBoundingClientRect().width;
+    const newImgWidth = screenshotImg.getBoundingClientRect().width;
     setScaleRatio(windowSize.width / newImgWidth);
   };
 


### PR DESCRIPTION
This PR fixes the issue where element highlighters over the screenshot were sometimes drawn over incorrect coordinates. This commonly happened when starting a session directly into landscape mode, or resizing the Inspector window height (not width). The underlying cause was that the scale ratio for drawing highlighters was using old data.
The overall implementation has also been slightly simplified, and the unnecessary 500ms debounce was removed, so now the highlighter update is subject to the same 50ms debounce used for calculating the screenshot scale - it feels much more responsive.

Fixes #1680.