### PR TITLE
fix: compatibility between new vendors and older capability sets

### DIFF
--- a/app/common/renderer/reducers/SessionBuilder.js
+++ b/app/common/renderer/reducers/SessionBuilder.js
@@ -130,7 +130,7 @@ export default function builder(state = INITIAL_STATE, action) {
         ...state,
         server: {
           ...state.server,
-          [action.serverType]: action.server[action.serverType],
+          [action.serverType]: action.server[action.serverType] ?? {},
         },
         serverType: action.serverType,
         caps: action.caps.map((cap) => ({


### PR DESCRIPTION
Noticed an issue related to new cloud provider vendors:
* Use Inspector version A that does not yet have support for cloud provider X
* Create and save any capability set
* Update to Inspector version B that _does_ have support for provider X
* Select vendor X as a visible provider
* Click on the tab for vendor X, then on the saved capability set (or vice versa) -> error

The cause was in the code for selecting the active capability set, as it was overriding _all_ server details with those from the capability set, and if the set was created on an older Inspector version, it would not have the server property for provider X, which caused it to be deleted.
With this fix, the code now only overrides details for the server matching the one used in the selected capability set, leaving all others unchanged.