### PR TITLE
fix: redux state mutation error when loading session from URL query string

### DIFF
--- a/app/common/renderer/reducers/SessionBuilder.js
+++ b/app/common/renderer/reducers/SessionBuilder.js
@@ -378,10 +378,7 @@ export default function builder(state = INITIAL_STATE, action) {
     case SET_STATE_FROM_URL:
       return {
         ...state,
-        server: {
-          ...state.server,
-          ...(action.state.server || {}),
-        },
+        server: _.merge({}, state.server, action.state.server || {}),
         ..._.omit(action.state, ['server']),
       };
 


### PR DESCRIPTION
When navigating to the Inspector with URL query parameters containing server configuration, a Redux state mutation error was thrown (in dev mode):

```
Error: A state mutation was detected inside a dispatch, in the path: builder.server.remote.host. Take a look at the reducer(s) handling the action undefined. (https://redux.js.org/style-guide/style-guide#do-not-mutate-state)
    at @reduxjs_toolkit.js?v=ca5c8dfa:1873:19
    at Object.measureTime (@reduxjs_toolkit.js?v=ca5c8dfa:1700:16)
    at @reduxjs_toolkit.js?v=ca5c8dfa:1868:22
    at Object.dispatch (@reduxjs_toolkit.js?v=ca5c8dfa:1691:12)
    at dispatch (page.bundle.js:6:7424)
    at boundActionCreators.<computed> (react-redux.js?v=7884b494:259:47)
    at t2 (SessionBuilder.jsx:83:17)
    at SessionBuilder.js:1007:16
    at @reduxjs_toolkit.js?v=ca5c8dfa:1600:14
    at @reduxjs_toolkit.js?v=ca5c8dfa:1867:34
```

This occurred when using URLs like:

```
http://localhost:5174/?state={"server":{"remote":{"hostname":"localhost","port":4723,"path":"/wd/hub","ssl":false}},"attachSessId":"..."}&autoStart=1
```