### PR TITLE
ci: add initial creating package GHA

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,25 @@
+name: Create packages
+
+on:
+  workflow_dispatch:
+  # push:
+  #   tags:
+  #     - '*'
+      
+jobs:
+  linux-package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+      - name: Install dependencies (Node.js)
+        run: npm ci
+      - name: Build electron app
+        run: npm run build:electron
+      - name: build package
+        run: npx electron-builder build --x64 --arm64 --publish never
+        

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,7 +5,7 @@ on:
   # push:
   #   tags:
   #     - '*'
-      
+
 jobs:
   linux-package:
     runs-on: ubuntu-latest
@@ -22,4 +22,3 @@ jobs:
         run: npm run build:electron
       - name: build package
         run: npx electron-builder build --x64 --arm64 --publish never
-        


### PR DESCRIPTION
Trying to move https://github.com/appium/appium-inspector/blob/main/ci-jobs/templates/package.yml to GHA.

I'll keep `never` in `npx electron-builder build` until these are ready.


This is an initial PR to run this package.yml action manually to test the package.yml out, so I'll merge this after CI pass for now.
cc @eglitise @jlipps 