### PR TITLE
chore: set plugin requirements to Appium 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "electron": "./node_modules/.bin/electron"
   },
   "//dependencies": {
-    "react": "V19: requires antd 5"
+    "react": "V19: requires antd 6"
   },
   "dependencies": {
     "@ant-design/pro-components": "2.8.10",
@@ -119,7 +119,7 @@
     "vitest": "3.2.4"
   },
   "engines": {
-    "node": "^20.19.0 || >=22.12.0",
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10.x"
   }
 }

--- a/plugins/package.json
+++ b/plugins/package.json
@@ -27,7 +27,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "appium": "^2.0.0 || ^3.0.0-beta.0"
+    "appium": "^3.0.0-beta.0"
   },
   "files": [
     "index.mjs",
@@ -36,11 +36,11 @@
     "README.md"
   ],
   "dependencies": {
-    "@appium/base-plugin": "2.3.7"
+    "@appium/base-plugin": "3.0.0"
   },
   "devDependencies": {},
   "engines": {
-    "node": "^20.19.0 || >=22.12.0",
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10.x"
   },
   "appium": {


### PR DESCRIPTION
Replaces #2255. The required Node.js and Appium versions have been adjusted to match those of `@appium/base-plugin` `3.0.0`, meaning the plugin version will no longer be compatible with Appium 2.