### PR TITLE
fix: attach to session tab not making requests

### DIFF
--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -654,7 +654,6 @@ function retreiveVendorProperties({server, serverType, sessionCaps}) {
     log.info(`Using ${VendorClass.name}`);
     try {
       const vendor = new VendorClass(server, sessionCaps);
-      // ({host, port, username, accessKey, https, path, headers} = await vendor.apply());
       return vendor.apply();
     } catch (e) {
       showError(e);

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -709,8 +709,9 @@ export function getRunningSessions() {
       return;
     }
 
+    const protocol = https ? 'https' : 'http';
     const adjPath = path.endsWith('/') ? path : `${path}/`;
-    const baseUrl = `http${https ? 's' : ''}://${host}:${port}${adjPath}`;
+    const baseUrl = `${protocol}://${host}:${port}${adjPath}`;
     const sessions = await fetchAllSessions(baseUrl, headers);
     dispatch({type: GET_SESSIONS_DONE, sessions});
 

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -226,7 +226,10 @@ export function newSession(originalCaps, attachSessId = null) {
     let sessionCaps = prefixedCaps ? getCapsObject(prefixedCaps) : {};
     sessionCaps = addCustomCaps(sessionCaps);
 
-    let {host, port, username, accessKey, https, path, headers} = await retreiveVendorProperties({...session, sessionCaps});
+    let {host, port, username, accessKey, https, path, headers} = await retreiveVendorProperties({
+      ...session,
+      sessionCaps,
+    });
 
     // if the server path is '' (or any other kind of falsy) set it to default
     path = path || DEFAULT_SERVER_PATH;
@@ -658,9 +661,7 @@ function retreiveVendorProperties({server, serverType, sessionCaps}) {
       return false;
     }
   } else {
-    log.info(
-      `No vendor mapping is defined for the server type '${serverType}'. Using defaults`,
-    );
+    log.info(`No vendor mapping is defined for the server type '${serverType}'. Using defaults`);
 
     return {};
   }
@@ -674,7 +675,11 @@ export function getRunningSessions() {
     const avoidServerTypes = ['sauce'];
     const state = getState().session;
     const {server, serverType, attachSessId} = state;
-    let {path, host, port, username, accessKey, https, headers} = await retreiveVendorProperties({server, serverType, sessionCaps: {}});
+    let {path, host, port, username, accessKey, https, headers} = await retreiveVendorProperties({
+      server,
+      serverType,
+      sessionCaps: {},
+    });
 
     if (username && accessKey) {
       const authToken = btoa(`${username}:${accessKey}`);

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -225,28 +225,8 @@ export function newSession(originalCaps, attachSessId = null) {
 
     let sessionCaps = prefixedCaps ? getCapsObject(prefixedCaps) : {};
     sessionCaps = addCustomCaps(sessionCaps);
-    let host, port, username, accessKey, https, path, headers;
-    //
-    // To register a new session vendor:
-    // - Implement a new class inherited from VendorBase in app/common/renderer/lib/vendor/<vendor_name>.js
-    // - Add the newly created class to the VENDOR_MAP defined in app/common/renderer/lib/vendor/map.js
-    //
-    /** @type {(new (server: unknown, caps: Record<string, any>) => import('../lib/vendor/base.js').BaseVendor) | undefined} */
-    const VendorClass = VENDOR_MAP[session.serverType];
-    if (VendorClass) {
-      log.info(`Using ${VendorClass.name}`);
-      try {
-        const vendor = new VendorClass(session.server, sessionCaps);
-        ({host, port, username, accessKey, https, path, headers} = await vendor.apply());
-      } catch (e) {
-        showError(e);
-        return false;
-      }
-    } else {
-      log.info(
-        `No vendor mapping is defined for the server type '${session.serverType}'. Using defaults`,
-      );
-    }
+
+    let {host, port, username, accessKey, https, path, headers} = await retreiveVendorProperties({...session, sessionCaps});
 
     // if the server path is '' (or any other kind of falsy) set it to default
     path = path || DEFAULT_SERVER_PATH;
@@ -657,6 +637,36 @@ export function saveSessionAsFile() {
 }
 
 /**
+ * @returns {Promise<VendorProperties>}
+ */
+function retreiveVendorProperties({server, serverType, sessionCaps}) {
+  //
+  // To register a new session vendor:
+  // - Implement a new class inherited from VendorBase in app/common/renderer/lib/vendor/<vendor_name>.js
+  // - Add the newly created class to the VENDOR_MAP defined in app/common/renderer/lib/vendor/map.js
+  //
+  const VendorClass = VENDOR_MAP[serverType];
+
+  if (VendorClass) {
+    log.info(`Using ${VendorClass.name}`);
+    try {
+      const vendor = new VendorClass(server, sessionCaps);
+      // ({host, port, username, accessKey, https, path, headers} = await vendor.apply());
+      return vendor.apply();
+    } catch (e) {
+      showError(e);
+      return false;
+    }
+  } else {
+    log.info(
+      `No vendor mapping is defined for the server type '${serverType}'. Using defaults`,
+    );
+
+    return {};
+  }
+}
+
+/**
  * Retrieve all running sessions for the currently configured server details
  */
 export function getRunningSessions() {
@@ -664,19 +674,28 @@ export function getRunningSessions() {
     const avoidServerTypes = ['sauce'];
     const state = getState().session;
     const {server, serverType, attachSessId} = state;
-    let {hostname, port, path, ssl, username, accessKey} = server[serverType];
-    const authToken = username && accessKey ? btoa(`${username}:${accessKey}`) : null;
+    let {path, host, port, username, accessKey, https, headers} = await retreiveVendorProperties({server, serverType, sessionCaps: {}});
+
+    if (username && accessKey) {
+      const authToken = btoa(`${username}:${accessKey}`);
+
+      headers = {
+        ...(headers || {}),
+        Authorization: `Basic ${authToken}`,
+      };
+    }
 
     // if we have a standard remote server, fill out connection info based on placeholder defaults
     // in case the user hasn't adjusted those fields
     if (serverType === SERVER_TYPES.REMOTE) {
-      hostname = hostname || DEFAULT_SERVER_HOST;
+      host = host || DEFAULT_SERVER_HOST;
       port = port || DEFAULT_SERVER_PORT;
       path = path || DEFAULT_SERVER_PATH;
     }
 
     // no need to get sessions if we don't have complete server info
-    if (!hostname || !port || !path) {
+    if (!host || !port || !path) {
+      showError(new Error('Missing server info, could not query sessions'), {secs: 5});
       return;
     }
 
@@ -687,8 +706,8 @@ export function getRunningSessions() {
     }
 
     const adjPath = path.endsWith('/') ? path : `${path}/`;
-    const baseUrl = `http${ssl ? 's' : ''}://${hostname}:${port}${adjPath}`;
-    const sessions = await fetchAllSessions(baseUrl, authToken);
+    const baseUrl = `http${https ? 's' : ''}://${host}:${port}${adjPath}`;
+    const sessions = await fetchAllSessions(baseUrl, headers);
     dispatch({type: GET_SESSIONS_DONE, sessions});
 
     // set attachSessId if only one session found
@@ -704,14 +723,14 @@ export function getRunningSessions() {
   };
 }
 
-async function fetchAllSessions(baseUrl, authToken) {
+async function fetchAllSessions(baseUrl, headers) {
   const appiumSessionsEndpoint = `${baseUrl}appium/sessions`; // Appium 3+
   const oldAppiumSessionsEndpoint = `${baseUrl}sessions`; // Appium 1-2
   const seleniumSessionsEndpoint = `${baseUrl}status`;
 
   async function fetchSessionsFromEndpoint(url) {
     try {
-      const res = await fetchSessionInformation({url, authToken});
+      const res = await fetchSessionInformation({url, headers});
       return url === seleniumSessionsEndpoint
         ? formatSeleniumGridSessions(res)
         : (res.data.value ?? []);

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -76,16 +76,13 @@ export const getSessionInfo = (session, serverType) => {
 };
 
 // Make a session-related HTTP GET request to the provided Appium server URL
-export async function fetchSessionInformation({url, authToken, apiKey, ...params}) {
-  const headers = {
-    'content-type': 'application/json; charset=utf-8',
-    ...(apiKey ? {Authorization: `Bearer ${apiKey}`} : {}),
-    ...(authToken ? {Authorization: `Basic ${authToken}`} : {}),
-  };
-
+export async function fetchSessionInformation({url, headers, ...params}) {
   return await axios({
     url,
-    headers,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      ...headers
+    },
     ...params,
   });
 }

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -81,7 +81,7 @@ export async function fetchSessionInformation({url, headers, ...params}) {
     url,
     headers: {
       'content-type': 'application/json; charset=utf-8',
-      ...headers
+      ...headers,
     },
     ...params,
   });

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -76,13 +76,16 @@ export const getSessionInfo = (session, serverType) => {
 };
 
 // Make a session-related HTTP GET request to the provided Appium server URL
-export async function fetchSessionInformation({url, authToken, ...params}) {
+export async function fetchSessionInformation({url, authToken, apiKey, ...params}) {
+  const headers = {
+    'content-type': 'application/json; charset=utf-8',
+    ...(apiKey ? {Authorization: `Bearer ${apiKey}`} : {}),
+    ...(authToken ? {Authorization: `Basic ${authToken}`} : {}),
+  };
+
   return await axios({
     url,
-    headers: {
-      'content-type': 'application/json; charset=utf-8',
-      ...(authToken ? {Authorization: `Basic ${authToken}`} : {}),
-    },
+    headers,
     ...params,
   });
 }


### PR DESCRIPTION
## Bug

When navigating to the `Attach to Session...` tab in the Sessions view, I had noticed that the requests for discovering sessions were not being made when any cloud vendor was set.

## Solution

- Use new vendor map when getting server details for `getRunningSessions`
- Use `headers` in the request if they exist on the vendor
- Call `showError` if session discovery query cannot be made to give user feedback