### PR TITLE
fix: restore style of toggle recording button

### DIFF
--- a/app/common/renderer/components/Inspector/HeaderButtons.jsx
+++ b/app/common/renderer/components/Inspector/HeaderButtons.jsx
@@ -217,7 +217,8 @@ const HeaderButtons = (props) => {
           <Button
             id="btnPause"
             icon={<VideoCameraOutlined />}
-            type={BUTTON.DANGER}
+            type={BUTTON.PRIMARY}
+            danger
             onClick={pauseRecording}
           />
         </Tooltip>

--- a/app/common/renderer/constants/antd-types.js
+++ b/app/common/renderer/constants/antd-types.js
@@ -9,8 +9,9 @@ export const ALERT = {
 export const BUTTON = {
   DEFAULT: 'default',
   PRIMARY: 'primary',
-  DISABLED: 'disabled',
-  DANGER: 'danger',
+  DASHED: 'dashed',
+  TEXT: 'text',
+  LINK: 'link',
 };
 
 export const INPUT = {


### PR DESCRIPTION
I noticed that after updating to antd v5, the background of the Start/Pause Recording button was removed while enabled. This PR restores the filled `danger` style, and updates the mapping of available values for antd Button `type`.