### PR TITLE
ci: run lint job for all changes

### DIFF
--- a/.github/workflows/pr-validation-lint.yml
+++ b/.github/workflows/pr-validation-lint.yml
@@ -1,0 +1,27 @@
+# Code validation job, executed on pull request
+# Runs linting and formatting tests
+
+name: PR Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: 'npm'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run test:lint
+      - name: Format
+        run: npm run test:format

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,5 +1,5 @@
 # Code validation job, executed on pull request
-# Builds the app, and runs lint, unit and integration tests
+# Builds the app, and runs unit and integration tests
 
 name: PR Validation
 
@@ -37,21 +37,3 @@ jobs:
         run: npm run build --if-present
       - name: Test
         run: npm run test:unit && npm run test:integration
-
-  lint:
-    name: Lint & Format
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js LTS
-        uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: 'npm'
-      - name: Install Dependencies
-        run: npm ci
-      - name: Lint
-        run: npm run test:lint
-      - name: Format
-        run: npm run test:format


### PR DESCRIPTION
This should avoid situations where a PR only changes documentation, but the changes would not pass the lint or formatting tests. Since the job does not actually run, CI is fine and the changes are merged, but now any new PRs will have that job fail.