### PR TITLE
refactor: use input text area in caps editor

### DIFF
--- a/app/common/renderer/components/Session/FormattedCaps.jsx
+++ b/app/common/renderer/components/Session/FormattedCaps.jsx
@@ -126,7 +126,7 @@ const FormattedCaps = (props) => {
         </div>
         {isEditingDesiredCaps && (
           <div className={SessionStyles.capsEditor}>
-            <textarea
+            <Input.TextArea
               onChange={(e) => setRawDesiredCaps(e.target.value)}
               value={rawDesiredCaps}
               className={`${SessionStyles.capsEditorBody} ${

--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -263,7 +263,7 @@
   padding: 0;
   margin: -1px;
   resize: none !important;
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
   font-size: 1em;
 }
 

--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -237,6 +237,7 @@
   position: absolute;
   right: 0;
   padding: 28px;
+  z-index: 1;
 }
 
 .capsEditorButton {
@@ -261,17 +262,15 @@
   width: 100%;
   padding: 0;
   margin: -1px;
-  resize: none;
-  border-color: lightgray;
-  font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  resize: none !important;
 }
 
 .capsEditorBodyFull {
-  height: 100%;
+  height: 100% !important;
 }
 
 .capsEditorBodyResized {
-  height: calc(100% - 40px);
+  height: calc(100% - 40px) !important;
 }
 
 .advancedSettingsContainerCol {

--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -263,6 +263,8 @@
   padding: 0;
   margin: -1px;
   resize: none !important;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+  font-size: 1em;
 }
 
 .capsEditorBodyFull {


### PR DESCRIPTION
Refactor to use antd `Input.TextArea` instead of html `textarea`.