### PR TITLE
chore(deps): update prettier to v3.6.0

### DIFF
--- a/docs/quickstart/starting-a-session.md
+++ b/docs/quickstart/starting-a-session.md
@@ -23,7 +23,6 @@ information about the Appium server is specified, so that the Inspector knows ho
 - If you wish to connect to a standalone local or remote Appium server, first make sure the server
   is launched and running. The start of the server log will have a list of IP addresses and ports
   that can be used to connect to the server.
-
     - For a local Appium server running on its default port, **all server details fields can be left
       unchanged**. By default, the Inspector will attempt to connect to `http://127.0.0.1:4723`,
       which matches the default values of the Appium server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-simple-import-sort": "12.1.1",
         "globals": "16.2.0",
-        "prettier": "3.5.3",
+        "prettier": "3.6.0",
         "rimraf": "6.0.1",
         "vite": "6.3.5",
         "vite-plugin-electron-renderer": "0.14.6",
@@ -13457,9 +13457,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
-      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-simple-import-sort": "12.1.1",
     "globals": "16.2.0",
-    "prettier": "3.5.3",
+    "prettier": "3.6.0",
     "rimraf": "6.0.1",
     "vite": "6.3.5",
     "vite-plugin-electron-renderer": "0.14.6",


### PR DESCRIPTION
Same as #2140 but with the additional changes resulting from running Prettier (just one deleted empty line in the docs, which has no effect on the generated page)