### PR TITLE
chore: adjust deprecated antd properties

### DIFF
--- a/app/common/renderer/components/Inspector/GestureEditor.jsx
+++ b/app/common/renderer/components/Inspector/GestureEditor.jsx
@@ -593,7 +593,7 @@ const GestureEditor = (props) => {
         value={tick.type}
         defaultValue={tick.type}
         size="middle"
-        dropdownMatchSelectWidth={false}
+        popupMatchSelectWidth={false}
         onChange={(e) => updateTick(tick, TICK_PROPS.POINTER_TYPE, e)}
       >
         <Select.Option className={InspectorCSS['option-inpt']} value={POINTER_MOVE}>
@@ -658,7 +658,7 @@ const GestureEditor = (props) => {
         </Col>
       ))}
       <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
-        <Card className={InspectorCSS['tick-plus-card']} bordered={false}>
+        <Card className={InspectorCSS['tick-plus-card']} variant="borderless">
           <center>
             <Tooltip title={t('Add')}>
               <Button
@@ -684,7 +684,7 @@ const GestureEditor = (props) => {
           }}
           value={pointer.name}
           defaultValue={pointer.name}
-          bordered={false}
+          variant="borderless"
           maxLength={10}
           onChange={(e) => updatePointerName(e.target.value, index)}
         />


### PR DESCRIPTION
Quick fix to adjust some deprecated `antd` properties in the gesture editor:

![image](https://github.com/user-attachments/assets/ea8fe656-93c4-47ca-a654-02081c00b172)
