### PR TITLE
fix: adjust recorder for element actions

### DIFF
--- a/app/common/renderer/lib/client-frameworks/dotnet-nunit.js
+++ b/app/common/renderer/lib/client-frameworks/dotnet-nunit.js
@@ -121,15 +121,15 @@ ${this.indent(code, 8)}
     }
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.Click();`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.Clear();`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `${this.getVarName(varName, varIndex)}.SendKeys(${JSON.stringify(text)});`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/java-common.js
+++ b/app/common/renderer/lib/client-frameworks/java-common.js
@@ -88,15 +88,15 @@ export default class JavaFramework extends CommonClientFramework {
     return varName;
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.click();`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.clear();`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `${this.getVarName(varName, varIndex)}.sendKeys(${JSON.stringify(text)});`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/js-oxygen.js
+++ b/app/common/renderer/lib/client-frameworks/js-oxygen.js
@@ -56,15 +56,15 @@ ${code}`;
     }
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `${this.type}.click(${this.getVarName(varName, varIndex)});`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `${this.type}.clear(${this.getVarName(varName, varIndex)});`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `${this.type}.type(${this.getVarName(varName, varIndex)}, ${JSON.stringify(text)});`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/common/renderer/lib/client-frameworks/js-wdio.js
@@ -55,15 +55,15 @@ main().catch(console.log);`;
     }
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `await ${this.getVarName(varName, varIndex)}.click();`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `await ${this.getVarName(varName, varIndex)}.clearValue();`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `await ${this.getVarName(varName, varIndex)}.addValue(${JSON.stringify(text)});`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/python.js
+++ b/app/common/renderer/lib/client-frameworks/python.js
@@ -83,15 +83,15 @@ driver.quit()`;
     }
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.click()`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.clear()`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `${this.getVarName(varName, varIndex)}.send_keys(${JSON.stringify(text)})`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/robot.js
+++ b/app/common/renderer/lib/client-frameworks/robot.js
@@ -61,15 +61,15 @@ ${this.indent(code, 4)}
     return `$\{${localVar}} =    Set Variable     ${suffixMap[strategy]}=${locator}`;
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `Click Element    $\{${this.getVarName(varName, varIndex)}}`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `Clear Text    $\{${this.getVarName(varName, varIndex)}}`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `Input Text    $\{${this.getVarName(varName, varIndex)}}    ${text}`;
   }
 

--- a/app/common/renderer/lib/client-frameworks/ruby.js
+++ b/app/common/renderer/lib/client-frameworks/ruby.js
@@ -69,15 +69,15 @@ driver.quit`;
     }
   }
 
-  codeFor_click(varName, varIndex) {
+  codeFor_elementClick(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.click`;
   }
 
-  codeFor_clear(varName, varIndex) {
+  codeFor_elementClear(varName, varIndex) {
     return `${this.getVarName(varName, varIndex)}.clear`;
   }
 
-  codeFor_sendKeys(varName, varIndex, text) {
+  codeFor_elementSendKeys(varName, varIndex, text) {
     return `${this.getVarName(varName, varIndex)}.send_keys ${JSON.stringify(text)}`;
   }
 


### PR DESCRIPTION
There was a regression in 2025.7.2 - the code recorder was no longer recording element actions like click, send keys, and clear. This was due to the methods responsible for generating that code not being renamed from their Web2Driver names to their WDIO names.