### PR TITLE
style: fix vertical align of app source tree expand icon

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -89,7 +89,7 @@ body::-webkit-scrollbar-corner {
 
 .ant-tree-switcher-icon {
   font-size: 14px !important;
-  vertical-align: sub !important;
+  vertical-align: middle !important;
 }
 
 .ant-switch-inner-checked,


### PR DESCRIPTION
Small fix for the expand icon in the app source tree, which seems to be misaligned after updating to antd v6.

Before:
<img width="80" height="138" alt="expand-current" src="https://github.com/user-attachments/assets/c8dd5bf4-0cf8-4bd9-9438-64ed585b8442" />

After:
<img width="82" height="136" alt="expand-new" src="https://github.com/user-attachments/assets/773ba0a5-1f03-432b-bdcb-25a5a9292122" />
