### PR TITLE
chore: simplify Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,13 +10,11 @@
     },
     {
       "matchPackageNames": ["antd", "@ant-design/icons"],
-      "groupName": "antd-related packages",
-      "groupSlug": "antd"
+      "groupName": "antd-related packages"
     },
     {
       "matchPackageNames": ["appium", "@appium/**", "!@appium/base-plugin"],
-      "groupName": "Appium-related packages",
-      "groupSlug": "appium"
+      "groupName": "Appium-related packages"
     },
     {
       "matchPackageNames": ["@appium/base-plugin"],


### PR DESCRIPTION
Small simplification of the Renovate config:
* Add schema
* Add extend for the Appium monorepo config
* Remove `config:recommended` (already included in Appium monorepo config -> `config:js-app`)
* Remove `:semanticCommitTypeAll(chore)` (already included in Appium monorepo config)
* Remove `:pinAllExceptPeerDependencies` (already included in Appium monorepo config -> `config:js-app`)
* Remove group slug for React (already included in `config:recommended` -> `group:monorepos` -> `group:reactMonorepo` -> `monorepo:react` and `config:recommended` -> `group:recommended` -> `group:react`)
* Remove group slug for WebdriverIO (already included in `config:recommended` -> `group:monorepos` -> `group:webdriverioMonorepo` -> `monorepo:webdriverio`)