### PR TITLE
feat: allow resizing/collapsing source/selected element panels

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -90,3 +90,7 @@ body::-webkit-scrollbar-corner {
 .ant-switch-inner-unchecked {
   font-size: 12px !important;
 }
+
+.ant-splitter-bar {
+  margin: 6px;
+}

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -12,7 +12,7 @@ import {
   TagOutlined,
   ThunderboltOutlined,
 } from '@ant-design/icons';
-import {Button, Card, Modal, Space, Spin, Switch, Tabs, Tooltip} from 'antd';
+import {Button, Card, Modal, Space, Spin, Splitter, Switch, Tabs, Tooltip} from 'antd';
 import _ from 'lodash';
 import {useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router';
@@ -279,7 +279,7 @@ const Inspector = (props) => {
           </Spin>
         )}
       </div>
-      <div id="sourceTreeContainer" className={InspectorStyles['interaction-tab-container']}>
+      <div className={InspectorStyles['inspector-tabs-container']}>
         <Tabs
           activeKey={selectedInspectorTab}
           size="small"
@@ -290,8 +290,8 @@ const Inspector = (props) => {
               key: INSPECTOR_TABS.SOURCE,
               disabled: !showScreenshot,
               children: (
-                <div className="action-row">
-                  <div className="action-col">
+                <Splitter>
+                  <Splitter.Panel collapsible defaultSize="50%" min="25%" max="80%">
                     <Card
                       title={
                         <span>
@@ -329,11 +329,8 @@ const Inspector = (props) => {
                     >
                       <Source {...props} />
                     </Card>
-                  </div>
-                  <div
-                    id="selectedElementContainer"
-                    className={`${InspectorStyles['interaction-tab-container']} ${InspectorStyles['element-detail-container']} action-col`}
-                  >
+                  </Splitter.Panel>
+                  <Splitter.Panel collapsible>
                     <Card
                       title={
                         <span>
@@ -345,8 +342,8 @@ const Inspector = (props) => {
                       {selectedElement.path && <SelectedElement {...props} />}
                       {!selectedElement.path && <i>{t('selectElementInSource')}</i>}
                     </Card>
-                  </div>
-                </div>
+                  </Splitter.Panel>
+                </Splitter>
               ),
             },
             {

--- a/app/common/renderer/components/Inspector/Inspector.module.css
+++ b/app/common/renderer/components/Inspector/Inspector.module.css
@@ -69,21 +69,6 @@
   overflow: hidden;
 }
 
-.inspector-main .interaction-tab-container :global(.ant-tabs-tabpane) {
-  height: 100%;
-}
-
-.inspector-main .interaction-tab-container {
-  position: relative;
-  flex-grow: 1;
-  flex-basis: 550px;
-  min-width: 380px;
-  padding-left: 1em;
-  display: flex;
-  flex-flow: column;
-  height: 100%;
-}
-
 .inspector-main :global(.ant-card-head-wrapper) {
   max-height: 48px;
 }
@@ -100,29 +85,65 @@
   scrollbar-width: none; /* -webkit-scrollbar for Firefox */
 }
 
-.inspector-main .interaction-tab-container :global(.ant-tabs) {
-  height: 100%;
+.inspector-main :global(.ant-card-body::-webkit-scrollbar) {
+  background: transparent;
+  width: 14px;
 }
 
-.inspector-main .interaction-tab-container :global(.ant-tabs-content) {
-  height: 100%;
-}
-
-.inspector-main .interaction-tab-container :global(.action-row) {
+.inspector-tabs-container {
+  position: relative;
+  flex-grow: 1;
+  flex-basis: 550px;
+  min-width: 380px;
+  padding-left: 1em;
   display: flex;
+  flex-flow: column;
   height: 100%;
 }
 
-.inspector-main .interaction-tab-container :global(.action-col) {
-  min-width: 50%;
-  max-width: 50%;
-}
-
-.inspector-main .interaction-tab-container :global(.ant-card) {
+.inspector-tabs-container :global(.ant-tabs) {
   height: 100%;
 }
 
-.inspector-main .tree-container {
+.inspector-tabs-container :global(.ant-tabs-content) {
+  height: 100%;
+}
+
+.inspector-tabs-container :global(.ant-tabs-tabpane) {
+  height: 100%;
+}
+
+.inspector-tabs-container :global(.ant-card) {
+  height: 100%;
+}
+
+.inspector-tabs-container .scroll-buttons {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-left: 1em;
+  padding-bottom: 1em;
+}
+
+.inspector-tabs-container .scroll-buttons :global(button) {
+  margin: 1em;
+}
+
+.inspector-tabs-container .scroll-buttons .scroll-right {
+  float: right;
+}
+
+.interaction-tab-card :global(.ant-card-body) {
+  overflow: scroll;
+}
+
+.interaction-tab-card {
+  flex: 2;
+  height: 100%;
+}
+
+.tree-container {
   height: 100%;
   overflow: auto;
 }
@@ -134,45 +155,6 @@
 
 .session-inner-table :global(.ant-table-body)::-webkit-scrollbar {
   width: 0px;
-}
-
-.inspector-main .interaction-tab-container .scroll-buttons {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding-left: 1em;
-  padding-bottom: 1em;
-}
-
-.inspector-main .interaction-tab-container .scroll-buttons :global(button) {
-  margin: 1em;
-}
-
-.inspector-main .interaction-tab-container .scroll-buttons .scroll-right {
-  float: right;
-}
-
-._inspector-main_0387c .ant-card-body {
-  height: 100%;
-  padding: 12px;
-}
-
-.inspector-main .interaction-tab-card :global(.ant-card-body) {
-  overflow: scroll;
-}
-
-.inspector-main .interaction-tab-card {
-  flex: 2;
-}
-
-.inspector-main :global(.ant-card-body::-webkit-scrollbar) {
-  background: transparent;
-  width: 14px;
-}
-
-.inspector-main .interaction-tab-container .interaction-tab-card {
-  height: 100%;
 }
 
 .highlighter-box {
@@ -381,10 +363,6 @@
 .elementKeyInputActions {
   max-width: 300px;
   flex: 1;
-}
-
-.inspector-main #selectedElementContainer {
-  padding-bottom: 0px;
 }
 
 .selected-element-table-cells {

--- a/app/common/renderer/components/Inspector/Inspector.module.css
+++ b/app/common/renderer/components/Inspector/Inspector.module.css
@@ -361,7 +361,7 @@
 }
 
 .elementKeyInputActions {
-  max-width: 300px;
+  max-width: 400px;
   flex: 1;
 }
 

--- a/app/common/renderer/components/Inspector/SelectedElement.jsx
+++ b/app/common/renderer/components/Inspector/SelectedElement.jsx
@@ -105,6 +105,7 @@ const SelectedElement = (props) => {
       dataIndex: 'name',
       key: 'name',
       fixed: 'left',
+      width: 150,
       render: (text) => selectedElementTableCell(text, false),
     },
     {
@@ -134,6 +135,7 @@ const SelectedElement = (props) => {
       dataIndex: 'find',
       key: 'find',
       fixed: 'left',
+      width: 150,
       render: (text) => selectedElementTableCell(text, false),
     },
     {


### PR DESCRIPTION
This PR adds support for resizing and collapsing of the source and selected element panels shown in the Session Inspector, as suggested in #766.
I've also set a fixed width for the fixed columns in the selected element tables (they leave too much blank space until the next column, which looks even worse if the source panel is collapsed), as well as increased the width of the send keys input field.
Here is a brief demo:

https://github.com/user-attachments/assets/4a2eed22-2d3f-406c-a197-c8d25689712c