### PR TITLE
fix: unhide cloud provider for selected caps set if hidden

### DIFF
--- a/app/common/renderer/reducers/SessionBuilder.js
+++ b/app/common/renderer/reducers/SessionBuilder.js
@@ -141,10 +141,10 @@ export default function builder(state = INITIAL_STATE, action) {
         })),
         capsUUID: action.uuid,
         capsName: action.name,
-        visibleProviders: _.union(
-          state.visibleProviders,
-          action.serverType !== SERVER_TYPES.REMOTE ? [action.serverType] : [],
-        ),
+        visibleProviders:
+          action.serverType !== SERVER_TYPES.REMOTE
+            ? _.union(state.visibleProviders, [action.serverType])
+            : state.visibleProviders,
       };
       return _.omit(nextState, 'isCapsDirty');
 


### PR DESCRIPTION
Fix for a small bug I noticed a while back:
1. Create and save 2 capability sets: set A for Appium server, and set B for any cloud provider
1. Select set A
1. Using the Select Cloud Providers button, hide the cloud provider of set B
1. Select set B -> server details has no elements

With this fix, the cloud provider of set B is changed to visible, and its server detail elements are shown properly.