### PR TITLE
fix: adjust plugin version Express paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 dist-browser
 release
 site
+plugins/package-lock.json
 main.map
 
 *.log

--- a/plugins/index.mjs
+++ b/plugins/index.mjs
@@ -39,6 +39,6 @@ export class AppiumInspectorPlugin extends BasePlugin {
    */
   static async updateServer(expressApp) {
     // Handle both /inspector and /inspector/* paths
-    expressApp.all(['/inspector', '/inspector/*'], AppiumInspectorPlugin.openInspector);
+    expressApp.all(['/inspector', '/inspector/*all'], AppiumInspectorPlugin.openInspector);
   }
 }


### PR DESCRIPTION
I missed the fact that the plugin version had to be adjusted for Express 5, similarly to https://github.com/appium/appium/pull/20789.
Tested this locally and it works fine.
Fixes #2284