### PR TITLE
chore(deps): adjust Renovate for base-plugin package.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,14 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["antd", "cheerio", "react"],
+      "matchPackageNames": [
+        "@types/react",
+        "@types/react-dom",
+        "antd",
+        "cheerio",
+        "react",
+        "react-dom"
+      ],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
@@ -22,9 +29,13 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["appium", "@appium/**"],
+      "matchPackageNames": ["appium", "@appium/**", "!@appium/base-plugin"],
       "groupName": "Appium-related packages",
       "groupSlug": "appium"
+    },
+    {
+      "matchPackageNames": ["@appium/base-plugin"],
+      "updateLockFiles": false
     }
   ],
   "baseBranches": ["main"],


### PR DESCRIPTION
Seems like Renovate gets a bit confused due to the `@appium/base-plugin` dependency in the plugin's `package.json` file. Let's try to update that separately from other Appium packages, and leave the common lockfile unchanged.
I've also extended the blocklist with other React-related packages, since they are blocked similarly to the main package.