### PR TITLE
fix: do not pass process value to browser build

### DIFF
--- a/app/common/renderer/actions/Session.js
+++ b/app/common/renderer/actions/Session.js
@@ -602,7 +602,7 @@ export function setSavedServerParams() {
 export function initFromSessionFile() {
   return async (dispatch) => {
     const lastArg = process.argv[process.argv.length - 1];
-    if (!lastArg.startsWith('filename=')) {
+    if (!lastArg?.startsWith('filename=')) {
       return null;
     }
     const filePath = lastArg.split('=')[1];

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -12,7 +12,9 @@ export default defineConfig({
     target: 'es2022',
   },
   define: {
-    'process.env': process.env,
+    // add empty polyfills for some Node.js primitives
+    'process.argv': [],
+    'process.env': {},
   },
   plugins: [react()],
   resolve: {


### PR DESCRIPTION
Slight security improvement for the browser version. Currently Vite is configured to pass the entire `process.env` object to the build, which is unneeded. However, it's not a critical issue because the object is only exposed in the dev build (I checked both the preview build and inspector.appiumpro.com).
This PR simply changes it to an empty object, eliminating the Vite build warning.
A similar adjustment is added for `process.argv`, which also eliminates one console error.