### PR TITLE
feat: add support for Appium 3 session retrieval

### DIFF
--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -966,27 +966,28 @@ export function getRunningSessions() {
 }
 
 async function fetchAllSessions(baseUrl, authToken) {
-  async function fetchAppiumServerSessions() {
-    const url = `${baseUrl}sessions`;
+  const appiumSessionsEndpoint = `${baseUrl}appium/sessions`; // Appium 3+
+  const oldAppiumSessionsEndpoint = `${baseUrl}sessions`; // Appium 1-2
+  const seleniumSessionsEndpoint = `${baseUrl}status`;
+
+  async function fetchSessionsFromEndpoint(url) {
     try {
       const res = await fetchSessionInformation({url, authToken});
-      return res.data.value ?? [];
+      return url === seleniumSessionsEndpoint ?
+        formatSeleniumGridSessions(res) :
+        res.data.value ?? [];
     } catch {
       return [];
     }
   }
 
-  async function fetchSeleniumGridSessions() {
-    const url = `${baseUrl}status`;
-    try {
-      const res = await fetchSessionInformation({url, authToken});
-      return formatSeleniumGridSessions(res);
-    } catch {
-      return [];
-    }
-  }
+  const [appiumSessions, oldAppiumSessions, seleniumSessions] = await Promise.all([
+    fetchSessionsFromEndpoint(appiumSessionsEndpoint),
+    fetchSessionsFromEndpoint(oldAppiumSessionsEndpoint),
+    fetchSessionsFromEndpoint(seleniumSessionsEndpoint),
+  ]);
 
-  return [...(await fetchAppiumServerSessions()), ...(await fetchSeleniumGridSessions())];
+  return [...appiumSessions, ...oldAppiumSessions, ...seleniumSessions];
 }
 
 export function startDesiredCapsNameEditor() {

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -973,9 +973,9 @@ async function fetchAllSessions(baseUrl, authToken) {
   async function fetchSessionsFromEndpoint(url) {
     try {
       const res = await fetchSessionInformation({url, authToken});
-      return url === seleniumSessionsEndpoint ?
-        formatSeleniumGridSessions(res) :
-        res.data.value ?? [];
+      return url === seleniumSessionsEndpoint
+        ? formatSeleniumGridSessions(res)
+        : (res.data.value ?? []);
     } catch {
       return [];
     }

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -65,8 +65,16 @@ const getSessionDescription = (caps, serverType) => {
   }
 };
 
-export const getSessionInfo = (session, serverType) =>
-  `${session.id} — ${getSessionDescription(session.capabilities, serverType).assemble()}`;
+export const getSessionInfo = (session, serverType) => {
+  let identifier = session.id;
+  if ('created' in session) {
+    // For Appium 3+ sessions, replace session ID with timestamp
+    const sessionTimestampInt = parseInt(session.created, 10);
+    identifier = new Date(sessionTimestampInt).toJSON();
+  }
+  const description = getSessionDescription(session.capabilities, serverType).assemble();
+  return `${identifier} — ${description}`;
+};
 
 // Make a session-related HTTP GET request to the provided Appium server URL
 export async function fetchSessionInformation({url, authToken, ...params}) {

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -67,10 +67,9 @@ const getSessionDescription = (caps, serverType) => {
 
 export const getSessionInfo = (session, serverType) => {
   let identifier = session.id;
-  if ('created' in session) {
+  if ('created' in session && !_.isUndefined(session.created)) {
     // For Appium 3+ sessions, replace session ID with timestamp
-    const sessionTimestampInt = parseInt(session.created, 10);
-    identifier = new Date(sessionTimestampInt).toJSON();
+    identifier = new Date(session.created).toJSON();
   }
   const description = getSessionDescription(session.capabilities, serverType).assemble();
   return `${identifier} — ${description}`;

--- a/test/unit/utils-attaching-to-session.spec.js
+++ b/test/unit/utils-attaching-to-session.spec.js
@@ -11,7 +11,7 @@ describe('utils/attaching-to-session.js', function () {
     it('should show correct info if all expected parameters are defined', function () {
       const session = {
         id: '12345',
-        created: '1738500585000',
+        created: 1738500585000,
         capabilities: {
           sessionName: 'Vitest Session',
           deviceName: 'Vitest Phone',

--- a/test/unit/utils-attaching-to-session.spec.js
+++ b/test/unit/utils-attaching-to-session.spec.js
@@ -11,6 +11,7 @@ describe('utils/attaching-to-session.js', function () {
     it('should show correct info if all expected parameters are defined', function () {
       const session = {
         id: '12345',
+        created: '1738500585000',
         capabilities: {
           sessionName: 'Vitest Session',
           deviceName: 'Vitest Phone',
@@ -22,7 +23,7 @@ describe('utils/attaching-to-session.js', function () {
       };
       const serverType = SERVER_TYPES.HEADSPIN;
       expect(getSessionInfo(session, serverType)).toEqual(
-        '12345 — Vitest Session / Vitest Phone / Android 100 / UiAutomator2 / bestapp.apk',
+        '2025-02-02T12:49:45.000Z — Vitest Session / Vitest Phone / Android 100 / UiAutomator2 / bestapp.apk',
       );
     });
     it('should show correct info if some expected parameters are missing', function () {


### PR DESCRIPTION
This PR adds support for retrieving and attaching to existing sessions in Appium 3, which will use the `/appium/sessions` endpoint (see https://github.com/appium/appium/issues/20880). If such sessions are found, they will also have the session ID (shown in their dropdown entry) replaced with the session creation timestamp.

Compatibility with Appium 1-2 and Selenium Grid sessions remains unchanged, although all 3 endpoints are now queried in parallel for better performance.