### PR TITLE
style: align button placement for Source and Selected Element paneks

### DIFF
--- a/app/common/renderer/components/Inspector/Inspector.module.css
+++ b/app/common/renderer/components/Inspector/Inspector.module.css
@@ -713,7 +713,7 @@
 
 .tree-search-input {
   max-width: 400px;
-  align-self: center;
+  flex: 1;
 }
 
 .tree-search-input :global(.ant-input-group-addon) {

--- a/app/common/renderer/components/Inspector/SelectedElement.jsx
+++ b/app/common/renderer/components/Inspector/SelectedElement.jsx
@@ -200,6 +200,28 @@ const SelectedElement = (props) => {
         </span>
       }
       className={styles['selected-element-card']}
+      extra={
+        <span>
+          <Tooltip title={t('Copy Attributes to Clipboard')}>
+            <Button
+              type="text"
+              disabled={isDisabled}
+              id="btnCopyAttributes"
+              icon={<CopyOutlined />}
+              onClick={() => copyToClipboard(JSON.stringify(dataSource))}
+            />
+          </Tooltip>
+          <Tooltip title={t('Download Screenshot')}>
+            <Button
+              type="text"
+              disabled={isDisabled}
+              icon={<DownloadOutlined />}
+              id="btnDownloadElemScreenshot"
+              onClick={() => downloadElementScreenshot(selectedElementId)}
+            />
+          </Tooltip>
+        </span>
+      }
     >
       <Space className={styles.spaceContainer} direction="vertical" size="middle">
         {showSnapshotMaxDepthReachedMessage()}
@@ -254,32 +276,14 @@ const SelectedElement = (props) => {
               />
             </Tooltip>
           </Space.Compact>
-          <Space.Compact>
-            <Tooltip title={t('Copy Attributes to Clipboard')}>
-              <Button
-                disabled={isDisabled}
-                id="btnCopyAttributes"
-                icon={<CopyOutlined />}
-                onClick={() => copyToClipboard(JSON.stringify(dataSource))}
-              />
-            </Tooltip>
-            <Tooltip title={t('Download Screenshot')}>
-              <Button
-                disabled={isDisabled}
-                icon={<DownloadOutlined />}
-                id="btnDownloadElemScreenshot"
-                onClick={() => downloadElementScreenshot(selectedElementId)}
-              />
-            </Tooltip>
-            <Tooltip title={t('Get Timing')}>
-              <Button
-                disabled={isDisabled}
-                id="btnGetTiming"
-                icon={<HourglassOutlined />}
-                onClick={() => getFindElementsTimes(findDataSource)}
-              />
-            </Tooltip>
-          </Space.Compact>
+          <Tooltip title={t('Get Timing')}>
+            <Button
+              disabled={isDisabled}
+              id="btnGetTiming"
+              icon={<HourglassOutlined />}
+              onClick={() => getFindElementsTimes(findDataSource)}
+            />
+          </Tooltip>
         </Row>
         {findDataSource.length > 0 && (
           <Row className={styles.selectedElemContentRow}>

--- a/app/common/renderer/components/Inspector/Source.jsx
+++ b/app/common/renderer/components/Inspector/Source.jsx
@@ -6,9 +6,10 @@ import {
   FileTextOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
-import {Button, Card, Input, Spin, Tooltip, Tree} from 'antd';
+import {Button, Card, Input, Row, Spin, Tooltip, Tree} from 'antd';
 import {useState} from 'react';
 
+import {BUTTON, ROW} from '../../constants/antd-types';
 import {IMPORTANT_SOURCE_ATTRS} from '../../constants/source';
 import {copyToClipboard} from '../../polyfills';
 import {downloadFile} from '../../utils/file-handling';
@@ -162,14 +163,6 @@ const Source = (props) => {
       }
       extra={
         <span>
-          <Tooltip title={t('Toggle Attributes')}>
-            <Button
-              type="text"
-              id="btnToggleAttrs"
-              icon={<CodeOutlined />}
-              onClick={toggleShowAttributes}
-            />
-          </Tooltip>
           <Tooltip title={t('Copy XML Source to Clipboard')}>
             <Button
               type="text"
@@ -200,17 +193,27 @@ const Source = (props) => {
           {/* Must switch to a new antd Tree component when there's changes to treeData  */}
           {treeData ? (
             <div className={InspectorStyles['tree-wrapper']}>
-              <Input
-                placeholder={t('Search Source')}
-                onChange={onChange}
-                value={searchValue}
-                allowClear
-                className={InspectorStyles['tree-search-input']}
-                prefix={<SearchOutlined />}
-                addonAfter={
-                  <Tooltip title={t('Matching Elements')}>{matchingElements.length}</Tooltip>
-                }
-              />
+              <Row justify="center" type={ROW.FLEX} align="middle">
+                <Tooltip title={t('Toggle Attributes')}>
+                  <Button
+                    id="btnToggleAttrs"
+                    icon={<CodeOutlined />}
+                    onClick={toggleShowAttributes}
+                    type={showSourceAttrs ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+                  />
+                </Tooltip>
+                <Input
+                  placeholder={t('Search Source')}
+                  onChange={onChange}
+                  value={searchValue}
+                  allowClear
+                  className={InspectorStyles['tree-search-input']}
+                  prefix={<SearchOutlined />}
+                  addonAfter={
+                    <Tooltip title={t('Matching Elements')}>{matchingElements.length}</Tooltip>
+                  }
+                />
+              </Row>
               <Tree
                 defaultExpandAll={true}
                 showLine={true}


### PR DESCRIPTION
With the addition of the search bar in the Source panel, both the Source and the Selected Element panels now have an actions row. However, Source also had several action buttons in the panel header, while Selected Element had none.

This PR aligns the headers for both panels, so that both only contain buttons for the copy and download actions. All other buttons are moved to the actions row below the header.

Current design:
<img width="1100" height="114" alt="headers-before" src="https://github.com/user-attachments/assets/aa18284d-a7c3-42b8-b692-461fc3dff189" />

New design:
<img width="1089" height="111" alt="headers-after" src="https://github.com/user-attachments/assets/78558397-bc4b-461d-a3a8-879289c76ccd" />

