### PR TITLE
chore: revert import syntax for updater

### DIFF
--- a/app/electron/main/updater.js
+++ b/app/electron/main/updater.js
@@ -1,5 +1,7 @@
 import {dialog} from 'electron';
-import {autoUpdater} from 'electron-updater';
+import pkg from 'electron-updater';
+// eslint-disable-next-line import/no-named-as-default-member -- module is CJS
+const {autoUpdater} = pkg;
 
 import {t} from './helpers';
 


### PR DESCRIPTION
ESLint's suggested import syntax for `electron-updater` unfortunately prevents the app from being launched in both dev and production modes:
```
SyntaxError: Named export 'autoUpdater' not found. The requested module 'electron-updater' is a CommonJS module, which may not support all module.exports as named exports.
```

This PR reverts to the previous syntax, which is also provided as a recommendation in the error message.