### PR TITLE
chore: move Session Inspector tab antd Card wrappers to tab-specific files

### DIFF
--- a/app/common/renderer/components/Inspector/Commands.jsx
+++ b/app/common/renderer/components/Inspector/Commands.jsx
@@ -1,4 +1,5 @@
-import {Alert, Button, Col, Collapse, Input, Modal, Row, Space, Switch, Tooltip} from 'antd';
+import {ThunderboltOutlined} from '@ant-design/icons';
+import {Alert, Button, Card, Col, Collapse, Input, Modal, Row, Space, Switch, Tooltip} from 'antd';
 import _ from 'lodash';
 
 import {ALERT, INPUT} from '../../constants/antd-types';
@@ -117,100 +118,109 @@ const Commands = (props) => {
     notes.map((note) => (_.isArray(note) ? `${t(note[0])}: ${note[1]}` : t(note))).join('; ');
 
   return (
-    <div className={InspectorStyles['commands-container']}>
-      <Space className={InspectorStyles.spaceContainer} direction="vertical" size="middle">
-        {t('commandsDescription')}
-        <Row>
-          {_.toPairs(TOP_LEVEL_COMMANDS).map(([commandName, command], index) => (
-            <Col key={index} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
-              <div className={InspectorStyles['btn-container']}>
-                <Button onClick={() => startPerformingCommand(commandName, command)}>
-                  {commandName}
-                </Button>
-              </div>
-            </Col>
-          ))}
-        </Row>
-        <Collapse
-          items={_.toPairs(COMMAND_DEFINITIONS).map(([commandGroup, commands]) => ({
-            key: commandGroup,
-            label: t(commandGroup),
-            children: (
-              <Row>
-                {_.toPairs(commands).map(
-                  ([commandName, command], index) =>
-                    (!command.drivers || command.drivers.includes(automationName)) && (
-                      <Col key={index} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
-                        <div className={InspectorStyles['btn-container']}>
-                          <Tooltip
-                            title={
-                              command.notes && !command.args
-                                ? generateCommandNotes(command.notes)
-                                : null
-                            }
-                          >
-                            <Button onClick={() => startPerformingCommand(commandName, command)}>
-                              {commandName}
-                            </Button>
-                          </Tooltip>
-                        </div>
-                      </Col>
-                    ),
-                )}
-              </Row>
-            ),
-          }))}
-        />
-      </Space>
-      {!!pendingCommand && (
-        <Modal
-          title={`${t('Enter Parameters for:')} ${t(pendingCommand.commandName)}`}
-          okText={t('Execute Command')}
-          cancelText={t('Cancel')}
-          open={!!pendingCommand}
-          onOk={() => executeCommand()}
-          onCancel={() => cancelPendingCommand()}
-        >
-          {pendingCommand.command.notes && (
-            <Alert
-              message={generateCommandNotes(pendingCommand.command.notes)}
-              type={ALERT.INFO}
-              showIcon
-            />
-          )}
-          {!_.isEmpty(pendingCommand.command.args) &&
-            _.map(pendingCommand.command.args, ([argName, argType], index) => (
-              <Row key={index} gutter={16}>
-                <Col span={24} className={InspectorStyles['arg-container']}>
-                  {argType === COMMAND_ARG_TYPES.NUMBER && (
-                    <Input
-                      type={INPUT.NUMBER}
-                      value={pendingCommand.args[index]}
-                      addonBefore={t(argName)}
-                      onChange={(e) => setCommandArg(index, _.toNumber(e.target.value))}
-                    />
-                  )}
-                  {argType === COMMAND_ARG_TYPES.BOOLEAN && (
-                    <div>
-                      {t(argName)}{' '}
-                      <Switch
-                        checked={pendingCommand.args[index]}
-                        onChange={(v) => setCommandArg(index, v)}
-                      />
-                    </div>
-                  )}
-                  {argType === COMMAND_ARG_TYPES.STRING && (
-                    <Input
-                      addonBefore={t(argName)}
-                      onChange={(e) => setCommandArg(index, e.target.value)}
-                    />
-                  )}
-                </Col>
-              </Row>
+    <Card
+      title={
+        <span>
+          <ThunderboltOutlined /> {t('Execute Commands')}
+        </span>
+      }
+      className={InspectorStyles['interaction-tab-card']}
+    >
+      <div className={InspectorStyles['commands-container']}>
+        <Space className={InspectorStyles.spaceContainer} direction="vertical" size="middle">
+          {t('commandsDescription')}
+          <Row>
+            {_.toPairs(TOP_LEVEL_COMMANDS).map(([commandName, command], index) => (
+              <Col key={index} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
+                <div className={InspectorStyles['btn-container']}>
+                  <Button onClick={() => startPerformingCommand(commandName, command)}>
+                    {commandName}
+                  </Button>
+                </div>
+              </Col>
             ))}
-        </Modal>
-      )}
-    </div>
+          </Row>
+          <Collapse
+            items={_.toPairs(COMMAND_DEFINITIONS).map(([commandGroup, commands]) => ({
+              key: commandGroup,
+              label: t(commandGroup),
+              children: (
+                <Row>
+                  {_.toPairs(commands).map(
+                    ([commandName, command], index) =>
+                      (!command.drivers || command.drivers.includes(automationName)) && (
+                        <Col key={index} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
+                          <div className={InspectorStyles['btn-container']}>
+                            <Tooltip
+                              title={
+                                command.notes && !command.args
+                                  ? generateCommandNotes(command.notes)
+                                  : null
+                              }
+                            >
+                              <Button onClick={() => startPerformingCommand(commandName, command)}>
+                                {commandName}
+                              </Button>
+                            </Tooltip>
+                          </div>
+                        </Col>
+                      ),
+                  )}
+                </Row>
+              ),
+            }))}
+          />
+        </Space>
+        {!!pendingCommand && (
+          <Modal
+            title={`${t('Enter Parameters for:')} ${t(pendingCommand.commandName)}`}
+            okText={t('Execute Command')}
+            cancelText={t('Cancel')}
+            open={!!pendingCommand}
+            onOk={() => executeCommand()}
+            onCancel={() => cancelPendingCommand()}
+          >
+            {pendingCommand.command.notes && (
+              <Alert
+                message={generateCommandNotes(pendingCommand.command.notes)}
+                type={ALERT.INFO}
+                showIcon
+              />
+            )}
+            {!_.isEmpty(pendingCommand.command.args) &&
+              _.map(pendingCommand.command.args, ([argName, argType], index) => (
+                <Row key={index} gutter={16}>
+                  <Col span={24} className={InspectorStyles['arg-container']}>
+                    {argType === COMMAND_ARG_TYPES.NUMBER && (
+                      <Input
+                        type={INPUT.NUMBER}
+                        value={pendingCommand.args[index]}
+                        addonBefore={t(argName)}
+                        onChange={(e) => setCommandArg(index, _.toNumber(e.target.value))}
+                      />
+                    )}
+                    {argType === COMMAND_ARG_TYPES.BOOLEAN && (
+                      <div>
+                        {t(argName)}{' '}
+                        <Switch
+                          checked={pendingCommand.args[index]}
+                          onChange={(v) => setCommandArg(index, v)}
+                        />
+                      </div>
+                    )}
+                    {argType === COMMAND_ARG_TYPES.STRING && (
+                      <Input
+                        addonBefore={t(argName)}
+                        onChange={(e) => setCommandArg(index, e.target.value)}
+                      />
+                    )}
+                  </Col>
+                </Row>
+              ))}
+          </Modal>
+        )}
+      </div>
+    </Card>
   );
 };
 

--- a/app/common/renderer/components/Inspector/GestureEditor.jsx
+++ b/app/common/renderer/components/Inspector/GestureEditor.jsx
@@ -2,6 +2,7 @@ import {
   AimOutlined,
   CloseOutlined,
   DownCircleOutlined,
+  HighlightOutlined,
   PauseCircleOutlined,
   PlayCircleOutlined,
   PlusOutlined,
@@ -696,7 +697,14 @@ const GestureEditor = (props) => {
   }));
 
   return (
-    <>
+    <Card
+      title={
+        <span>
+          <HighlightOutlined /> {t('Gesture Builder')}
+        </span>
+      }
+      className={InspectorCSS['interaction-tab-card']}
+    >
       <PageHeader
         className={InspectorCSS['gesture-header']}
         onBack={() => onBack()}
@@ -722,7 +730,7 @@ const GestureEditor = (props) => {
         tabBarGutter={10}
         items={pointerTabs}
       />
-    </>
+    </Card>
   );
 };
 

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -7,7 +7,6 @@ import {
   FileTextOutlined,
   PlusSquareOutlined,
   SelectOutlined,
-  TagOutlined,
 } from '@ant-design/icons';
 import {Button, Card, Modal, Space, Spin, Splitter, Switch, Tabs, Tooltip} from 'antd';
 import _ from 'lodash';
@@ -31,7 +30,7 @@ import InspectorStyles from './Inspector.module.css';
 import Recorder from './Recorder.jsx';
 import SavedGestures from './SavedGestures.jsx';
 import Screenshot from './Screenshot.jsx';
-import SelectedElement from './SelectedElement.jsx';
+import SelectedElementContainer from './SelectedElementContainer.jsx';
 import SessionInfo from './SessionInfo.jsx';
 import Source from './Source.jsx';
 
@@ -53,7 +52,6 @@ const Inspector = (props) => {
   const {
     screenshot,
     screenshotError,
-    selectedElement = {},
     quitSession,
     screenshotInteractionMode,
     visibleCommandMethod,
@@ -328,17 +326,7 @@ const Inspector = (props) => {
                     </Card>
                   </Splitter.Panel>
                   <Splitter.Panel collapsible>
-                    <Card
-                      title={
-                        <span>
-                          <TagOutlined /> {t('selectedElement')}
-                        </span>
-                      }
-                      className={InspectorStyles['selected-element-card']}
-                    >
-                      {selectedElement.path && <SelectedElement {...props} />}
-                      {!selectedElement.path && <i>{t('selectElementInSource')}</i>}
-                    </Card>
+                    <SelectedElementContainer {...props} />
                   </Splitter.Panel>
                 </Splitter>
               ),

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -1,14 +1,11 @@
 import {
   CheckCircleOutlined,
   CloseCircleOutlined,
-  CodeOutlined,
-  CopyOutlined,
   DownloadOutlined,
-  FileTextOutlined,
   PlusSquareOutlined,
   SelectOutlined,
 } from '@ant-design/icons';
-import {Button, Card, Modal, Space, Spin, Splitter, Switch, Tabs, Tooltip} from 'antd';
+import {Button, Modal, Space, Spin, Splitter, Switch, Tabs, Tooltip} from 'antd';
 import _ from 'lodash';
 import {useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router';
@@ -21,7 +18,6 @@ import {
   MJPEG_STREAM_CHECK_INTERVAL,
   SESSION_EXPIRY_PROMPT_TIMEOUT,
 } from '../../constants/session-inspector';
-import {copyToClipboard} from '../../polyfills';
 import {downloadFile} from '../../utils/file-handling';
 import Commands from './Commands.jsx';
 import GestureEditor from './GestureEditor.jsx';
@@ -35,12 +31,6 @@ import SessionInfo from './SessionInfo.jsx';
 import Source from './Source.jsx';
 
 const {SELECT, TAP_SWIPE} = SCREENSHOT_INTERACTION_MODE;
-
-const downloadXML = (sourceXML) => {
-  const href = 'data:application/xml;charset=utf-8,' + encodeURIComponent(sourceXML);
-  const filename = `app-source-${new Date().toJSON()}.xml`;
-  downloadFile(href, filename);
-};
 
 const downloadScreenshot = (screenshot) => {
   const href = `data:image/png;base64,${screenshot}`;
@@ -61,7 +51,6 @@ const Inspector = (props) => {
     setUserWaitTimeout,
     showKeepAlivePrompt,
     keepSessionAlive,
-    sourceXML,
     visibleCommandResult,
     serverDetails,
     isUsingMjpegMode,
@@ -69,7 +58,6 @@ const Inspector = (props) => {
     toggleShowCentroids,
     showCentroids,
     isGestureEditorVisible,
-    toggleShowAttributes,
     isSourceRefreshOn,
     windowSize,
     t,
@@ -287,43 +275,7 @@ const Inspector = (props) => {
               children: (
                 <Splitter>
                   <Splitter.Panel collapsible defaultSize="50%" min="25%" max="80%">
-                    <Card
-                      title={
-                        <span>
-                          <FileTextOutlined /> {t('App Source')}{' '}
-                        </span>
-                      }
-                      extra={
-                        <span>
-                          <Tooltip title={t('Toggle Attributes')}>
-                            <Button
-                              type="text"
-                              id="btnToggleAttrs"
-                              icon={<CodeOutlined />}
-                              onClick={toggleShowAttributes}
-                            />
-                          </Tooltip>
-                          <Tooltip title={t('Copy XML Source to Clipboard')}>
-                            <Button
-                              type="text"
-                              id="btnSourceXML"
-                              icon={<CopyOutlined />}
-                              onClick={() => copyToClipboard(sourceXML)}
-                            />
-                          </Tooltip>
-                          <Tooltip title={t('Download Source as .XML File')}>
-                            <Button
-                              type="text"
-                              id="btnDownloadSourceXML"
-                              icon={<DownloadOutlined />}
-                              onClick={() => downloadXML(sourceXML)}
-                            />
-                          </Tooltip>
-                        </span>
-                      }
-                    >
-                      <Source {...props} />
-                    </Card>
+                    <Source {...props} />
                   </Splitter.Panel>
                   <Splitter.Panel collapsible>
                     <SelectedElementContainer {...props} />

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -5,7 +5,6 @@ import {
   CopyOutlined,
   DownloadOutlined,
   FileTextOutlined,
-  HighlightOutlined,
   PlusSquareOutlined,
   SelectOutlined,
   TagOutlined,
@@ -355,27 +354,9 @@ const Inspector = (props) => {
               key: INSPECTOR_TABS.GESTURES,
               disabled: !showScreenshot,
               children: isGestureEditorVisible ? (
-                <Card
-                  title={
-                    <span>
-                      <HighlightOutlined /> {t('Gesture Builder')}
-                    </span>
-                  }
-                  className={InspectorStyles['interaction-tab-card']}
-                >
-                  <GestureEditor {...props} />
-                </Card>
+                <GestureEditor {...props} />
               ) : (
-                <Card
-                  title={
-                    <span>
-                      <HighlightOutlined /> {t('Saved Gestures')}
-                    </span>
-                  }
-                  className={InspectorStyles['interaction-tab-card']}
-                >
-                  <SavedGestures {...props} />
-                </Card>
+                <SavedGestures {...props} />
               ),
             },
             {

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -6,7 +6,6 @@ import {
   DownloadOutlined,
   FileTextOutlined,
   HighlightOutlined,
-  InfoCircleOutlined,
   PlusSquareOutlined,
   SelectOutlined,
   TagOutlined,
@@ -401,18 +400,7 @@ const Inspector = (props) => {
               label: t('Session Information'),
               key: INSPECTOR_TABS.SESSION_INFO,
               disabled: !showScreenshot,
-              children: (
-                <Card
-                  title={
-                    <span>
-                      <InfoCircleOutlined /> {t('Session Information')}
-                    </span>
-                  }
-                  className={InspectorStyles['interaction-tab-card']}
-                >
-                  <SessionInfo {...props} />
-                </Card>
-              ),
+              children: <SessionInfo {...props} />,
             },
           ]}
         />

--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -9,7 +9,6 @@ import {
   PlusSquareOutlined,
   SelectOutlined,
   TagOutlined,
-  ThunderboltOutlined,
 } from '@ant-design/icons';
 import {Button, Card, Modal, Space, Spin, Splitter, Switch, Tabs, Tooltip} from 'antd';
 import _ from 'lodash';
@@ -349,18 +348,7 @@ const Inspector = (props) => {
               label: t('Commands'),
               key: INSPECTOR_TABS.COMMANDS,
               disabled: !showScreenshot,
-              children: (
-                <Card
-                  title={
-                    <span>
-                      <ThunderboltOutlined /> {t('Execute Commands')}
-                    </span>
-                  }
-                  className={InspectorStyles['interaction-tab-card']}
-                >
-                  <Commands {...props} />
-                </Card>
-              ),
+              children: <Commands {...props} />,
             },
             {
               label: t('Gestures'),

--- a/app/common/renderer/components/Inspector/SavedGestures.jsx
+++ b/app/common/renderer/components/Inspector/SavedGestures.jsx
@@ -3,10 +3,11 @@ import {
   DownloadOutlined,
   EditOutlined,
   ExclamationCircleOutlined,
+  HighlightOutlined,
   PlayCircleOutlined,
   PlusOutlined,
 } from '@ant-design/icons';
-import {Button, Collapse, Modal, Popconfirm, Row, Space, Table, Tooltip} from 'antd';
+import {Button, Card, Collapse, Modal, Popconfirm, Row, Space, Table, Tooltip} from 'antd';
 import _ from 'lodash';
 import moment from 'moment';
 import {useEffect} from 'react';
@@ -198,30 +199,39 @@ const SavedGestures = (props) => {
   }, []);
 
   return (
-    <Space className={InspectorStyles.spaceContainer} direction="vertical" size="middle">
-      {t('gesturesDescription')}
-      <Table
-        onRow={(row) => onRowMouseOver(row.key)}
-        pagination={false}
-        dataSource={dataSource(savedGestures, t)}
-        columns={columns}
-        scroll={{y: 'calc(100vh - 32em)'}}
-        footer={() => (
-          <Space.Compact>
-            <Tooltip title={t('Create New Gesture')}>
-              <Button onClick={showGestureEditor} icon={<PlusOutlined />} />
-            </Tooltip>
-            <FileUploader
-              tooltipTitle={t('Upload Gesture File')}
-              onUpload={uploadGesturesFromFile}
-              multiple={true}
-              type="application/json"
-            />
-          </Space.Compact>
-        )}
-      />
-      {gestureUploadErrors && showGestureUploadErrorsModal()}
-    </Space>
+    <Card
+      title={
+        <span>
+          <HighlightOutlined /> {t('Saved Gestures')}
+        </span>
+      }
+      className={InspectorStyles['interaction-tab-card']}
+    >
+      <Space className={InspectorStyles.spaceContainer} direction="vertical" size="middle">
+        {t('gesturesDescription')}
+        <Table
+          onRow={(row) => onRowMouseOver(row.key)}
+          pagination={false}
+          dataSource={dataSource(savedGestures, t)}
+          columns={columns}
+          scroll={{y: 'calc(100vh - 32em)'}}
+          footer={() => (
+            <Space.Compact>
+              <Tooltip title={t('Create New Gesture')}>
+                <Button onClick={showGestureEditor} icon={<PlusOutlined />} />
+              </Tooltip>
+              <FileUploader
+                tooltipTitle={t('Upload Gesture File')}
+                onUpload={uploadGesturesFromFile}
+                multiple={true}
+                type="application/json"
+              />
+            </Space.Compact>
+          )}
+        />
+        {gestureUploadErrors && showGestureUploadErrorsModal()}
+      </Space>
+    </Card>
   );
 };
 

--- a/app/common/renderer/components/Inspector/SelectedElementContainer.jsx
+++ b/app/common/renderer/components/Inspector/SelectedElementContainer.jsx
@@ -1,0 +1,29 @@
+import {TagOutlined} from '@ant-design/icons';
+import {Card} from 'antd';
+
+import InspectorStyles from './Inspector.module.css';
+import SelectedElement from './SelectedElement.jsx';
+
+/**
+ * Wrapper for the Selected Element panel,
+ * both when an element is actually selected and when not
+ */
+const SelectedElementContainer = (props) => {
+  const {selectedElement = {}, t} = props;
+
+  return (
+    <Card
+      title={
+        <span>
+          <TagOutlined /> {t('selectedElement')}
+        </span>
+      }
+      className={InspectorStyles['selected-element-card']}
+    >
+      {selectedElement.path && <SelectedElement {...props} />}
+      {!selectedElement.path && <i>{t('selectElementInSource')}</i>}
+    </Card>
+  );
+};
+
+export default SelectedElementContainer;

--- a/app/common/renderer/components/Inspector/SessionInfo.jsx
+++ b/app/common/renderer/components/Inspector/SessionInfo.jsx
@@ -1,4 +1,5 @@
-import {Space, Table} from 'antd';
+import {InfoCircleOutlined} from '@ant-design/icons';
+import {Card, Space, Table} from 'antd';
 import _ from 'lodash';
 import {useEffect, useRef, useState} from 'react';
 
@@ -6,7 +7,7 @@ import InspectorStyles from './Inspector.module.css';
 import SessionCodeBox from './SessionCodeBox.jsx';
 
 const SessionInfo = (props) => {
-  const {driver} = props;
+  const {driver, t} = props;
 
   const interval = useRef();
   const [sessionLength, setSessionLength] = useState(0);
@@ -107,17 +108,26 @@ const SessionInfo = (props) => {
   }, []);
 
   return (
-    <Space direction="vertical" size="middle">
-      <Table
-        columns={columns}
-        dataSource={outerDataSource()}
-        pagination={false}
-        showHeader={false}
-        bordered={true}
-        size="small"
-      />
-      <SessionCodeBox {...props} />
-    </Space>
+    <Card
+      title={
+        <span>
+          <InfoCircleOutlined /> {t('Session Information')}
+        </span>
+      }
+      className={InspectorStyles['interaction-tab-card']}
+    >
+      <Space direction="vertical" size="middle">
+        <Table
+          columns={columns}
+          dataSource={outerDataSource()}
+          pagination={false}
+          showHeader={false}
+          bordered={true}
+          size="small"
+        />
+        <SessionCodeBox {...props} />
+      </Space>
+    </Card>
   );
 };
 


### PR DESCRIPTION
This is a slight refactor of the Session Inspector main JSX file. Each tab component is wrapped in an antd Card component, but these Cards were located in the main JSX file. Now they are moved to the respective tab component file.

The Recorder tab was already implemented this way, so this PR aligns the implementation of the 4 remaining tabs.

This is needed in preparation for aligning the button locations in the Source and Selected Element tabs. 