### PR TITLE
chore: replace more deprecated antd properties

### DIFF
--- a/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
@@ -10,7 +10,7 @@ import styles from './ErrorMessage.module.css';
 const ErrorMessage = ({error, copyTrace, t}) => (
   <div className={styles.errorMessage}>
     <Alert
-      message={
+      title={
         <>
           {t('Unexpected Error:')} <code>{error.message}</code>
         </>

--- a/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
@@ -138,7 +138,7 @@ const CapabilityJSON = (props) => {
                 isValidCapsJson ? styles.capsEditorBodyFull : styles.capsEditorBodyResized
               }`}
             />
-            {!isValidCapsJson && <Alert message={invalidCapsJsonReason} type={ALERT.ERROR} />}
+            {!isValidCapsJson && <Alert title={invalidCapsJsonReason} type={ALERT.ERROR} />}
           </div>
         )}
         {!isEditingDesiredCaps && (

--- a/app/common/renderer/components/SessionInspector/Header/ElementLocator.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/ElementLocator.jsx
@@ -55,7 +55,7 @@ const ElementLocator = (props) => {
         </Radio.Group>
       </Row>
       {!automationName && (
-        <Alert message={t('missingAutomationNameForStrategies')} type={ALERT.INFO} showIcon />
+        <Alert title={t('missingAutomationNameForStrategies')} type={ALERT.INFO} showIcon />
       )}
       {t('selector')}
       <Input.TextArea

--- a/app/common/renderer/components/SessionInspector/Header/LocatedElements.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/LocatedElements.jsx
@@ -35,7 +35,7 @@ const LocatedElements = (props) => {
     ) {
       return (
         <Row>
-          <Alert message={t('idAutocompletionCanBeDisabled')} type={ALERT.INFO} showIcon />
+          <Alert title={t('idAutocompletionCanBeDisabled')} type={ALERT.INFO} showIcon />
         </Row>
       );
     }

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement.jsx
@@ -63,7 +63,7 @@ const SelectedElement = (props) => {
           <Col>
             <Alert
               type={ALERT.INFO}
-              message={t('snapshotMaxDepthReached', {selectedElementDepth})}
+              title={t('snapshotMaxDepthReached', {selectedElementDepth})}
               showIcon
             />
           </Col>
@@ -229,7 +229,7 @@ const SelectedElement = (props) => {
         {elementInteractionsNotAvailable && (
           <Row type={ROW.FLEX} gutter={10} className={styles.selectedElemInfoMessage}>
             <Col>
-              <Alert type={ALERT.INFO} message={t('interactionsNotAvailable')} showIcon />
+              <Alert type={ALERT.INFO} title={t('interactionsNotAvailable')} showIcon />
             </Col>
           </Row>
         )}
@@ -300,7 +300,7 @@ const SelectedElement = (props) => {
           </Row>
         )}
         {currentContext === NATIVE_APP && showXpathWarning && (
-          <Alert message={t('usingXPathNotRecommended')} type={ALERT.WARNING} showIcon />
+          <Alert title={t('usingXPathNotRecommended')} type={ALERT.WARNING} showIcon />
         )}
         {dataSource.length > 0 && (
           <Row className={styles.selectedElemContentRow}>


### PR DESCRIPTION
Follow-up to #2492 - I had missed the `message` property for `Alert`.