### PR TITLE
chore: run npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -449,31 +449,31 @@
       }
     },
     "node_modules/@appium/base-driver": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-10.0.1.tgz",
-      "integrity": "sha512-5E/vsVY/6yzj6/M51JO+Qzr9/03KlgHqSPwm+46bV4qGMgBSe0kKRvUea5Vjva8Bwy/Bl60gZEA1ZkAWSjkBIA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@appium/base-driver/-/base-driver-10.1.0.tgz",
+      "integrity": "sha512-5xBeoBUZSN/YjONGqj4u1jy0pxymset3gXiRkfYWnricdvcQ5t5tY9jzzgzuo78dzlFvFhE3YoHMDAyDJ++ibw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/support": "^7.0.1",
-        "@appium/types": "^1.0.1",
+        "@appium/support": "^7.0.2",
+        "@appium/types": "^1.1.0",
         "@colors/colors": "1.6.0",
         "async-lock": "1.4.1",
         "asyncbox": "3.0.0",
-        "axios": "1.11.0",
+        "axios": "1.12.2",
         "bluebird": "3.7.2",
         "body-parser": "2.2.0",
         "express": "5.1.0",
         "fastest-levenshtein": "1.0.16",
         "http-status-codes": "2.3.0",
         "lodash": "4.17.21",
-        "lru-cache": "11.2.1",
+        "lru-cache": "11.2.2",
         "method-override": "3.0.0",
         "morgan": "1.10.1",
         "path-to-regexp": "8.3.0",
         "serve-favicon": "2.5.1",
         "source-map-support": "0.5.21",
-        "type-fest": "4.41.0"
+        "type-fest": "5.0.1"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -481,18 +481,6 @@
       },
       "optionalDependencies": {
         "spdy": "4.0.2"
-      }
-    },
-    "node_modules/@appium/base-driver/node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@appium/base-driver/node_modules/path-to-regexp": {
@@ -507,14 +495,14 @@
       }
     },
     "node_modules/@appium/base-plugin": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-3.0.2.tgz",
-      "integrity": "sha512-IERIaEDitViUODdECbBYKFLnrGZ71+TXsXkxkXyiE/iyxRDisLOnieFG8CHIm/DttzmKS3Noys7/KUobEBUOKg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@appium/base-plugin/-/base-plugin-3.0.3.tgz",
+      "integrity": "sha512-so4Erl9nNbAmNujQ4u9W4HfeCN8nbf824tlYzpDUTMSkt3FPhs7Wzf9pwa5nbRwufRNDU2CWxa4GMLrYip1ccg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@appium/base-driver": "^10.0.1",
-        "@appium/support": "^7.0.1"
+        "@appium/base-driver": "^10.1.0",
+        "@appium/support": "^7.0.2"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
@@ -549,22 +537,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@appium/docutils/node_modules/type-fest": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
-      "integrity": "sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@appium/eslint-config-appium-ts": {
@@ -628,16 +600,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@appium/logger/node_modules/lru-cache": {
-      "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/@appium/schema": {
@@ -706,35 +668,6 @@
         "sharp": "0.34.4"
       }
     },
-    "node_modules/@appium/support/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@appium/support/node_modules/type-fest": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
-      "integrity": "sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@appium/tsconfig": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@appium/tsconfig/-/tsconfig-1.1.0.tgz",
@@ -764,22 +697,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/@appium/types/node_modules/type-fest": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
-      "integrity": "sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "dependencies": {
-        "tagged-tag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -4152,56 +4069,6 @@
         "text-hex": "1.0.x"
       }
     },
-    "node_modules/@so-ric/colorspace/node_modules/color": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
-      "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^3.0.1",
-        "color-string": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-convert": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
-      "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-name": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
-      "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
-      }
-    },
-    "node_modules/@so-ric/colorspace/node_modules/color-string": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
-      "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -5728,39 +5595,40 @@
       }
     },
     "node_modules/appium": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/appium/-/appium-3.0.2.tgz",
