### PR TITLE
chore: replace more endpoints removed in Appium 3

### DIFF
--- a/app/common/renderer/actions/Inspector.js
+++ b/app/common/renderer/actions/Inspector.js
@@ -738,7 +738,10 @@ export function getActiveAppId(isIOS, isAndroid) {
         dispatch({type: SET_APP_ID, appId: bundleId});
       }
       if (isAndroid) {
-        const action = applyClientMethod({methodName: 'getCurrentPackage'});
+        const action = applyClientMethod({
+          methodName: 'executeScript',
+          args: ['mobile:getCurrentPackage', []],
+        });
         const appPackage = await action(dispatch, getState);
         dispatch({type: SET_APP_ID, appId: appPackage});
       }

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -73,21 +73,36 @@ const HeaderButtons = (props) => {
             <Button
               id="btnPressHomeButton"
               icon={<IoChevronBackOutline className={InspectorStyles['custom-button-icon']} />}
-              onClick={() => applyClientMethod({methodName: 'pressKeyCode', args: [4]})}
+              onClick={() =>
+                applyClientMethod({
+                  methodName: 'executeScript',
+                  args: ['mobile:pressKey', [{keycode: 4}]],
+                })
+              }
             />
           </Tooltip>
           <Tooltip title={t('Press Home Button')}>
             <Button
               id="btnPressHomeButton"
               icon={<BiCircle className={InspectorStyles['custom-button-icon']} />}
-              onClick={() => applyClientMethod({methodName: 'pressKeyCode', args: [3]})}
+              onClick={() =>
+                applyClientMethod({
+                  methodName: 'executeScript',
+                  args: ['mobile:pressKey', [{keycode: 3}]],
+                })
+              }
             />
           </Tooltip>
           <Tooltip title={t('Press App Switch Button')}>
             <Button
               id="btnPressHomeButton"
               icon={<BiSquare className={InspectorStyles['custom-button-icon']} />}
-              onClick={() => applyClientMethod({methodName: 'pressKeyCode', args: [187]})}
+              onClick={() =>
+                applyClientMethod({
+                  methodName: 'executeScript',
+                  args: ['mobile:pressKey', [{keycode: 187}]],
+                })
+              }
             />
           </Tooltip>
         </>

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -9,27 +9,26 @@ This step is only relevant if using the Inspector desktop app or Appium plugin f
 Like all Appium plugins, the Inspector plugin can be installed and activated using
 [the Appium command line](https://appium.io/docs/en/latest/cli/).
 
-1. Install the plugin:
+1.  Install the plugin:
 
-```bash
-appium plugin install --source=npm appium-inspector-plugin
-```
+    ```bash
+    appium plugin install --source=npm appium-inspector-plugin
+    ```
 
-!!! note
+    !!! note
 
-    Appium 3 will also support the `appium plugin install inspector` command
+         Appium 3 will also support the `appium plugin install inspector` command
 
-2. Launch the Appium server with the plugin activated:
+2.  Launch the Appium server with the plugin activated:
 
-```bash
-appium --use-plugins=inspector --allow-cors
-```
+    ```bash
+    appium --use-plugins=inspector --allow-cors
+    ```
 
-3. Open the Inspector URL in your web browser:
-
-```
-http://localhost:4723/inspector
-```
+3.  Open the Inspector URL in your web browser:
+    ```
+    http://localhost:4723/inspector
+    ```
 
 !!! info
 

--- a/docs/quickstart/requirements.md
+++ b/docs/quickstart/requirements.md
@@ -20,11 +20,22 @@ will differ:
     - The plugin version requires around **9MB** of free space
     - Viewport size of at least **870 x 610** pixels is recommended
 
-All Inspector versions also require an **Appium server** to connect to, which can be hosted either
-locally or remotely. For instructions on how to install and set up the server, please refer to the
-[Appium documentation](https://appium.io/docs/en/latest/quickstart/install/). Make sure to also
-install the necessary [driver(s)](https://appium.io/docs/en/latest/ecosystem/drivers/) for your
-target platform(s).
+### Appium Server Requirements
+
+The Inspector cannot do much without an **Appium server** to connect to. Unless you only want to
+connect to existing Appium servers, you will need to install and set up a server of your own,
+which can be hosted either locally or remotely. For instructions on how to do this, please refer
+to the [Appium documentation](https://appium.io/docs/en/latest/quickstart/install/).
+
+If setting up your own server, make sure to also install the **Appium driver(s)** for your target
+platform(s). You can find links to all known drivers in the [Appium documentation's Ecosystem page](https://appium.io/docs/en/latest/ecosystem/drivers/).
+Refer to each driver's documentation for its specific requirements and setup instructions.
+
+The following driver versions are recommended for best compatibility:
+
+- [Espresso](https://github.com/appium/appium-espresso-driver): `2.23.0` or later
+- [UiAutomator2](https://github.com/appium/appium-uiautomator2-driver): `2.21.0` or later
+- [XCUITest](https://appium.github.io/appium-xcuitest-driver/latest/): `3.38.0` or later
 
 Continue with the [Installation](./installation.md) steps, or jump directly to
 [Starting a Session](./starting-a-session.md)!


### PR DESCRIPTION
Small PR to replace 2 more server commands that will be removed in Appium 3 (see #2016). Some related documentation has also been updated.

* Replace `getCurrentPackage` and `pressKeyCode` methods with their `mobile:` equivalents
  * All four changes were confirmed to work
  * This leaves only `getSession` as the last used method that will be removed in Appium 3
* Add more details in documentation about the recommended driver versions
  * The specified versions added support for `mobile:getSystemBars` / `mobile:deviceScreenInfo`
* Fix indentation in the plugin install instructions