### PR TITLE
feat: add commands to retrieve session commands, extensions & caps

### DIFF
--- a/app/common/renderer/constants/commands.js
+++ b/app/common/renderer/constants/commands.js
@@ -25,6 +25,9 @@ export const COMMAND_DEFINITIONS = {
   Session: {
     status: {},
     getSession: {},
+    getAppiumCommands: {},
+    getAppiumExtensions: {},
+    getAppiumSessionCapabilities: {},
     getTimeouts: {},
     setTimeouts: {
       args: [

--- a/app/common/renderer/lib/client-frameworks/dotnet-nunit.js
+++ b/app/common/renderer/lib/client-frameworks/dotnet-nunit.js
@@ -199,6 +199,18 @@ _driver.PerformActions(new List<ActionSequence> { swipe });
     return `let sessionDetails = _driver.SessionDetails;`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `// Not supported: getAppiumCommands`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `// Not supported: getAppiumExtensions`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `// Not supported: getAppiumSessionCapabilities`;
+  }
+
   codeFor_getTimeouts() {
     return `
 let timeouts = new Dictionary<string, TimeSpan>()

--- a/app/common/renderer/lib/client-frameworks/java-common.js
+++ b/app/common/renderer/lib/client-frameworks/java-common.js
@@ -169,6 +169,18 @@ driver.perform(Arrays.asList(swipe));
     return `var caps = driver.getSessionDetails();`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `// Not supported: getAppiumCommands`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `// Not supported: getAppiumExtensions`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `// Not supported: getAppiumSessionCapabilities`;
+  }
+
   codeFor_getTimeouts() {
     return `
 var implicitTimeout = driver.manage().timeouts().getImplicitWaitTimeout();

--- a/app/common/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/common/renderer/lib/client-frameworks/js-oxygen.js
@@ -117,7 +117,7 @@ ${code}`;
   }
 
   codeFor_getAppiumSessionCapabilities() {
-    return `let sessionCaps = ${this.type}.getDriver().getSessionCapabilities();`;
+    return `let sessionCaps = ${this.type}.getDriver().getAppiumSessionCapabilities();`;
   }
 
   codeFor_getTimeouts() {

--- a/app/common/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/common/renderer/lib/client-frameworks/js-oxygen.js
@@ -108,6 +108,18 @@ ${code}`;
     return `let caps = ${this.type}.getDriver().getSession();`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `let appiumCommands = ${this.type}.getDriver().getAppiumCommands();`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `let appiumExtensions = ${this.type}.getDriver().getAppiumExtensions();`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `let sessionCaps = ${this.type}.getDriver().getSessionCapabilities();`;
+  }
+
   codeFor_getTimeouts() {
     return `let timeouts = ${this.type}.getDriver().getTimeouts();`;
   }

--- a/app/common/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/common/renderer/lib/client-frameworks/js-wdio.js
@@ -126,7 +126,7 @@ main().catch(console.log);`;
   }
 
   codeFor_getAppiumSessionCapabilities() {
-    return `let sessionCaps = await driver.getSessionCapabilities();`;
+    return `let sessionCaps = await driver.getAppiumSessionCapabilities();`;
   }
 
   codeFor_getTimeouts() {

--- a/app/common/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/common/renderer/lib/client-frameworks/js-wdio.js
@@ -117,6 +117,18 @@ main().catch(console.log);`;
     return `let sessionDetails = await driver.getSession();`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `let appiumCommands = await driver.getAppiumCommands();`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `let appiumExtensions = await driver.getAppiumExtensions();`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `let sessionCaps = await driver.getSessionCapabilities();`;
+  }
+
   codeFor_getTimeouts() {
     return `let timeouts = await driver.getTimeouts();`;
   }

--- a/app/common/renderer/lib/client-frameworks/python.js
+++ b/app/common/renderer/lib/client-frameworks/python.js
@@ -147,6 +147,18 @@ actions.perform()
     return `desired_caps = driver.desired_capabilities()`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `# Not supported: getAppiumCommands`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `# Not supported: getAppiumExtensions`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `# Not supported: getAppiumSessionCapabilities`;
+  }
+
   codeFor_getTimeouts() {
     return 'timeouts = driver.timeouts()';
   }

--- a/app/common/renderer/lib/client-frameworks/robot.js
+++ b/app/common/renderer/lib/client-frameworks/robot.js
@@ -117,6 +117,18 @@ ${varAssignment}Execute Script    ${scriptCmd}    $\{scriptArgument}`;
     return '# Not supported: getSession';
   }
 
+  codeFor_getAppiumCommands() {
+    return `# Not supported: getAppiumCommands`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `# Not supported: getAppiumExtensions`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `# Not supported: getAppiumSessionCapabilities`;
+  }
+
   codeFor_getTimeouts() {
     return '# Not supported: getTimeouts';
   }

--- a/app/common/renderer/lib/client-frameworks/ruby.js
+++ b/app/common/renderer/lib/client-frameworks/ruby.js
@@ -132,6 +132,18 @@ driver.quit`;
     return `session_capabilities = driver.session_capabilities`;
   }
 
+  codeFor_getAppiumCommands() {
+    return `# Not supported: getAppiumCommands`;
+  }
+
+  codeFor_getAppiumExtensions() {
+    return `# Not supported: getAppiumExtensions`;
+  }
+
+  codeFor_getAppiumSessionCapabilities() {
+    return `# Not supported: getAppiumSessionCapabilities`;
+  }
+
   codeFor_getTimeouts() {
     return `timeouts = driver.get_timeouts`;
   }


### PR DESCRIPTION
This PR adds 3 new commands to the Commands list, that can be used to retrieve current session information:
* `getAppiumCommands`
* `getAppiumExtensions`
* `getAppiumSessionCapabilities`

In order to use these commands, the following are required:
* Appium `>= 2.16.0`
* UiAutomator2 driver `>= 4.2.6` or XCUITest driver `>= 8.3.2`