### PR TITLE
chore: fix dev mode error from i18next-fs-backend

### DIFF
--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -46,6 +46,14 @@ export default defineConfig({
         },
       },
     },
+    optimizeDeps: {
+      include: ['i18next-fs-backend'],
+      esbuildOptions: {
+        supported: {
+          'top-level-await': true
+        },
+      },
+    },
     plugins: [react(), renderer()],
     resolve: {
       alias: {

--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig({
       include: ['i18next-fs-backend'],
       esbuildOptions: {
         supported: {
-          'top-level-await': true
+          'top-level-await': true,
         },
       },
     },


### PR DESCRIPTION
This PR fixes a problem with building the app in dev mode due to an error from `i18next-fs-backend`. The problem first appeared after #1802, where a top-level await was added in the dependency code.
The issue did not seem to affect the app's preview build, and it does not affect the browser version, as this dependency is not used there.