### PR TITLE
chore(renovate): update config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -31,7 +31,6 @@
       "updateLockFiles": false
     }
   ],
-  "baseBranches": ["main"],
   "semanticCommits": "enabled",
   "schedule": ["after 10pm", "before 5:00am"],
   "timezone": "America/Vancouver"


### PR DESCRIPTION
Replaces #2209. The `baseBranches`/`baseBranchPatterns` option is actually not needed at all, since Renovate already targets the default branch by default.