### PR TITLE
fix: gesture circles not shown in Firefox/Safari

### DIFF
--- a/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.jsx
@@ -199,7 +199,7 @@ const Screenshot = (props) => {
           {screenshotInteractionMode === TAP_SWIPE && (
             <svg className={styles.swipeSvg}>
               {coordStart && (
-                <circle cx={coordStart.x / scaleRatio} cy={coordStart.y / scaleRatio} />
+                <circle cx={coordStart.x / scaleRatio} cy={coordStart.y / scaleRatio} r={10} />
               )}
               {coordStart && !coordEnd && (
                 <line
@@ -240,6 +240,7 @@ const Screenshot = (props) => {
                       key={`${tick.id}.circle`}
                       cx={tick.x / scaleRatio}
                       cy={tick.y / scaleRatio}
+                      r={8}
                       style={
                         tick.type === GESTURE_ITEM_STYLES.FILLED
                           ? {fill: tick.color}

--- a/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.module.css
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.module.css
@@ -126,7 +126,6 @@
 }
 
 .swipeSvg circle {
-  r: 10;
   fill: rgba(255, 153, 153, 0.8);
 }
 
@@ -156,7 +155,6 @@
 }
 
 .gestureSvg circle {
-  r: 8;
   fill: none;
   stroke-width: 0.4%;
 }


### PR DESCRIPTION
When using the browser/plugin version, the start/end circles for custom gestures are currently only rendered in Chrome (and I assume Chromium in general), but not in Firefox and Safari:
<img width="183" height="482" alt="gesture-before" src="https://github.com/user-attachments/assets/eaabd2de-2ddf-4dbc-a4b8-cf00d7c36efa" />

This is because the `r` attribute [is not supported as a CSS property in SVG 1.1](https://stackoverflow.com/questions/36466176/svg-circle-element-shows-invalid-value-in-firefox-but-works-in-chrome#comment60546376_36466176), and different browsers implement different parts of the SVG 2 spec.
The fix was to simply move the attribute to the `circle` element definition:
<img width="177" height="473" alt="gesture-after" src="https://github.com/user-attachments/assets/ea081e9a-8215-4aae-a397-2a60d8a82cae" />