-      "integrity": "sha512-5QayeF7R+bGbLuP4E3SV9aGSdB2tVXDwBO7bp3J/TzZ4r5xeNrnp33dv/sGJR8t7AlWkSmsr8L+AVGilouV3Yg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/appium/-/appium-3.1.0.tgz",
+      "integrity": "sha512-1j/Yr7KuqdPNPL6t6QxbBBntMGsTpp7bGrOz5hbnwFv6facOg1eApwrfQRFz5WPWrREF91AjiIIuQsfFMDZCZg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "@appium/base-driver": "^10.0.1",
-        "@appium/base-plugin": "^3.0.2",
-        "@appium/docutils": "^2.1.0",
-        "@appium/logger": "^2.0.1",
+        "@appium/base-driver": "^10.1.0",
+        "@appium/base-plugin": "^3.0.3",
+        "@appium/docutils": "^2.1.1",
+        "@appium/logger": "^2.0.2",
         "@appium/schema": "^1.0.0",
-        "@appium/support": "^7.0.1",
-        "@appium/types": "^1.0.1",
+        "@appium/support": "^7.0.2",
+        "@appium/types": "^1.1.0",
         "@sidvind/better-ajv-errors": "4.0.0",
         "ajv": "8.17.1",
         "ajv-formats": "3.0.1",
         "argparse": "2.0.1",
         "async-lock": "1.4.1",
         "asyncbox": "3.0.0",
-        "axios": "1.11.0",
+        "axios": "1.12.2",
         "bluebird": "3.7.2",
         "lilconfig": "3.1.3",
         "lodash": "4.17.21",
-        "lru-cache": "11.2.1",
+        "lru-cache": "11.2.2",
         "ora": "5.4.1",
         "package-changed": "3.0.0",
         "resolve-from": "5.0.0",
-        "semver": "7.7.2",
+        "semver": "7.7.3",
         "source-map-support": "0.5.21",
         "teen_process": "3.0.1",
-        "type-fest": "4.41.0",
-        "winston": "3.17.0",
+        "type-fest": "5.0.1",
+        "winston": "3.18.3",
         "wrap-ansi": "7.0.0",
         "ws": "8.18.3",
         "yaml": "2.8.1"
@@ -5771,18 +5639,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": ">=10"
-      }
-    },
-    "node_modules/appium/node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/archiver": {
@@ -7234,6 +7090,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.2.tgz",
+      "integrity": "sha512-e2hz5BzbUPcYlIRHo8ieAhYgoajrJr+hWoceg6E345TPsATMUKqDgzt8fSXZJJbxfpiPzkWyphz8yn8At7q3fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.0.1",
+        "color-string": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -7251,6 +7121,52 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.2.tgz",
+      "integrity": "sha512-RxmjYxbWemV9gKu4zPgiZagUxbH3RQpEIO77XoSSX0ivgABDZ+h8Zuash/EMFLTI4N9QgFPOJ6JQpPZKFxa+dA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+      "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.2.tgz",
+      "integrity": "sha512-UNqkvCDXstVck3kdowtOTWROIJQwafjOfXSmddoDrXo4cewMKmusCeF22Q24zvjR8nwWib/3S/dfyzPItPEiJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.2.tgz",
+      "integrity": "sha512-9vEt7gE16EW7Eu7pvZnR0abW9z6ufzhXxGXZEVU9IqPdlsUiMwJeJfRtq0zePUmnbHGT9zajca7mX8zgoayo4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -12386,9 +12302,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
-      "integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -15601,9 +15517,9 @@
       "optional": true
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17157,13 +17073,16 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.0.1.tgz",
+      "integrity": "sha512-9MpwAI52m8H6ssA542UxSLnSiSD2dsC3/L85g6hVubLSXd82wdI80eZwTWhdOfN67NlA+D+oipAs1MlcTcu3KA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -18036,14 +17955,14 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
-      "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.18.3.tgz",
+      "integrity": "sha512-NoBZauFNNWENgsnC9YpgyYwOVrl2m58PpQ8lNHjV3kosGs7KJ7Npk9pCUE+WJlawVSe8mykWDKWFSVfs3QO9ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@colors/colors": "^1.6.0",
-        "@dabh/diagnostics": "^2.0.2",
+        "@dabh/diagnostics": "^2.0.8",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
         "logform": "^2.7.0",


### PR DESCRIPTION
This updates the lockfile after running `npm audit fix`, which removes the vulnerable `axios` versions. Nearly all changes here are for dev-only dependencies, with the exception of `semver` `7.7.2` -> `7.7.3`, so it should be safe to merge.