### PR TITLE
chore: add style label support to autolabeler & release notes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,10 @@ labels:
     matcher:
       title: '^feat.*?:'
 
+  - label: 'style'
+    matcher:
+      title: '^style.*?:'
+
   - label: 'fix'
     matcher:
       title: '^fix.*?:'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,6 +8,9 @@ changelog:
     - title: 🚀 New Features
       labels:
         - enhancement
+    - title: 🎨 Design Changes
+      labels:
+        - style
     - title: 🛠 Fixes
       labels:
         - fix


### PR DESCRIPTION
Since this is a GUI application, it is possible to have PRs that simply adjust the existing GUI, without any functionality changes (such as #2265). The new `style` label is meant for this exact purpose, and this PR adds handling of this label for the autolabeler and release notes generator actions.