### PR TITLE
fix: resolve error when switching saved caps set after closing session

### DIFF
--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -75,13 +75,8 @@ const CapabilityEditor = (props) => {
   // added a new cap field, so focus that input element. But only do this once, so we don't annoy
   // the user if they decide to unfocus and do something else.
   useEffect(() => {
-    if (
-      caps.length > 1 &&
-      !latestCapField.current.input.value &&
-      !latestCapField.current.__didFocus
-    ) {
+    if (caps.length > 1 && latestCapField.current && !latestCapField.current.input.value) {
       latestCapField.current.focus();
-      latestCapField.current.__didFocus = true;
     }
   }, [caps.length, latestCapField]);
 

--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -71,9 +71,8 @@ const CapabilityEditor = (props) => {
   const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
   const latestCapField = useRef();
 
-  // if we have more than one cap and the most recent cap name is empty, it means we've just
-  // added a new cap field, so focus that input element. But only do this once, so we don't annoy
-  // the user if they decide to unfocus and do something else.
+  // if we have more than one cap and the most recent cap name is empty,
+  // it means we've just added a new cap field, so focus that input element
   useEffect(() => {
     if (caps.length > 1 && latestCapField.current && !latestCapField.current.input.value) {
       latestCapField.current.focus();


### PR DESCRIPTION
Randomly stumbled upon this bug: after starting and closing a session, then switching to another saved caps set with a different number of capabilities, the app throws an error. Not reproducible on 2025.3.1, so it may be related to antd v5.

The fix here just adds an extra guard to validate that `latestCapField.current` is set before attempting to access its properties. The `__didFocus` property checks were also removed, as they did not change the expected behavior (autofocusing upon adding a new capability)