### PR TITLE
chore: fix React 19 lint warnings

### DIFF
--- a/app/common/renderer/hooks/use-theme.jsx
+++ b/app/common/renderer/hooks/use-theme.jsx
@@ -1,5 +1,5 @@
-import {useContext} from 'react';
+import {use} from 'react';
 
 import {ThemeContext} from '../providers/ThemeProvider.jsx';
 
-export const useTheme = () => useContext(ThemeContext);
+export const useTheme = () => use(ThemeContext);

--- a/app/common/renderer/providers/ThemeProvider.jsx
+++ b/app/common/renderer/providers/ThemeProvider.jsx
@@ -60,13 +60,13 @@ export const ThemeProvider = ({children}) => {
   };
 
   return (
-    <ThemeContext.Provider value={{updateTheme, preferredTheme, isDarkTheme}}>
+    <ThemeContext value={{updateTheme, preferredTheme, isDarkTheme}}>
       <ConfigProvider theme={themeConfig}>
         <App>
           <Layout>{children}</Layout>
           <Notification />
         </App>
       </ConfigProvider>
-    </ThemeContext.Provider>
+    </ThemeContext>
   );
 };


### PR DESCRIPTION
Noticed 2 new lint warnings from `@eslint-react` after upgrading to React 19:
* [`no-context-provider`](https://www.eslint-react.xyz/docs/rules/no-context-provider)
* [`no-use-context`](https://www.eslint-react.xyz/docs/rules/no-use-context)

This PR fixes both warnings.