### PR TITLE
feat: add button to collapse all Source tree nodes

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -91,6 +91,7 @@
   "Pause Recording": "Pause Recording",
   "Search for element": "Search for element",
   "App Source": "App Source",
+  "Collapse All": "Collapse All",
   "Toggle Attributes": "Toggle Attributes",
   "Copy XML Source to Clipboard": "Copy XML Source to Clipboard",
   "Download Source as .XML File": "Download Source as .XML File",

--- a/app/common/renderer/components/Inspector/Source.jsx
+++ b/app/common/renderer/components/Inspector/Source.jsx
@@ -141,8 +141,7 @@ const Source = (props) => {
     ? flatTreeData.filter((el) => elementMatchesSearch(el, searchValue))
     : [];
 
-  const expandedKeys =
-    matchingElements.length > 0 ? matchingElements.map((el) => el.path) : expandedPaths;
+  const expandedKeys = [...matchingElements.map((el) => el.path), ...expandedPaths];
 
   const onChange = (e) => {
     const {value} = e.target;

--- a/app/common/renderer/components/Inspector/Source.jsx
+++ b/app/common/renderer/components/Inspector/Source.jsx
@@ -4,9 +4,10 @@ import {
   CopyOutlined,
   DownloadOutlined,
   FileTextOutlined,
+  NodeCollapseOutlined,
   SearchOutlined,
 } from '@ant-design/icons';
-import {Button, Card, Input, Row, Spin, Tooltip, Tree} from 'antd';
+import {Button, Card, Input, Row, Space, Spin, Tooltip, Tree} from 'antd';
 import {useState} from 'react';
 
 import {BUTTON, ROW} from '../../constants/antd-types';
@@ -154,6 +155,11 @@ const Source = (props) => {
     setAutoExpandParent(false);
   };
 
+  const collapseAll = () => {
+    setExpandedPaths([]);
+    setAutoExpandParent(false);
+  };
+
   return (
     <Card
       title={
@@ -199,14 +205,23 @@ const Source = (props) => {
                 align="middle"
                 className={InspectorStyles['tree-actions']}
               >
-                <Tooltip title={t('Toggle Attributes')}>
-                  <Button
-                    id="btnToggleAttrs"
-                    icon={<CodeOutlined />}
-                    onClick={toggleShowAttributes}
-                    type={showSourceAttrs ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-                  />
-                </Tooltip>
+                <Space.Compact>
+                  <Tooltip title={t('Collapse All')}>
+                    <Button
+                      id="btnCollapseAll"
+                      icon={<NodeCollapseOutlined />}
+                      onClick={collapseAll}
+                    />
+                  </Tooltip>
+                  <Tooltip title={t('Toggle Attributes')}>
+                    <Button
+                      id="btnToggleAttrs"
+                      icon={<CodeOutlined />}
+                      onClick={toggleShowAttributes}
+                      type={showSourceAttrs ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+                    />
+                  </Tooltip>
+                </Space.Compact>
                 <Input
                   placeholder={t('Search Source')}
                   onChange={onChange}


### PR DESCRIPTION
This PR adds a new button above the Source tree, which can be used to collapse all nodes in the entire tree at once (as suggested in #766). This behavior is different from clicking on the root node's collapse button, since in that case reopening the root reinstates its children to their previously expanded state, while this new button also collapses all children nodes.

I am also including a slight adjustment for text search, which currently prevents the user from expanding any nodes by clicking on the screenshot while a search term is entered. With the fix, the expanded paths from both approaches are always combined, giving the user more flexibility.

Here is a demo for both adjustments:

https://github.com/user-attachments/assets/79acd31a-3c47-4b82-8596-e2bc6f1cfaa7

