### PR TITLE
feat: allow resizing/collapsing session builder panels

### DIFF
--- a/app/common/renderer/components/Session/CapabilityEditor.jsx
+++ b/app/common/renderer/components/Session/CapabilityEditor.jsx
@@ -1,8 +1,7 @@
 import {DeleteOutlined, PlusOutlined} from '@ant-design/icons';
-import {Button, Checkbox, Col, Form, Input, Modal, Row, Select, Tooltip} from 'antd';
+import {Button, Checkbox, Col, Form, Input, Modal, Row, Select, Splitter, Tooltip} from 'antd';
 import {useEffect, useRef} from 'react';
 
-import {ROW} from '../../constants/antd-types';
 import {CAPABILITY_TYPES} from '../../constants/session-builder';
 import CapabilityControl from './CapabilityControl.jsx';
 import FormattedCaps from './FormattedCaps.jsx';
@@ -80,12 +79,12 @@ const CapabilityEditor = (props) => {
   }, [caps.length, latestCapField]);
 
   return (
-    <Row type={ROW.FLEX} align="top" justify="start" className={SessionStyles.capsFormRow}>
-      <Col order={1} span={12} className={SessionStyles.capsFormCol}>
+    <Splitter>
+      <Splitter.Panel collapsible resizable={false}>
         <Form className={SessionStyles.newSessionForm}>
           {caps.map((cap, index) => (
             <Row gutter={8} key={index}>
-              <Col span={7}>
+              <Col md={7} lg={8} xl={8} xxl={9}>
                 <Form.Item>
                   <Tooltip title={whitespaceMsg(cap.name, t)} open={whitespaces.test(cap.name)}>
                     <Input
@@ -100,7 +99,7 @@ const CapabilityEditor = (props) => {
                   </Tooltip>
                 </Form.Item>
               </Col>
-              <Col span={8}>
+              <Col flex="auto">
                 <Form.Item>
                   <Select
                     disabled={isEditingDesiredCaps}
@@ -116,7 +115,7 @@ const CapabilityEditor = (props) => {
                   </Select>
                 </Form.Item>
               </Col>
-              <Col span={7}>
+              <Col md={7} lg={8} xl={9} xxl={10}>
                 <Form.Item>
                   <Tooltip title={whitespaceMsg(cap.value, t)} open={whitespaces.test(cap.value)}>
                     <CapabilityControl
@@ -129,7 +128,7 @@ const CapabilityEditor = (props) => {
                   </Tooltip>
                 </Form.Item>
               </Col>
-              <Col span={2}>
+              <Col flex="40px">
                 <div className={SessionStyles.btnDeleteCap}>
                   <Form.Item>
                     <Tooltip title={t('Delete')} placement="right">
@@ -144,8 +143,8 @@ const CapabilityEditor = (props) => {
               </Col>
             </Row>
           ))}
-          <Row>
-            <Col span={22}>
+          <Row gutter={8}>
+            <Col flex="auto">
               <Form.Item>
                 <Checkbox
                   checked={addVendorPrefixes}
@@ -155,7 +154,7 @@ const CapabilityEditor = (props) => {
                 </Checkbox>
               </Form.Item>
             </Col>
-            <Col span={2}>
+            <Col flex="40px">
               <Form.Item>
                 <Tooltip title={t('Add')} placement="right">
                   <Button
@@ -170,8 +169,8 @@ const CapabilityEditor = (props) => {
             </Col>
           </Row>
         </Form>
-      </Col>
-      <Col order={2} span={12} className={SessionStyles.capsFormattedCol}>
+      </Splitter.Panel>
+      <Splitter.Panel collapsible>
         <FormattedCaps {...props} />
         <Modal
           open={showSaveAsModal}
@@ -192,8 +191,8 @@ const CapabilityEditor = (props) => {
             <p className={SessionStyles.errorMessage}> {t('duplicateCapabilityNameError')}</p>
           )}
         </Modal>
-      </Col>
-    </Row>
+      </Splitter.Panel>
+    </Splitter>
   );
 };
 

--- a/app/common/renderer/components/Session/SavedSessions.jsx
+++ b/app/common/renderer/components/Session/SavedSessions.jsx
@@ -122,7 +122,7 @@ const SavedSessions = (props) => {
           />
         </Card>
       </Splitter.Panel>
-      <Splitter.Panel min={400}>
+      <Splitter.Panel collapsible min={400}>
         <FormattedCaps
           {...props}
           title={capsUUID ? getSessionById(savedSessions, capsUUID, t).name : null}

--- a/app/common/renderer/components/Session/SavedSessions.jsx
+++ b/app/common/renderer/components/Session/SavedSessions.jsx
@@ -1,5 +1,5 @@
 import {DeleteOutlined, EditOutlined} from '@ant-design/icons';
-import {Button, Card, Col, Popconfirm, Row, Space, Table, Tooltip} from 'antd';
+import {Button, Card, Popconfirm, Space, Splitter, Table, Tooltip} from 'antd';
 import moment from 'moment';
 
 import {SAVED_SESSIONS_TABLE_VALUES, SESSION_BUILDER_TABS} from '../../constants/session-builder';
@@ -104,9 +104,9 @@ const SavedSessions = (props) => {
   ];
 
   return (
-    <Row className={SessionStyles.savedSessions}>
-      <Col span={12}>
-        <Card className={SessionStyles.savedCaps}>
+    <Splitter>
+      <Splitter.Panel min={430}>
+        <Card className={SessionStyles.savedSessions}>
           <Table
             pagination={false}
             sticky={true}
@@ -121,14 +121,14 @@ const SavedSessions = (props) => {
             }}
           />
         </Card>
-      </Col>
-      <Col span={12} className={SessionStyles.capsFormattedCol}>
+      </Splitter.Panel>
+      <Splitter.Panel min={400}>
         <FormattedCaps
           {...props}
           title={capsUUID ? getSessionById(savedSessions, capsUUID, t).name : null}
         />
-      </Col>
-    </Row>
+      </Splitter.Panel>
+    </Splitter>
   );
 };
 

--- a/app/common/renderer/components/Session/Session.module.css
+++ b/app/common/renderer/components/Session/Session.module.css
@@ -95,6 +95,7 @@
 
 .scrollingTabCont {
   margin-top: 15px;
+  margin-bottom: 15px;
   flex-grow: 1;
   display: flex;
   flex-direction: column;
@@ -129,8 +130,9 @@
   height: 100%;
 }
 
-.savedSessions :global(.ant-col) {
-  height: calc(100% - 15px);
+.savedSessions :global(.ant-card-body) {
+  height: 100%;
+  padding: 0;
 }
 
 .savedSessions :global(.ant-table) {
@@ -155,23 +157,13 @@
   width: 0px;
 }
 
-.capsFormattedCol {
-  padding-left: 12px;
+.newSessionForm :global(.ant-form-item) {
+  margin-bottom: 0.5em;
 }
 
-.savedCaps,
 .formattedCaps,
 .formattedCapsBody {
   height: 100%;
-}
-
-.savedCaps :global(.ant-card-body) {
-  height: 100%;
-  padding: 0;
-}
-
-.formattedCaps :global(.ant-row) {
-  width: 100%;
 }
 
 .formattedCaps :global(.ant-card-head-title) {
@@ -205,26 +197,8 @@
   margin-left: 1em;
 }
 
-.capsFormCol {
-  min-width: 420px;
-  height: 100%;
-}
-
-.capsFormRow {
-  font-size: 14px;
-  height: 100%;
-}
-
-.capsFormRow :global(.ant-col) {
-  height: calc(100% - 15px);
-}
-
 .capsBoxFont {
   font-family: monospace;
-}
-
-.capsFormRow :global(.ant-form-item) {
-  margin-bottom: 0.5em;
 }
 
 .capsValueControl {


### PR DESCRIPTION
This PR is a follow-up to #2196 and adds the antd Splitter component for the Session Builder as well.
* The Capability Builder tab now supports collapsing either the fields or JSON panels. Resizing is intentionally disabled due to CSS issues with the form fields.
  * I also adjusted the form field column widths, making the capability name and value fields larger
* The Saved Capability Sets tab now supports resizing the saved sets and JSON structure panels, as well as collapsing the JSON structure panel. Collapsing for the saved sets is intentionally disabled since it doesn't really make sense.

Here is a brief demo:

https://github.com/user-attachments/assets/296b0415-57b3-4fce-9536-0fd3e4eeda4a

