### PR TITLE
chore: decouple mocked xpath.select from its real usage

### DIFF
--- a/app/common/renderer/utils/locator-generation.js
+++ b/app/common/renderer/utils/locator-generation.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import XPath, {select as xpathSelect} from 'xpath';
+import {select as xpathSelect} from 'xpath';
 
 import {log} from './logger.js';
 import {childNodesOf, domToXML, findDOMNodeByPath, xmlToDOM} from './source-parsing.js';
@@ -241,8 +241,7 @@ class XPathGenerator extends LocatorGeneratorBase {
 
     // If the XPath does not parse, move to the next unique attribute
     try {
-      // eslint-disable-next-line import/no-named-as-default-member -- needed for Vitest spy functionality
-      othersWithAttr = XPath.select(xpath, this._doc);
+      othersWithAttr = xpathSelect(xpath, this._doc);
     } catch {
       return [false];
     }

--- a/test/unit/utils-locator-generation.spec.js
+++ b/test/unit/utils-locator-generation.spec.js
@@ -1,5 +1,5 @@
 import {describe, expect, it, vi} from 'vitest';
-import xpath from 'xpath';
+import * as xpath from 'xpath';
 
 import {
   areAttrAndValueUnique,
@@ -10,6 +10,15 @@ import {
   getSimpleSuggestedLocators,
 } from '../../app/common/renderer/utils/locator-generation.js';
 import {xmlToDOM} from '../../app/common/renderer/utils/source-parsing.js';
+
+// Create identical mock of xpath, so that xpath.select can be modified as needed
+vi.mock('xpath', async (importOriginal) => {
+  const originalXpath = await importOriginal();
+  return {
+    ...originalXpath,
+    select: vi.fn(originalXpath.select),
+  };
+});
 
 // Helper that checks that the optimal xpath for a node is the one that we expect and also
 // checks that the XPath successfully locates the node in it's doc
@@ -339,7 +348,7 @@ describe('utils/locator-generation.js', function () {
 
     describe('when exceptions are thrown', function () {
       it('should keep going if xpath.select throws an exception', function () {
-        vi.spyOn(xpath, 'select').mockImplementation(() => {
+        vi.mocked(xpath.select).mockImplementation(() => {
           throw new Error('Exception');
         });
         const doc = xmlToDOM(`<node id='foo'>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -31,7 +31,7 @@ export default defineConfig(({command}) => {
     },
     root: join(__dirname, 'app', 'common'),
     test: {
-      restoreMocks: true,
+      mockReset: true,
       root: join(__dirname, 'test'),
     },
   };


### PR DESCRIPTION
This improves the mocking configuration for `xpath.select`, making it no longer require specific syntax in production files. It does make the tests run ~100ms slower due to the second import of `xpath`, but this kind of separation is still better.