### PR TITLE
fix: adjust width for capability set title edit field

### DIFF
--- a/app/common/renderer/components/Session/FormattedCaps.jsx
+++ b/app/common/renderer/components/Session/FormattedCaps.jsx
@@ -37,7 +37,7 @@ const FormattedCaps = (props) => {
       return title;
     } else {
       return (
-        <Row>
+        <Row className={SessionStyles.capsEditorTitle}>
           <Input
             onChange={(e) => setDesiredCapsName(e.target.value)}
             value={desiredCapsName}


### PR DESCRIPTION
Quick fix for the editor row that is shown when editing the title of a saved capability set. The current width of this row is too small, which may cause editing difficulties for longer names (my guess is this was introduced with antd 5).
This PR sets the width back to how it was with antd 4.

Before:
<img width="492" height="76" alt="before" src="https://github.com/user-attachments/assets/95cd908b-058c-45e9-84e6-cf0920434741" />

After:
<img width="498" height="81" alt="after" src="https://github.com/user-attachments/assets/0491fdbc-df97-4579-8f7b-86cf99cad4ef" />

