### PR TITLE
chore(deps): remove vite from Renovate blocklist

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,9 +94,6 @@
     "web2driver": "3.0.4",
     "xpath": "0.0.34"
   },
-  "//devDependencies": {
-    "vite": "V6: need support in electron-vite"
-  },
   "devDependencies": {
     "@appium/docutils": "1.0.29",
     "@appium/eslint-config-appium-ts": "1.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["antd", "cheerio", "react", "vite"],
+      "matchPackageNames": ["antd", "cheerio", "react"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },


### PR DESCRIPTION
Now that there are no more blockers for Vite v6, it should be safe to remove from Renovate's blocklist.