### PR TITLE
feat: add beta for testing and npm available

### DIFF
--- a/plugins/index.mjs
+++ b/plugins/index.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {BasePlugin} from 'appium/plugin';
+import {BasePlugin} from 'appium/plugin.js';
 const PLUGIN_ROOT_PATH = '/inspector';
 const INDEX_HTML = 'index.html';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'dist-browser');

--- a/plugins/index.mjs
+++ b/plugins/index.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {BasePlugin} from 'appium/plugin.js';
+import {BasePlugin} from '@appium/base-plugin';
 const PLUGIN_ROOT_PATH = '/inspector';
 const INDEX_HTML = 'index.html';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'dist-browser');

--- a/plugins/index.mjs
+++ b/plugins/index.mjs
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
-import {BasePlugin} from 'appium/plugin.js';
+import {BasePlugin} from 'appium/plugin';
 const PLUGIN_ROOT_PATH = '/inspector';
 const INDEX_HTML = 'index.html';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), 'dist-browser');

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.5",
+  "version": "2024.12.1-beta.7",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1",
+  "version": "2024.12.1-beta.1",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.1",
+  "version": "2024.12.1-beta.4",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",
@@ -23,7 +23,8 @@
   "exports": {
     ".": {
       "import": "./index.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "peerDependencies": {
     "appium": "^2.0.0"
@@ -31,6 +32,7 @@
   "files": [
     "index.mjs",
     "package.json",
+    "npm-shrinkwrap.json",
     "dist-browser",
     "README.md"
   ],

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.7",
+  "version": "2024.12.1-beta.10",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",
@@ -35,7 +35,9 @@
     "dist-browser",
     "README.md"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@appium/base-plugin": "^2.3.0"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=20.x",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.4",
+  "version": "2024.12.1-beta.5",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",
@@ -32,7 +32,6 @@
   "files": [
     "index.mjs",
     "package.json",
-    "npm-shrinkwrap.json",
     "dist-browser",
     "README.md"
   ],

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.5",
+  "version": "2024.12.1-beta.6",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",
@@ -35,7 +35,9 @@
     "dist-browser",
     "README.md"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "@appium/base-plugin": "^2.2.52"
+  },
   "devDependencies": {},
   "engines": {
     "node": ">=20.x",

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appium-inspector-plugin",
-  "version": "2024.12.1-beta.6",
+  "version": "2024.12.1-beta.5",
   "description": "An app inspector for use with an Appium server",
   "repository": {
     "type": "git",
@@ -35,9 +35,7 @@
     "dist-browser",
     "README.md"
   ],
-  "dependencies": {
-    "@appium/base-plugin": "^2.2.52"
-  },
+  "dependencies": {},
   "devDependencies": {},
   "engines": {
     "node": ">=20.x",


### PR DESCRIPTION
This PR does:

- [x] Make the plugin available via `npm` install
    - Update https://www.npmjs.com/package/appium-inspector-plugin

Fixed

```
$ appium plugin install --source=npm appium-inspector-plugin@2024.12.1-beta.1
✔ Checking if 'appium-inspector-plugin' is compatible
✖ Installing 'appium-inspector-plugin@2024.12.1-beta.1'
Error: ✖ Encountered an error when installing package: Package subpath './package.json' is not defined by "exports" in /Users/kazu/.appium/node_modules/appium-inspector-plugin/package.json
```

Fixed below as well, but I needed to add `dependencies`...

```
[Appium] Could not load plugin 'inspector', so it will not be available. Error in loading the plugin was: Cannot find package 'appium' imported from /Users/kazu/.appium/node_modules/appium-inspector-plugin/index.mjs
[Appium] Error: Cannot find package 'appium' imported from /Users/kazu/.appium/node_modules/appium-inspector-plugin/index.mjs
    at packageResolve (node:internal/modules/esm/resolve:854:9)
    at moduleResolve (node:internal/modules/esm/resolve:927:18)
    at defaultResolve (node:internal/modules/esm/resolve:1169:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:540:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:509:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:239:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:96:40)
    at link (node:internal/modules/esm/module_job:95:36)
[Appium] Welcome to Appium v2.14.1 (REV bab86d5de571015b63fd8fc30b47bbe072a1290e)
[Appium] Non-default server args:
```


----

I'll do below as another PR to merge this idea first:

- [ ] Update README to add `npm` install method
- [ ] Add https://www.npmjs.com/settings/appium/packages to the `appium-inspector-plugin` package
- [ ] Configure GHA to release a new plugin version as part of https://github.com/appium/appium-inspector/blob/main/.github/workflows/package.yml
- [ ] Gather plugin related commands as general command such as `npm run build` will build plugin as well
