### PR TITLE
fix: remove extra quotes from string command results

### DIFF
--- a/app/common/renderer/components/SessionInspector/CommandsTab/CommandResultModal.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/CommandResultModal.jsx
@@ -208,7 +208,7 @@ const CommandResultModalFooter = ({
   </Row>
 );
 
-const CommandResultModal = ({commandName, commandResult, clearCurrentCommand, t}) => {
+const CommandResultModal = ({commandName, commandResult, resultType, clearCurrentCommand, t}) => {
   const [formatResult, setFormatResult] = useState(false);
 
   const {parsedResult, isPrimitive} = parseCommandResult(commandResult);
@@ -220,7 +220,7 @@ const CommandResultModal = ({commandName, commandResult, clearCurrentCommand, t}
 
   return (
     <Modal
-      title={t('methodCallResult', {methodName: commandName})}
+      title={`${t('methodCallResult', {methodName: commandName})}${resultType ? ` (type: ${resultType})` : ''}`}
       open={!!commandResult}
       onCancel={() => closeCommandModal()}
       width={{md: '80%', lg: '70%', xl: '60%', xxl: '50%'}}

--- a/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
@@ -39,6 +39,7 @@ const Commands = (props) => {
   const curCommandParamVals = useRef([]);
 
   const [commandResult, setCommandResult] = useState(null);
+  const [resultType, setResultType] = useState(null);
 
   const startCommand = (commandDetails) => {
     setCurCommandDetails(commandDetails);
@@ -80,13 +81,15 @@ const Commands = (props) => {
       args,
       skipRefresh,
     });
-    const formattedResult =
-      _.isObject(res) && _.isEmpty(res)
-        ? null
-        : typeof res === 'string'
-          ? res
-          : JSON.stringify(res, null, 2);
+    if (_.isObject(res) && _.isEmpty(res)) {
+      setCommandResult(null);
+      setResultType(null);
+      return;
+    }
+    const type = typeof res;
+    const formattedResult = type === 'string' ? res : JSON.stringify(res, null, 2);
     setCommandResult(formattedResult);
+    setResultType(type);
   };
 
   const prepareAndRunCommand = (commandDetails) => {
@@ -108,6 +111,7 @@ const Commands = (props) => {
 
   const clearCurrentCommand = () => {
     setCommandResult(null);
+    setResultType(null);
     setCurCommandDetails(null);
     curCommandParamVals.current = [];
   };
@@ -161,6 +165,7 @@ const Commands = (props) => {
           <CommandResultModal
             commandName={curCommandDetails.name}
             commandResult={commandResult}
+            resultType={resultType}
             clearCurrentCommand={clearCurrentCommand}
             t={t}
           />


### PR DESCRIPTION
## Description

Minor improvement to how command results are formatted in the `CommandsTab` component. The change ensures that if the result is already a string, it is displayed as-is, rather than being stringified again.

#### from
<img width="305" height="209" alt="image" src="https://github.com/user-attachments/assets/239f9dde-9dfe-4b08-bfe4-7314f947c475" />

#### to
<img width="409" height="208" alt="image" src="https://github.com/user-attachments/assets/ec8294d2-0ee7-4bfb-98ff-6982fa85c6ce" />

just tired of removing quotes from base64 images 🥲 