### PR TITLE
fix: add missing standard W3C caps

### DIFF
--- a/app/common/renderer/constants/session-builder.js
+++ b/app/common/renderer/constants/session-builder.js
@@ -60,6 +60,8 @@ export const STANDARD_W3C_CAPS = [
   'proxy',
   'setWindowRect',
   'timeouts',
+  'strictFileInteractability',
   'unhandledPromptBehavior',
+  'userAgent',
   'webSocketUrl', // WebDriver BiDi
 ];


### PR DESCRIPTION
It seems that the W3C WebDriver standard [has added 2 more standard capabilities](https://www.w3.org/TR/webdriver2/#capabilities) since I last checked: `strictFileInteractability` and `userAgent`. This PR ensures that these capabilities are not prefixed with `appium:`, just like all other standard capabilities.