### PR TITLE
feat: show lines between source tree nodes

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -86,6 +86,10 @@ body::-webkit-scrollbar-corner {
   font-size: 20px !important;
 }
 
+.ant-tree-switcher-icon {
+  vertical-align: sub !important;
+}
+
 .ant-switch-inner-checked,
 .ant-switch-inner-unchecked {
   font-size: 12px !important;

--- a/app/common/renderer/components/Inspector/Source.jsx
+++ b/app/common/renderer/components/Inspector/Source.jsx
@@ -1,3 +1,4 @@
+import {CaretDownOutlined} from '@ant-design/icons';
 import {Spin, Tree} from 'antd';
 
 import {IMPORTANT_SOURCE_ATTRS} from '../../constants/source';
@@ -84,6 +85,8 @@ const Source = (props) => {
         {treeData ? (
           <Tree
             defaultExpandAll={true}
+            showLine={true}
+            switcherIcon={<CaretDownOutlined />}
             onExpand={setExpandedPaths}
             expandedKeys={expandedPaths}
             onSelect={(selectedPaths) => handleSelectElement(selectedPaths[0])}


### PR DESCRIPTION
Small PR to add a useful feature in the antd Tree component - showing lines between sibling nodes in the source tree. I've also included a minor CSS fix for the tree node expand/collapse icon, since it was vertically misaligned.

For a comparison, this is how a tree might look currently:
<img width="700" height="455" alt="tree-current" src="https://github.com/user-attachments/assets/02c8d7c2-d4ee-43ea-a1c6-b59c2ce2c5f4" />

This is how the same tree looks after these changes:
<img width="700" height="456" alt="tree-new" src="https://github.com/user-attachments/assets/4fa548de-d002-42f8-8da3-8cb8fd6bd4dd" />
