### PR TITLE
refactor: notification to hooks usage

### DIFF
--- a/app/common/renderer/Root.jsx
+++ b/app/common/renderer/Root.jsx
@@ -3,6 +3,7 @@ import {Suspense} from 'react';
 import {Provider} from 'react-redux';
 import {MemoryRouter, Route, Routes} from 'react-router';
 
+import Notification from './components/Notification';
 import Spinner from './components/Spinner/Spinner.jsx';
 import InspectorPage from './containers/InspectorPage';
 import SessionPage from './containers/SessionPage';
@@ -42,6 +43,7 @@ const Root = ({store}) => (
             </Suspense>
           </MemoryRouter>
         </Layout>
+        <Notification />
       </App>
     </ConfigProvider>
   </Provider>

--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -1,4 +1,3 @@
-import {notification} from 'antd';
 import _ from 'lodash';
 import {Web2Driver} from 'web2driver';
 
@@ -17,6 +16,7 @@ import {getSetting, ipcRenderer, setSetting} from '../polyfills';
 import {fetchSessionInformation, formatSeleniumGridSessions} from '../utils/attaching-to-session';
 import {downloadFile, parseSessionFileContents} from '../utils/file-handling';
 import {log} from '../utils/logger';
+import {notification} from '../utils/notification';
 import {addVendorPrefixes} from '../utils/other';
 import {quitSession, setSessionDetails} from './Inspector';
 

--- a/app/common/renderer/components/Inspector/Commands.jsx
+++ b/app/common/renderer/components/Inspector/Commands.jsx
@@ -1,20 +1,9 @@
-import {
-  Alert,
-  Button,
-  Col,
-  Collapse,
-  Input,
-  Modal,
-  notification,
-  Row,
-  Space,
-  Switch,
-  Tooltip,
-} from 'antd';
+import {Alert, Button, Col, Collapse, Input, Modal, Row, Space, Switch, Tooltip} from 'antd';
 import _ from 'lodash';
 
 import {ALERT, INPUT} from '../../constants/antd-types';
 import {COMMAND_ARG_TYPES, COMMAND_DEFINITIONS, TOP_LEVEL_COMMANDS} from '../../constants/commands';
+import {notification} from '../../utils/notification';
 import InspectorStyles from './Inspector.module.css';
 
 const Commands = (props) => {

--- a/app/common/renderer/components/Inspector/GestureEditor.jsx
+++ b/app/common/renderer/components/Inspector/GestureEditor.jsx
@@ -16,7 +16,6 @@ import {
   Col,
   Divider,
   Input,
-  notification,
   Popover,
   Row,
   Select,
@@ -42,6 +41,7 @@ import {
   TICK_PROPS,
 } from '../../constants/gestures';
 import {SCREENSHOT_INTERACTION_MODE} from '../../constants/screenshot';
+import {notification} from '../../utils/notification';
 import {percentageToPixels, pixelsToPercentage} from '../../utils/other';
 import InspectorCSS from './Inspector.module.css';
 

--- a/app/common/renderer/components/Notification.jsx
+++ b/app/common/renderer/components/Notification.jsx
@@ -1,0 +1,23 @@
+import {App} from 'antd';
+import {useEffect} from 'react';
+
+import {NOTIFICATION_EVENT} from '../utils/notification';
+
+export default function Notification() {
+  const {notification} = App.useApp();
+
+  useEffect(() => {
+    const handleMessage = (event) => {
+      const {args, type} = event.detail;
+      notification[type](args);
+    };
+
+    document.addEventListener(NOTIFICATION_EVENT, handleMessage);
+
+    return () => {
+      document.removeEventListener(NOTIFICATION_EVENT, handleMessage);
+    };
+  }, [notification]);
+
+  return null;
+}

--- a/app/common/renderer/utils/notification.js
+++ b/app/common/renderer/utils/notification.js
@@ -1,0 +1,30 @@
+export const NOTIFICATION_EVENT = 'notificationEvent';
+
+function dispatchNotificationEvent(type, args) {
+  document.dispatchEvent(
+    new CustomEvent(NOTIFICATION_EVENT, {
+      detail: {
+        type,
+        args,
+      },
+    }),
+  );
+}
+
+export const notification = {
+  success: (args) => {
+    dispatchNotificationEvent('success', args);
+  },
+  error: (args) => {
+    dispatchNotificationEvent('error', args);
+  },
+  info: (args) => {
+    dispatchNotificationEvent('info', args);
+  },
+  warning: (args) => {
+    dispatchNotificationEvent('warning', args);
+  },
+  open: (args) => {
+    dispatchNotificationEvent('open', args);
+  },
+};


### PR DESCRIPTION
Refactor according to console warning since upgrading to antd v5 (https://github.com/appium/appium-inspector/pull/2123): 

`[antd: notification] Static function can not consume context like dynamic theme. Please use App component instead.`

Now using `notification` from `App.useApp()`. It's recommended by antd to use hooks instead of the static notification method (https://ant.design/components/notification). Notifications are triggered by dispatching an event which are picked up by the `Notification` component listener.