### PR TITLE
feat: Improve Appium Inspector stability by handling USB/Wifi disconnection gracefully

### DIFF
--- a/app/common/renderer/lib/appium/inspector-driver.js
+++ b/app/common/renderer/lib/appium/inspector-driver.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 
+import {quitSession} from '../../actions/SessionInspector.js';
 import {SCREENSHOT_INTERACTION_MODE} from '../../constants/screenshot.js';
 import {APP_MODE, NATIVE_APP, REFRESH_DELAY_MILLIS} from '../../constants/session-inspector.js';
 import {log} from '../../utils/logger.js';
@@ -395,6 +396,8 @@ export default class InspectorDriver {
       const screenshot = await this.driver.takeScreenshot();
       return {screenshot};
     } catch (err) {
+      const quitSes = quitSession('Window closed');
+      await quitSes();
       return {screenshotError: err};
     }
   }


### PR DESCRIPTION
Resolved session issue because the connection was lost.
When using Appium Inspector, we observed an issue where the inspector stops working if the Debugger connection is lost after a session has started. In order to continue inspecting and interacting with other pages, users previously had to quit the session, re-enter all capabilities, and start a new session. This process was both time-consuming and inconvenient.

This PR introduces a fix to handle session loss more seamlessly. Now, whenever a USB/Wifi disconnection occurs, the old session is automatically quit, and the page source is refreshed. This allows users to continue their workflow without needing to exit the inspector window or manually reconfigure the session.

With this improvement, users can enjoy a smoother and more efficient experience when working with Appium Inspector 