### PR TITLE
fix: adjust screenshot container size for small resolution DUTs

### DIFF
--- a/app/common/renderer/components/Inspector/Inspector.jsx
+++ b/app/common/renderer/components/Inspector/Inspector.jsx
@@ -97,7 +97,8 @@ const Inspector = (props) => {
       const attemptedImgWidth = (containerRect.height / imgRect.height) * imgRect.width;
       // get the maximum image width as a fraction of the current window width
       const maxImgWidth = window.innerWidth * WINDOW_DIMENSIONS.MAX_IMAGE_WIDTH_FRACTION;
-      const curMaxImgWidth = Math.min(maxImgWidth, attemptedImgWidth);
+      // make sure not to exceed both the maximum allowed width and the full screenshot width
+      const curMaxImgWidth = Math.min(maxImgWidth, attemptedImgWidth, windowSize.width);
       screenshotContainer.style.maxWidth = `${curMaxImgWidth}px`;
     } else if (imgRect.width < containerRect.width) {
       screenshotContainer.style.maxWidth = `${imgRect.width}px`;


### PR DESCRIPTION
I was experimenting with an Android Wear device and observed an issue with screenshot scaling, which resulted in a lot of empty space. This was due to the watch's screen resolution: its display height was smaller than that of the Inspector's screenshot container, and this case was not accounted for. This is a simple fix for the issue.

Before the fix:
<img width="1600" height="800" alt="inspector-before" src="https://github.com/user-attachments/assets/b7353b2d-ae57-4e89-b4b3-2361c5c0eb31" />

After the fix:
<img width="1600" height="800" alt="inspector-after" src="https://github.com/user-attachments/assets/1cdcd85b-759e-4cef-a801-3c70455fd719" />
