### PR TITLE
chore: tidy up ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,15 +1,7 @@
-import path from 'node:path';
-import {fileURLToPath} from 'node:url';
-
 import appiumConfig from '@appium/eslint-config-appium-ts';
-import {includeIgnoreFile} from '@eslint/compat';
 import reactPlugin from 'eslint-plugin-react';
 import simpleImportSortPlugin from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const gitignorePath = path.resolve(__dirname, '.gitignore');
 
 export default [
   ...appiumConfig,
@@ -45,6 +37,6 @@ export default [
   },
   {
     name: 'Ignores',
-    ignores: [...includeIgnoreFile(gitignorePath).ignores, '**/*.xml', '**/*.html'],
+    ignores: ['**/*.xml', '**/*.html'],
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "@appium/eslint-config-appium-ts": "1.0.2",
         "@appium/fake-driver": "5.7.0",
         "@appium/support": "6.0.3",
-        "@eslint/compat": "1.2.5",
         "@types/react": "18.3.18",
         "@vitejs/plugin-react": "4.3.4",
         "asyncbox": "3.0.0",
@@ -1679,6 +1678,7 @@
       "integrity": "sha512-5iuG/StT+7OfvhoBHPlmxkPA9om6aDUFgmD4+mWKAGsYt4vCe8rypneG03AuseyRHBmcCLXQtIH5S26tIoggLg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "@appium/eslint-config-appium-ts": "1.0.2",
     "@appium/fake-driver": "5.7.0",
     "@appium/support": "6.0.3",
-    "@eslint/compat": "1.2.5",
     "@types/react": "18.3.18",
     "@vitejs/plugin-react": "4.3.4",
     "asyncbox": "3.0.0",


### PR DESCRIPTION
This PR removes the `.gitignore` file-related code from the ESLint config, since this functionality is handled by `@appium/eslint-config-appium-ts` `>=1.0.2`. This change also allows to remove the explicit dependency on `@eslint/compat`.