### PR TITLE
chore(deps): remove cheerio from renovate blacklist

### DIFF
--- a/app/common/renderer/utils/webview.js
+++ b/app/common/renderer/utils/webview.js
@@ -14,8 +14,8 @@ import {load} from 'cheerio';
 export function setHtmlElementAttributes(obj) {
   const {isAndroid, webviewTopOffset, webviewLeftOffset} = obj;
   const htmlElements = document.body.getElementsByTagName('*');
-  // iOS uses CSS sizes for elements and screenshots, Android sizes times DRP
-  // for other platforms, use default DRP of 1
+  // iOS uses CSS sizes for elements and screenshots, Android sizes times DPR
+  // for other platforms, use default DPR of 1
   const dpr = isAndroid ? window.devicePixelRatio : 1;
 
   Array.from(htmlElements).forEach((el) => {
@@ -49,7 +49,7 @@ export function parseHtmlSource(source) {
     return source;
   }
 
-  const $ = load(source, {_useHtmlParser2: true});
+  const $ = load(source);
 
   // Remove the head and the scripts
   const head = $('head');

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,6 @@
         "@types/react",
         "@types/react-dom",
         "antd",
-        "cheerio",
         "react",
         "react-dom"
       ],


### PR DESCRIPTION
Renovate unexpectedly updated `cheerio` to `1.1.0` so I checked out if it still works, despite the breaking changes in `1.0.0`. To my surprise - it does.

* Remove `cheerio` from Renovate blacklist
* Remove obsolete `cheerio` option `_useHtmlParser2` - while it is replaced with the `xml` option, using it failed to load most of the webview contents, whereas they loaded just fine without any extra options.
* Fix typos in comment