### PR TITLE
fix: prevent Coordinates Mode from intercepting modals

### DIFF
--- a/app/common/renderer/components/Inspector/Inspector.module.css
+++ b/app/common/renderer/components/Inspector/Inspector.module.css
@@ -501,13 +501,13 @@
 .coordinatesContainer {
   position: absolute;
   background: rgba(255, 250, 205, 0.8);
-  z-index: 10000000;
+  z-index: 100;
   padding: 2px;
 }
 
 .swipeSvg {
   position: absolute;
-  z-index: 100000000;
+  z-index: 100;
   top: 0;
   left: 0;
   height: 100%;
@@ -525,18 +525,9 @@
   fill: rgba(255, 153, 153, 0.8);
 }
 
-.tapDiv {
-  position: absolute;
-  z-index: 100000000;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-}
-
 .gestureSvg {
   position: absolute;
-  z-index: 100000000;
+  z-index: 100;
   top: 0;
   left: 0;
   height: 100%;


### PR DESCRIPTION
Small PR to fix #1691. The `z-index` of antd modals is set to 1000, but several other elements had a higher `z-index` value and were therefore intercepting interactions with the modal (specifically, `swipeSvg`).
This also removes the style for an unused `tapDiv` class.