### PR TITLE
chore: add js/jsx extensions to all imported files

### DIFF
--- a/app/common/renderer/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,6 +1,6 @@
 import {Component} from 'react';
 
-import {copyToClipboard} from '../../polyfills';
+import {copyToClipboard} from '../../polyfills.js';
 import ErrorMessage from './ErrorMessage.jsx';
 
 const copyTrace = (trace) => {

--- a/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
@@ -1,10 +1,10 @@
 import {CopyOutlined} from '@ant-design/icons';
 import {Alert, Button, Tooltip} from 'antd';
 
-import {ALERT} from '../../constants/antd-types';
-import {LINKS} from '../../constants/common';
-import {withTranslation} from '../../i18next';
-import {openLink} from '../../polyfills';
+import {ALERT} from '../../constants/antd-types.js';
+import {LINKS} from '../../constants/common.js';
+import {withTranslation} from '../../i18next.js';
+import {openLink} from '../../polyfills.js';
 import styles from './ErrorMessage.module.css';
 
 const ErrorMessage = ({error, copyTrace, t}) => (

--- a/app/common/renderer/components/Notification.jsx
+++ b/app/common/renderer/components/Notification.jsx
@@ -1,7 +1,7 @@
 import {App} from 'antd';
 import {useEffect} from 'react';
 
-import {NOTIFICATION_EVENT} from '../utils/notification';
+import {NOTIFICATION_EVENT} from '../utils/notification.js';
 
 export default function Notification() {
   const {notification} = App.useApp();

--- a/app/common/renderer/hooks/use-theme.jsx
+++ b/app/common/renderer/hooks/use-theme.jsx
@@ -1,5 +1,5 @@
 import {useContext} from 'react';
 
-import {ThemeContext} from '../providers/ThemeProvider';
+import {ThemeContext} from '../providers/ThemeProvider.jsx';
 
 export const useTheme = () => useContext(ThemeContext);

--- a/app/common/renderer/i18next.js
+++ b/app/common/renderer/i18next.js
@@ -2,9 +2,9 @@ import i18n from 'i18next';
 import _ from 'lodash';
 import {initReactI18next, withTranslation as wt} from 'react-i18next';
 
-import {commonI18NextOptions} from '../shared/i18next.config';
-import {PREFERRED_LANGUAGE} from '../shared/setting-defs';
-import {getSetting, i18NextBackend, i18NextBackendOptions} from './polyfills';
+import {commonI18NextOptions} from '../shared/i18next.config.js';
+import {PREFERRED_LANGUAGE} from '../shared/setting-defs.js';
+import {getSetting, i18NextBackend, i18NextBackendOptions} from './polyfills.js';
 
 const i18nextOptions = {
   ...commonI18NextOptions,

--- a/app/common/renderer/polyfills.js
+++ b/app/common/renderer/polyfills.js
@@ -6,7 +6,7 @@
 
 import {settings} from '#local-polyfills'; // eslint-disable-line import/no-unresolved
 
-import {DEFAULT_SETTINGS} from '../shared/setting-defs';
+import {DEFAULT_SETTINGS} from '../shared/setting-defs.js';
 
 export async function getSetting(setting) {
   if (await settings.has(setting)) {

--- a/app/common/renderer/providers/ThemeProvider.jsx
+++ b/app/common/renderer/providers/ThemeProvider.jsx
@@ -1,10 +1,10 @@
 import {App, ConfigProvider, Layout, theme} from 'antd';
 import {createContext, useEffect, useState} from 'react';
 
-import {PREFERRED_THEME} from '../../shared/setting-defs';
-import Notification from '../components/Notification';
-import {getSetting, setSetting, setTheme} from '../polyfills';
-import {loadHighlightTheme} from '../utils/highlight-theme';
+import {PREFERRED_THEME} from '../../shared/setting-defs.js';
+import Notification from '../components/Notification.jsx';
+import {getSetting, setSetting, setTheme} from '../polyfills.js';
+import {loadHighlightTheme} from '../utils/highlight-theme.js';
 
 const systemPrefersDarkTheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
 

--- a/app/common/renderer/store.js
+++ b/app/common/renderer/store.js
@@ -1,7 +1,7 @@
 import {configureStore} from '@reduxjs/toolkit';
 
-import actions from './actions';
-import createRootReducer from './reducers';
+import actions from './actions/index.js';
+import createRootReducer from './reducers/index.js';
 
 const store = configureStore({
   reducer: createRootReducer(),

--- a/app/common/renderer/utils/attaching-to-session.js
+++ b/app/common/renderer/utils/attaching-to-session.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import _ from 'lodash';
 
-import {SERVER_TYPES} from '../constants/session-builder';
+import {SERVER_TYPES} from '../constants/session-builder.js';
 
 class DefaultSessionDescription {
   constructor(caps) {

--- a/app/common/renderer/utils/file-handling.js
+++ b/app/common/renderer/utils/file-handling.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import {CAPABILITY_TYPES, SERVER_TYPES} from '../constants/session-builder';
+import {CAPABILITY_TYPES, SERVER_TYPES} from '../constants/session-builder.js';
 
 export function downloadFile(href, filename) {
   let element = document.createElement('a');

--- a/app/common/renderer/utils/locator-generation.js
+++ b/app/common/renderer/utils/locator-generation.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import XPath, {select as xpathSelect} from 'xpath';
 
-import {log} from './logger';
-import {childNodesOf, domToXML, findDOMNodeByPath, xmlToDOM} from './source-parsing';
+import {log} from './logger.js';
+import {childNodesOf, domToXML, findDOMNodeByPath, xmlToDOM} from './source-parsing.js';
 
 // Attributes on nodes that are likely to be unique to the node so we should consider first when
 // suggesting xpath locators. These are considered IN ORDER.

--- a/app/common/renderer/utils/other.js
+++ b/app/common/renderer/utils/other.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-import {STANDARD_W3C_CAPS} from '../constants/session-builder';
+import {STANDARD_W3C_CAPS} from '../constants/session-builder.js';
 
 export function addVendorPrefixes(caps) {
   return caps.map((cap) => {

--- a/app/common/shared/setting-defs.js
+++ b/app/common/shared/setting-defs.js
@@ -1,6 +1,6 @@
 // Definitions for all the persistent settings used in the app
 
-import {fallbackLng} from './i18next.config';
+import {fallbackLng} from './i18next.config.js';
 
 export const PREFERRED_LANGUAGE = 'PREFERRED_LANGUAGE';
 export const PREFERRED_THEME = 'PREFERRED_THEME';

--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -2,7 +2,7 @@ import {clipboard, ipcMain, nativeTheme, shell} from 'electron';
 import settings from 'electron-settings';
 import fs from 'fs';
 
-import i18n from './i18next';
+import i18n from './i18next.js';
 
 export const isDev = process.env.NODE_ENV === 'development';
 

--- a/app/electron/main/i18next.js
+++ b/app/electron/main/i18next.js
@@ -3,8 +3,8 @@ import i18n from 'i18next';
 import i18NextBackend from 'i18next-fs-backend';
 import {join} from 'path';
 
-import {commonI18NextOptions, fallbackLng} from '../../common/shared/i18next.config';
-import {PREFERRED_LANGUAGE} from '../../common/shared/setting-defs';
+import {commonI18NextOptions, fallbackLng} from '../../common/shared/i18next.config.js';
+import {PREFERRED_LANGUAGE} from '../../common/shared/setting-defs.js';
 
 const localesPath =
   process.env.NODE_ENV === 'development'

--- a/app/electron/main/main.js
+++ b/app/electron/main/main.js
@@ -1,9 +1,9 @@
 import {app} from 'electron';
 import debug from 'electron-debug';
 
-import {installExtensions} from './debug';
-import {isDev, setupIPCListeners} from './helpers';
-import {setupMainWindow} from './windows';
+import {installExtensions} from './debug.js';
+import {isDev, setupIPCListeners} from './helpers.js';
+import {setupMainWindow} from './windows.js';
 
 // Used when opening Inspector through an .appiumsession file (Windows/Linux).
 // This value is not set in dev mode, since accessing argv[1] there throws an error,

--- a/app/electron/main/menus.js
+++ b/app/electron/main/menus.js
@@ -1,10 +1,10 @@
 import {app, dialog, Menu, shell} from 'electron';
 
-import {languageList} from '../../common/shared/i18next.config';
-import {APPIUM_SESSION_EXTENSION, isDev, openSessionFile, t} from './helpers';
-import i18n from './i18next';
-import {checkForUpdates} from './updater';
-import {launchNewSessionWindow} from './windows';
+import {languageList} from '../../common/shared/i18next.config.js';
+import {APPIUM_SESSION_EXTENSION, isDev, openSessionFile, t} from './helpers.js';
+import i18n from './i18next.js';
+import {checkForUpdates} from './updater.js';
+import {launchNewSessionWindow} from './windows.js';
 
 const INSPECTOR_DOCS_URL = 'https://appium.github.io/appium-inspector';
 const APPIUM_DOCS_URL = 'https://appium.io';

--- a/app/electron/main/updater.js
+++ b/app/electron/main/updater.js
@@ -3,7 +3,7 @@ import pkg from 'electron-updater';
 // eslint-disable-next-line import/no-named-as-default-member -- module is CJS
 const {autoUpdater} = pkg;
 
-import {t} from './helpers';
+import {t} from './helpers.js';
 
 const RELEASES_LINK = 'https://github.com/appium/appium-inspector/releases';
 

--- a/app/electron/main/windows.js
+++ b/app/electron/main/windows.js
@@ -2,11 +2,11 @@ import {BrowserWindow, Menu, nativeTheme, webContents} from 'electron';
 import settings from 'electron-settings';
 import {join} from 'path';
 
-import {PREFERRED_LANGUAGE, PREFERRED_THEME} from '../../common/shared/setting-defs';
-import {isDev} from './helpers';
-import i18n from './i18next';
-import {openFilePath} from './main';
-import {rebuildMenus} from './menus';
+import {PREFERRED_LANGUAGE, PREFERRED_THEME} from '../../common/shared/setting-defs.js';
+import {isDev} from './helpers.js';
+import i18n from './i18next.js';
+import {openFilePath} from './main.js';
+import {rebuildMenus} from './menus.js';
 
 const mainPath = isDev
   ? process.env.ELECTRON_RENDERER_URL

--- a/test/e2e/inspector-e2e.test.js
+++ b/test/e2e/inspector-e2e.test.js
@@ -3,7 +3,7 @@ import {retryInterval} from 'asyncbox';
 import path from 'path';
 import {expect} from 'vitest';
 
-import InspectorPage from './pages/inspector-page-object';
+import InspectorPage from './pages/inspector-page-object.js';
 
 const FAKE_DRIVER_PORT = 12121;
 

--- a/test/e2e/pages/inspector-page-object.js
+++ b/test/e2e/pages/inspector-page-object.js
@@ -1,8 +1,8 @@
 import {retryInterval} from 'asyncbox';
 import _ from 'lodash';
 
-import BasePage from './base-page-object';
-import {setValueReact} from './utils';
+import BasePage from './base-page-object.js';
+import {setValueReact} from './utils.js';
 
 export default class InspectorPage extends BasePage {
   constructor(client) {

--- a/test/unit/utils-attaching-to-session.spec.js
+++ b/test/unit/utils-attaching-to-session.spec.js
@@ -1,10 +1,10 @@
 import {describe, expect, it} from 'vitest';
 
-import {SERVER_TYPES} from '../../app/common/renderer/constants/session-builder';
+import {SERVER_TYPES} from '../../app/common/renderer/constants/session-builder.js';
 import {
   formatSeleniumGridSessions,
   getSessionInfo,
-} from '../../app/common/renderer/utils/attaching-to-session';
+} from '../../app/common/renderer/utils/attaching-to-session.js';
 
 describe('utils/attaching-to-session.js', function () {
   describe('#getSessionInfo', function () {

--- a/test/unit/utils-file-handling.spec.js
+++ b/test/unit/utils-file-handling.spec.js
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {parseSessionFileContents} from '../../app/common/renderer/utils/file-handling';
+import {parseSessionFileContents} from '../../app/common/renderer/utils/file-handling.js';
 
 describe('utils/file-handling.js', function () {
   describe('#parseSessionFileContents', function () {

--- a/test/unit/utils-locator-generation.spec.js
+++ b/test/unit/utils-locator-generation.spec.js
@@ -8,8 +8,8 @@ import {
   getOptimalUiAutomatorSelector,
   getOptimalXPath,
   getSimpleSuggestedLocators,
-} from '../../app/common/renderer/utils/locator-generation';
-import {xmlToDOM} from '../../app/common/renderer/utils/source-parsing';
+} from '../../app/common/renderer/utils/locator-generation.js';
+import {xmlToDOM} from '../../app/common/renderer/utils/source-parsing.js';
 
 // Helper that checks that the optimal xpath for a node is the one that we expect and also
 // checks that the XPath successfully locates the node in it's doc

--- a/test/unit/utils-other.spec.js
+++ b/test/unit/utils-other.spec.js
@@ -1,6 +1,6 @@
 import {describe, expect, it} from 'vitest';
 
-import {addVendorPrefixes} from '../../app/common/renderer/utils/other';
+import {addVendorPrefixes} from '../../app/common/renderer/utils/other.js';
 
 describe('utils/other.js', function () {
   describe('#addVendorPrefixes', function () {

--- a/test/unit/utils-source-parsing.spec.js
+++ b/test/unit/utils-source-parsing.spec.js
@@ -5,7 +5,7 @@ import {
   findJSONElementByPath,
   xmlToDOM,
   xmlToJSON,
-} from '../../app/common/renderer/utils/source-parsing';
+} from '../../app/common/renderer/utils/source-parsing.js';
 
 describe('utils/source-parsing.js', function () {
   describe('#findDOMNodeByPath', function () {

--- a/test/unit/utils-webview.spec.js
+++ b/test/unit/utils-webview.spec.js
@@ -2,7 +2,7 @@ import {promises as fs} from 'fs';
 import {join} from 'path';
 import {describe, expect, it} from 'vitest';
 
-import {parseHtmlSource} from '../../app/common/renderer/utils/webview';
+import {parseHtmlSource} from '../../app/common/renderer/utils/webview.js';
 
 describe('webview-helpers.js', function () {
   describe('#parseHtmlSource', function () {


### PR DESCRIPTION
Some file imports were missing the `.js`/`.jsx` extension, which prevented VS Code IntelliSense from working properly.