### PR TITLE
docs: update minimum macOS version

### DIFF
--- a/docs/quickstart/requirements.md
+++ b/docs/quickstart/requirements.md
@@ -9,7 +9,7 @@ Since the Inspector is released in [3 versions](../overview.md#formats), the req
 will differ:
 
 - Desktop app
-    - Works on Windows 10+, macOS 11+, Ubuntu 18.04+, Debian 10+, openSUSE 15.5+, or Fedora Linux 39+
+    - Works on Windows 10+, macOS 12+, Ubuntu 18.04+, Debian 10+, openSUSE 15.5+, or Fedora Linux 39+
         - [These requirements are taken from Chrome](https://support.google.com/chrome/a/answer/7100626),
           as the Inspector is built using Electron (which uses Chromium)
     - Up to around **600MB** of free space is required


### PR DESCRIPTION
Electron 38 updates to Chromium 140, and Chromium has dropped support for macOS 11 as of version 139.