### PR TITLE
chore: add '|| ^3.0.0-beta.0' to plugin

### DIFF
--- a/plugins/package.json
+++ b/plugins/package.json
@@ -27,7 +27,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "appium": "^2.0.0"
+    "appium": "^2.0.0 || ^3.0.0-beta.0"
   },
   "files": [
     "index.mjs",


### PR DESCRIPTION
to avoid:
```
✖ Checking if 'appium-inspector-plugin' is compatible
Error: ✖ 'inspector' cannot be installed because the server version it requires (^2.0.0) does not meet the currently installed one (3.0.0-beta.0). Please install a compatible server version first.
```
in the install command. So far, we don't have breaking changes related to this plugin.