### PR TITLE
fix: ensure selected client framework dropdown values are in sync

### DIFF
--- a/app/common/renderer/components/Inspector/Recorder.jsx
+++ b/app/common/renderer/components/Inspector/Recorder.jsx
@@ -47,6 +47,7 @@ const Recorder = (props) => {
         )}
         <Select
           defaultValue={actionFramework}
+          value={actionFramework}
           onChange={setActionFramework}
           className={InspectorStyles['framework-dropdown']}
         >

--- a/app/common/renderer/components/Inspector/SessionCodeBox.jsx
+++ b/app/common/renderer/components/Inspector/SessionCodeBox.jsx
@@ -29,6 +29,7 @@ const SessionCodeBox = (props) => {
       </Tooltip>
       <Select
         defaultValue={actionFramework}
+        value={actionFramework}
         onChange={setActionFramework}
         className={InspectorStyles['framework-dropdown']}
       >


### PR DESCRIPTION
This fixes a small issue I noticed while refactoring the framework-related code:
* Open the Recorder tab, then switch to Session Information tab
* Change the selected client framework to any other
* Switch back to Recorder -> selected dropdown value is still for the previous framework

This PR ensures that the selected dropdown value is shared between both dropdowns.