### PR TITLE
style: reduce empty space for gesture editor tick cards

### DIFF
--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
@@ -548,17 +548,17 @@ const GestureEditor = (props) => {
 
   const tickButton = (tick) => (
     <center>
-      <Space.Compact className={styles.tickButtonGroup}>
+      <Space.Compact block>
         <Button
+          block
           type={tick.button === POINTER_DOWN_BTNS.LEFT ? 'primary' : 'default'}
-          className={styles.tickButtonInput}
           onClick={() => updateTick(tick, TICK_PROPS.BUTTON, POINTER_DOWN_BTNS.LEFT)}
         >
           {t('Left')}
         </Button>
         <Button
+          block
           type={tick.button === POINTER_DOWN_BTNS.RIGHT ? 'primary' : 'default'}
-          className={styles.tickButtonInput}
           onClick={() => updateTick(tick, TICK_PROPS.BUTTON, POINTER_DOWN_BTNS.RIGHT)}
         >
           {t('Right')}
@@ -569,35 +569,37 @@ const GestureEditor = (props) => {
 
   const tickDuration = (tick) => (
     <center>
-      <Input
-        className={styles.tickInputBox}
-        value={!isNaN(tick.duration) ? tick.duration : null}
-        placeholder={t('Duration')}
-        defaultValue={tick.duration}
-        onChange={(e) => updateTick(tick, TICK_PROPS.DURATION, e.target.value)}
-        addonAfter="ms"
-      />
+      <Space.Compact block>
+        <Input
+          className={styles.tickInputBox}
+          value={!isNaN(tick.duration) ? tick.duration : null}
+          placeholder={t('Duration')}
+          defaultValue={tick.duration}
+          onChange={(e) => updateTick(tick, TICK_PROPS.DURATION, e.target.value)}
+        />
+        <Space.Addon className={styles.tickDurationAddonText}>ms</Space.Addon>
+      </Space.Compact>
     </center>
   );
 
   const tickCoords = (tick) => (
     <center>
-      <div className={styles.tickInputBox}>
+      <Space.Compact block>
         <Input
-          className={styles.tickCoordBox}
+          className={styles.tickInputBox}
           value={!isNaN(tick.x) ? tick.x : ''}
           placeholder="X"
           defaultValue={tick.x}
           onChange={(e) => updateTick(tick, TICK_PROPS.X, e.target.value)}
         />
         <Input
-          className={styles.tickCoordBox}
+          className={styles.tickInputBox}
           value={!isNaN(tick.y) ? tick.y : ''}
           placeholder="Y"
           defaultValue={tick.y}
           onChange={(e) => updateTick(tick, TICK_PROPS.Y, e.target.value)}
         />
-      </div>
+      </Space.Compact>
     </center>
   );
 
@@ -674,17 +676,11 @@ const GestureEditor = (props) => {
         </Col>
       ))}
       <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
-        <Card className={styles.tickPlusCard} variant="borderless">
-          <center>
-            <Tooltip title={t('Add')}>
-              <Button
-                className={styles.tickPlusBtn}
-                icon={<PlusOutlined />}
-                onClick={() => addTick(pointer.id)}
-              />
-            </Tooltip>
-          </center>
-        </Card>
+        <div className={styles.tickPlusBtnWrapper}>
+          <Tooltip title={t('Add')}>
+            <Button icon={<PlusOutlined />} onClick={() => addTick(pointer.id)} />
+          </Tooltip>
+        </div>
       </Col>
     </Row>
   );

--- a/app/common/renderer/components/SessionInspector/GesturesTab/Gestures.module.css
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/Gestures.module.css
@@ -55,59 +55,41 @@
   background-color: var(--timelineColor);
 }
 
-.tickButtonGroup {
-  display: block;
-}
-
-.tickButtonInput {
-  width: 73px;
+.tickDurationAddonText {
+  width: 40px;
+  padding: 0 6px;
 }
 
 .tickInputBox {
-  width: 145px;
-}
-
-.tickInputBox :global(.ant-input-group-addon) {
-  position: sticky;
-  width: 50px;
-}
-
-.tickCoordBox {
-  width: 72px;
+  display: block;
   text-align: center;
 }
 
 .tickPointerInput {
-  width: 145px;
+  width: 100%;
 }
 
 .optionInput {
   text-align: center;
 }
 
-.tickCard {
-  overflow: hidden;
-}
-
 .tickCard :global(.ant-card-head) {
-  margin-top: -16px;
-  padding-right: 0px;
+  min-height: unset;
+  padding: 0px;
   border-bottom: none;
 }
 
 .tickCard :global(.ant-card-body) {
-  margin-top: -12px;
-  min-height: 167px;
-  margin-right: -12px;
+  padding-top: 6px;
+  height: calc(100% - 25px);
 }
 
-.tickPlusCard {
-  min-height: 220px;
-}
-
-.tickPlusBtn {
-  position: absolute;
-  top: 40%;
+.tickPlusBtnWrapper {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
 .pointerTitle {


### PR DESCRIPTION
Slight adjustment for the styling of gesture tick cards in the gesture editor:
* Reduced padding for card contents
* Reduced empty space at the bottom of the card (height now adjusts depending on card content)
* Ensure all numerical values are centered
* More accurate centering of the new tick button
* Replace usage of deprecated `addonAfter`

Before:
<img width="1340" height="323" alt="gesture-cards-old" src="https://github.com/user-attachments/assets/7a0a5966-071d-4c08-8e19-959ffa19e460" />
After:
<img width="1342" height="326" alt="gesture-cards-new" src="https://github.com/user-attachments/assets/9611d533-0fdd-4748-a673-95c93f1f1509" />
