### PR TITLE
refactor: button group to space compact

### DIFF
--- a/app/common/renderer/components/Inspector/GestureEditor.jsx
+++ b/app/common/renderer/components/Inspector/GestureEditor.jsx
@@ -395,7 +395,7 @@ const GestureEditor = (props) => {
 
   const headerButtons = (
     <>
-      <Button.Group>
+      <Space.Compact>
         <Tooltip title={t('showMoveActionCoordsInPercentage')}>
           <Button
             className={InspectorCSS['gesture-header-coord-btn']}
@@ -422,7 +422,7 @@ const GestureEditor = (props) => {
             px
           </Button>
         </Tooltip>
-      </Button.Group>
+      </Space.Compact>
       <Tooltip title={t('Play')}>
         <Button type="primary" icon={<PlayCircleOutlined />} onClick={() => onPlay()} />
       </Tooltip>
@@ -532,7 +532,7 @@ const GestureEditor = (props) => {
 
   const tickButton = (tick) => (
     <center>
-      <Button.Group className={InspectorCSS['tick-button-group']}>
+      <Space.Compact className={InspectorCSS['tick-button-group']}>
         <Button
           type={tick.button === POINTER_DOWN_BTNS.LEFT ? 'primary' : 'default'}
           className={InspectorCSS['tick-button-input']}
@@ -547,7 +547,7 @@ const GestureEditor = (props) => {
         >
           {t('Right')}
         </Button>
-      </Button.Group>
+      </Space.Compact>
     </center>
   );
 

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -111,7 +111,7 @@ const HeaderButtons = (props) => {
   );
 
   const appModeControls = (
-    <Space.Compact value={appMode}>
+    <Space.Compact>
       <Tooltip title={t('Native App Mode')}>
         <Button
           icon={<AppstoreOutlined />}

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -43,7 +43,7 @@ const HeaderButtons = (props) => {
   } = props;
 
   const deviceControls = (
-    <Button.Group>
+    <Space.Compact>
       {driver && driver.client.isIOS && (
         <>
           <Tooltip title={t('Press Home Button')}>
@@ -107,11 +107,11 @@ const HeaderButtons = (props) => {
           </Tooltip>
         </>
       )}
-    </Button.Group>
+    </Space.Compact>
   );
 
   const appModeControls = (
-    <Button.Group value={appMode}>
+    <Space.Compact value={appMode}>
       <Tooltip title={t('Native App Mode')}>
         <Button
           icon={<AppstoreOutlined />}
@@ -174,11 +174,11 @@ const HeaderButtons = (props) => {
           </Tooltip>
         </>
       )}
-    </Button.Group>
+    </Space.Compact>
   );
 
   const generalControls = (
-    <Button.Group>
+    <Space.Compact>
       {isUsingMjpegMode && !isSourceRefreshOn && (
         <Tooltip title={t('Start Refreshing Source')}>
           <Button
@@ -222,7 +222,7 @@ const HeaderButtons = (props) => {
           />
         </Tooltip>
       )}
-    </Button.Group>
+    </Space.Compact>
   );
 
   const quitSessionButton = (

--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -129,7 +129,7 @@ const HeaderButtons = (props) => {
       {contexts && contexts.length === 1 && (
         <Tooltip
           title={t('noAdditionalContextsFound')}
-          overlayClassName={InspectorStyles['wide-tooltip']}
+          classNames={{root: InspectorStyles['wide-tooltip']}}
         >
           <div
             className={`${InspectorStyles['contexts-custom-btn']} ${InspectorStyles['no-contexts-info-icon']}`}
@@ -143,7 +143,7 @@ const HeaderButtons = (props) => {
           <Select
             className={InspectorStyles['header-context-selector']}
             value={currentContext}
-            dropdownMatchSelectWidth={false}
+            popupMatchSelectWidth={false}
             onChange={(value) => {
               setContext(value);
               applyClientMethod({methodName: 'switchContext', args: [value]});
@@ -164,7 +164,7 @@ const HeaderButtons = (props) => {
                 </a>
               </>
             }
-            overlayClassName={InspectorStyles['wide-tooltip']}
+            classNames={{root: InspectorStyles['wide-tooltip']}}
           >
             <div
               className={`${InspectorStyles['contexts-custom-btn']} ${InspectorStyles['contexts-info-icon']}`}

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -236,7 +236,7 @@ const Inspector = (props) => {
             disabled={isGestureEditorVisible}
           />
         </Tooltip>
-        <Space.Compact value={screenshotInteractionMode}>
+        <Space.Compact>
           <Tooltip title={t('Select Elements')}>
             <Button
               icon={<SelectOutlined />}

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -236,7 +236,7 @@ const Inspector = (props) => {
             disabled={isGestureEditorVisible}
           />
         </Tooltip>
-        <Button.Group value={screenshotInteractionMode}>
+        <Space.Compact value={screenshotInteractionMode}>
           <Tooltip title={t('Select Elements')}>
             <Button
               icon={<SelectOutlined />}
@@ -253,7 +253,7 @@ const Inspector = (props) => {
               disabled={isGestureEditorVisible}
             />
           </Tooltip>
-        </Button.Group>
+        </Space.Compact>
         {showScreenshot && !isUsingMjpegMode && (
           <Tooltip title={t('Download Screenshot')}>
             <Button icon={<DownloadOutlined />} onClick={() => downloadScreenshot(screenshot)} />

--- a/app/common/renderer/components/Inspector/LocatedElements.jsx
+++ b/app/common/renderer/components/Inspector/LocatedElements.jsx
@@ -115,7 +115,7 @@ const LocatedElements = (props) => {
                     }
                   />
                 </Tooltip>
-                <Button.Group className={InspectorStyles.searchResultsActions}>
+                <Space.Compact className={InspectorStyles.searchResultsActions}>
                   <Input
                     className={InspectorStyles.searchResultsKeyInput}
                     disabled={!locatorTestElement}
@@ -146,7 +146,7 @@ const LocatedElements = (props) => {
                       }
                     />
                   </Tooltip>
-                </Button.Group>
+                </Space.Compact>
               </Space>
             </Row>
           </Space>

--- a/app/common/renderer/components/Inspector/Recorder.jsx
+++ b/app/common/renderer/components/Inspector/Recorder.jsx
@@ -31,7 +31,7 @@ const Recorder = (props) => {
     return (
       <Space size="middle">
         {!!recordedActions.length && (
-          <Button.Group>
+          <Space.Compact>
             <Tooltip title={t('Show/Hide Boilerplate Code')}>
               <Button
                 onClick={toggleShowBoilerplate}
@@ -45,7 +45,7 @@ const Recorder = (props) => {
             <Tooltip title={t('Clear Actions')}>
               <Button icon={<ClearOutlined />} onClick={clearRecording} />
             </Tooltip>
-          </Button.Group>
+          </Space.Compact>
         )}
         <Select
           defaultValue={clientFramework}

--- a/app/common/renderer/components/Inspector/SavedGestures.jsx
+++ b/app/common/renderer/components/Inspector/SavedGestures.jsx
@@ -120,7 +120,7 @@ const SavedGestures = (props) => {
         render: (_, record) => {
           const gesture = getGestureByID(savedGestures, record.key, t);
           return (
-            <Button.Group>
+            <Space.Compact>
               <Tooltip zIndex={3} title={t('Play')}>
                 <Button
                   key="play"
@@ -147,7 +147,7 @@ const SavedGestures = (props) => {
                   <Button icon={<DeleteOutlined />} />
                 </Popconfirm>
               </Tooltip>
-            </Button.Group>
+            </Space.Compact>
           );
         },
       };
@@ -203,7 +203,7 @@ const SavedGestures = (props) => {
         columns={columns}
         scroll={{y: 'calc(100vh - 32em)'}}
         footer={() => (
-          <Button.Group>
+          <Space.Compact>
             <Tooltip title={t('Create New Gesture')}>
               <Button onClick={showGestureEditor} icon={<PlusOutlined />} />
             </Tooltip>
@@ -213,7 +213,7 @@ const SavedGestures = (props) => {
               multiple={true}
               type="application/json"
             />
-          </Button.Group>
+          </Space.Compact>
         )}
       />
       {gestureUploadErrors && showGestureUploadErrorsModal()}

--- a/app/common/renderer/components/Inspector/SelectedElement.jsx
+++ b/app/common/renderer/components/Inspector/SelectedElement.jsx
@@ -208,7 +208,7 @@ const SelectedElement = (props) => {
             onClick={() => applyClientMethod({methodName: 'click', elementId: selectedElementId})}
           />
         </Tooltip>
-        <Button.Group className={styles.elementKeyInputActions}>
+        <Space.Compact className={styles.elementKeyInputActions}>
           <Input
             className={styles.elementKeyInput}
             disabled={isDisabled}
@@ -238,8 +238,8 @@ const SelectedElement = (props) => {
               onClick={() => applyClientMethod({methodName: 'clear', elementId: selectedElementId})}
             />
           </Tooltip>
-        </Button.Group>
-        <Button.Group>
+        </Space.Compact>
+        <Space.Compact>
           <Tooltip title={t('Copy Attributes to Clipboard')}>
             <Button
               disabled={isDisabled}
@@ -264,7 +264,7 @@ const SelectedElement = (props) => {
               onClick={() => getFindElementsTimes(findDataSource)}
             />
           </Tooltip>
-        </Button.Group>
+        </Space.Compact>
       </Row>
       {findDataSource.length > 0 && (
         <Row className={styles.selectedElemContentRow}>

--- a/app/common/renderer/components/Session/SavedSessions.jsx
+++ b/app/common/renderer/components/Session/SavedSessions.jsx
@@ -1,5 +1,5 @@
 import {DeleteOutlined, EditOutlined} from '@ant-design/icons';
-import {Button, Col, Popconfirm, Row, Table, Tooltip} from 'antd';
+import {Button, Col, Popconfirm, Row, Space, Table, Tooltip} from 'antd';
 import moment from 'moment';
 
 import {SAVED_SESSIONS_TABLE_VALUES, SESSION_BUILDER_TABS} from '../../constants/session-builder';
@@ -77,7 +77,7 @@ const SavedSessions = (props) => {
       key: 'action',
       width: SAVED_SESSIONS_TABLE_VALUES.ACTIONS_COLUMN_WIDTH,
       render: (_, record) => (
-        <Button.Group>
+        <Space.Compact>
           <Tooltip zIndex={3} title={t('Edit')}>
             <Button
               icon={<EditOutlined />}
@@ -98,7 +98,7 @@ const SavedSessions = (props) => {
               <Button icon={<DeleteOutlined />} />
             </Popconfirm>
           </Tooltip>
-        </Button.Group>
+        </Space.Compact>
       ),
     },
   ];


### PR DESCRIPTION
Refactor according to console warning since upgrading to antd v5 (https://github.com/appium/appium-inspector/pull/2123): 

`[antd: Button.Group] Button.Group is deprecated. Please use Space.Compact instead.`

No changes to UI as far as I could tell.