### PR TITLE
chore: fix lint issues

### DIFF
--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -81,15 +81,15 @@ const CapabilityEditor = (props) => {
   } = props;
 
   const onSaveAsOk = () => saveSession(server, serverType, caps, {name: saveAsText});
-  const latestCapField = useRef(null);
+  const latestCapFieldRef = useRef(null);
 
   // if we have more than one cap and the most recent cap name is empty,
   // it means we've just added a new cap field, so focus that input element
   useEffect(() => {
-    if (caps.length > 1 && latestCapField.current && !latestCapField.current.input.value) {
-      latestCapField.current.focus();
+    if (caps.length > 1 && latestCapFieldRef.current && !latestCapFieldRef.current.input.value) {
+      latestCapFieldRef.current.focus();
     }
-  }, [caps.length, latestCapField]);
+  }, [caps.length, latestCapFieldRef]);
 
   return (
     <Splitter>
@@ -106,7 +106,7 @@ const CapabilityEditor = (props) => {
                       placeholder={t('Name')}
                       value={cap.name}
                       onChange={(e) => setCapabilityParam(cap.id, 'name', e.target.value)}
-                      ref={index === caps.length - 1 ? latestCapField : null}
+                      ref={index === caps.length - 1 ? latestCapFieldRef : null}
                       className={styles.capsBoxFont}
                     />
                   </Tooltip>

--- a/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
@@ -32,11 +32,11 @@ const Commands = (props) => {
   const {applyClientMethod, getSupportedSessionMethods, storeSessionSettings, t} = props;
 
   const [hasMethodsMap, setHasMethodsMap] = useState(null);
-  const driverCommands = useRef(null);
-  const driverExecuteMethods = useRef(null);
+  const [driverCommands, setDriverCommands] = useState(null);
+  const [driverExecuteMethods, setDriverExecuteMethods] = useState(null);
 
   const [curCommandDetails, setCurCommandDetails] = useState(null);
-  const curCommandParamVals = useRef([]);
+  const curCommandParamValsRef = useRef([]);
 
   const [commandResult, setCommandResult] = useState(undefined);
 
@@ -49,7 +49,7 @@ const Commands = (props) => {
 
   const prepareCommand = (cmdName, cmdParams, isExecute) => {
     const adjustedCmdName = isExecute ? COMMAND_EXECUTE_SCRIPT : cmdName;
-    let adjustedCmdParams = curCommandParamVals.current.map(adjustParamValueType);
+    let adjustedCmdParams = curCommandParamValsRef.current.map(adjustParamValueType);
 
     // If we are about to run an execute method,
     // the parameters array needs to be turned into an object,
@@ -103,15 +103,15 @@ const Commands = (props) => {
   const clearCurrentCommand = () => {
     setCommandResult(undefined);
     setCurCommandDetails(null);
-    curCommandParamVals.current = [];
+    curCommandParamValsRef.current = [];
   };
 
   useEffect(() => {
     (async () => {
       const {commands, executeMethods} = await getSupportedSessionMethods();
       setHasMethodsMap(!(_.isEmpty(commands) && _.isEmpty(executeMethods)));
-      driverCommands.current = transformCommandsMap(commands);
-      driverExecuteMethods.current = transformExecMethodsMap(executeMethods);
+      setDriverCommands(transformCommandsMap(commands));
+      setDriverExecuteMethods(transformExecMethodsMap(executeMethods));
     })();
   }, [getSupportedSessionMethods]);
 
@@ -146,7 +146,7 @@ const Commands = (props) => {
             {_.map(curCommandDetails.details.params, (param, index) => (
               <Space.Compact block key={index} className={styles.commandArgInputRow}>
                 <Space.Addon>{formatParamInputLabel(param)}</Space.Addon>
-                <Input onChange={(e) => (curCommandParamVals.current[index] = e.target.value)} />
+                <Input onChange={(e) => (curCommandParamValsRef.current[index] = e.target.value)} />
               </Space.Compact>
             ))}
           </Modal>

--- a/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsList.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsList.jsx
@@ -14,11 +14,11 @@ const MethodMapCommandsList = (props) => {
 
   const [searchQuery, setSearchQuery] = useState('');
 
-  const hasNoCommands = _.isEmpty(driverCommands.current);
-  const hasNoExecuteMethods = _.isEmpty(driverExecuteMethods.current);
+  const hasNoCommands = _.isEmpty(driverCommands);
+  const hasNoExecuteMethods = _.isEmpty(driverExecuteMethods);
 
-  const filteredDriverCommands = filterMethodPairs(driverCommands.current, searchQuery);
-  const filteredDriverExecuteMethods = filterMethodPairs(driverExecuteMethods.current, searchQuery);
+  const filteredDriverCommands = filterMethodPairs(driverCommands, searchQuery);
+  const filteredDriverExecuteMethods = filterMethodPairs(driverExecuteMethods, searchQuery);
 
   const methodButton = (methodName, methodDetails, isExecute) => (
     <div className={styles.btnContainer}>

--- a/app/common/renderer/components/SessionInspector/GesturesTab/FileUploader.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/FileUploader.jsx
@@ -5,16 +5,16 @@ import {useRef} from 'react';
 const FileUploader = (props) => {
   const {multiple, onUpload, type, icon, tooltipTitle} = props;
 
-  const fileCounter = useRef(1);
+  const fileCounterRef = useRef(1);
 
   // If multiple files are uploaded at once, this function is called once for every file.
   // In order to upload everything only once, use a counter to track invocation count.
   const beforeUpload = (_file, list) => {
-    if (fileCounter.current >= list.length) {
+    if (fileCounterRef.current >= list.length) {
       onUpload(list);
-      fileCounter.current = 1;
+      fileCounterRef.current = 1;
     } else {
-      fileCounter.current += 1;
+      fileCounterRef.current += 1;
     }
     return false;
   };

--- a/app/common/renderer/components/SessionInspector/Header/LocatedElements.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/LocatedElements.jsx
@@ -23,7 +23,7 @@ const LocatedElements = (props) => {
     t,
   } = props;
 
-  const sendKeys = useRef(null);
+  const sendKeysRef = useRef(null);
 
   const showIdAutocompleteInfo = () => {
     const {automationName, sessionSettings} = props;
@@ -123,7 +123,7 @@ const LocatedElements = (props) => {
                     disabled={!locatorTestElement}
                     placeholder={t('Enter Keys to Send')}
                     allowClear={true}
-                    onChange={(e) => (sendKeys.current = e.target.value)}
+                    onChange={(e) => (sendKeysRef.current = e.target.value)}
                   />
                   <Tooltip title={t('Send Keys')} placement="bottom">
                     <Button
@@ -133,7 +133,7 @@ const LocatedElements = (props) => {
                         applyClientMethod({
                           methodName: 'elementSendKeys',
                           elementId: locatorTestElement,
-                          args: [sendKeys.current || ''],
+                          args: [sendKeysRef.current || ''],
                         })
                       }
                     />

--- a/app/common/renderer/components/SessionInspector/Screenshot/HighlighterRectForBounds.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/HighlighterRectForBounds.jsx
@@ -4,11 +4,11 @@ import styles from './Screenshot.module.css';
  * Single absolute positioned div that overlays the app screenshot and highlights the bounding
  * box of the element found through element search
  */
-const HighlighterRectForBounds = ({elSize, elLocation, scaleRatio, xOffset}) => (
+const HighlighterRectForBounds = ({elSize, elLocation, scaleRatio}) => (
   <div
     className={`${styles.highlighterBox} ${styles.inspectedElementBox}`}
     style={{
-      left: elLocation.x / scaleRatio + xOffset,
+      left: elLocation.x / scaleRatio,
       top: elLocation.y / scaleRatio,
       width: elSize.width / scaleRatio,
       height: elSize.height / scaleRatio,

--- a/app/common/renderer/components/SessionInspector/Screenshot/HighlighterRects.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/HighlighterRects.jsx
@@ -12,7 +12,6 @@ const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
 const HighlighterRects = (props) => {
   const {
     sourceJSON,
-    containerEl,
     searchedForElementBounds,
     scaleRatio,
     showCentroids,
@@ -22,7 +21,6 @@ const HighlighterRects = (props) => {
 
   const highlighterRects = [];
   const highlighterCentroids = [];
-  let highlighterXOffset = 0;
 
   const getElements = (sourceJSON) => {
     const elementsByOverlap = buildElementsWithProps(sourceJSON, null, [], {});
@@ -71,18 +69,17 @@ const HighlighterRects = (props) => {
       return {};
     }
     const {x1, y1, x2, y2} = parseCoordinates(sourceJSON);
-    const xOffset = highlighterXOffset || 0;
     const centerPoint = (v1, v2) => Math.round(v1 + (v2 - v1) / 2) / scaleRatio;
     const obj = {
       type: CENTROID,
       element: sourceJSON,
       parent: prevElement,
       properties: {
-        left: x1 / scaleRatio + xOffset,
+        left: x1 / scaleRatio,
         top: y1 / scaleRatio,
         width: (x2 - x1) / scaleRatio,
         height: (y2 - y1) / scaleRatio,
-        centerX: centerPoint(x1, x2) + xOffset,
+        centerX: centerPoint(x1, x2),
         centerY: centerPoint(y1, y2),
         angleX: null,
         angleY: null,
@@ -202,12 +199,6 @@ const HighlighterRects = (props) => {
   // Array of all element objects with properties to draw rectangles and/or centroids
   const elements = getElements(sourceJSON);
 
-  if (containerEl.current) {
-    const screenshotEl = containerEl.current.querySelector('img');
-    highlighterXOffset =
-      screenshotEl.getBoundingClientRect().left - containerEl.current.getBoundingClientRect().left;
-  }
-
   // If the user selected an element that they searched for, highlight that element
   if (searchedForElementBounds && isLocatorTestModalVisible) {
     const {location, size} = searchedForElementBounds;
@@ -217,7 +208,6 @@ const HighlighterRects = (props) => {
         elLocation={location}
         scaleRatio={scaleRatio}
         key={`el.${location.x}.${location.y}.${size.width}.${size.height}`}
-        xOffset={highlighterXOffset}
       />,
     );
   }

--- a/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.jsx
@@ -1,5 +1,5 @@
 import {Spin} from 'antd';
-import {Fragment, useRef, useState} from 'react';
+import {Fragment, useState} from 'react';
 
 import {GESTURE_ITEM_STYLES, POINTER_TYPES} from '../../../constants/gestures.js';
 import {
@@ -35,7 +35,6 @@ const Screenshot = (props) => {
     t,
   } = props;
 
-  const containerEl = useRef(null);
   const [x, setX] = useState();
   const [y, setY] = useState();
 
@@ -176,7 +175,6 @@ const Screenshot = (props) => {
     <Spin size="large" spinning={!!methodCallInProgress && !isUsingMjpegMode}>
       <div className={styles.innerScreenshotContainer}>
         <div
-          ref={containerEl}
           style={screenshotStyle}
           onMouseDown={handleScreenshotDown}
           onMouseUp={handleScreenshotUp}
@@ -193,9 +191,7 @@ const Screenshot = (props) => {
             </div>
           )}
           {screenImg}
-          {screenshotInteractionMode === SELECT && (
-            <HighlighterRects {...props} containerEl={containerEl} />
-          )}
+          {screenshotInteractionMode === SELECT && <HighlighterRects {...props} />}
           {screenshotInteractionMode === TAP_SWIPE && (
             <svg className={styles.swipeSvg}>
               {coordStart && (

--- a/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfo.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfo.jsx
@@ -10,7 +10,7 @@ import styles from './SessionInfo.module.css';
 const SessionInfo = (props) => {
   const {driver, getActiveAppId, getServerStatus, getFlatSessionCaps, sessionStartTime, t} = props;
 
-  const interval = useRef(null);
+  const intervalRef = useRef(null);
   const [sessionLength, setSessionLength] = useState(0);
 
   const formatSessionLength = () => {
@@ -102,10 +102,10 @@ const SessionInfo = (props) => {
     getServerStatus();
     getFlatSessionCaps();
 
-    interval.current = setInterval(() => {
+    intervalRef.current = setInterval(() => {
       setSessionLength(Date.now() - sessionStartTime);
     }, 1000);
-    return () => clearInterval(interval.current);
+    return () => clearInterval(intervalRef.current);
   }, [driver, getActiveAppId, getServerStatus, getFlatSessionCaps, sessionStartTime]);
 
   return (

--- a/app/common/renderer/components/SessionInspector/SessionInspector.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInspector.jsx
@@ -81,8 +81,8 @@ const Inspector = (props) => {
     t,
   } = props;
 
-  const screenshotContainerEl = useRef(null);
-  const mjpegStreamCheckInterval = useRef(null);
+  const screenshotContainerElRef = useRef(null);
+  const mjpegStreamCheckIntervalRef = useRef(null);
   // Debounced updater stored in a ref to avoid creating it during render
   const updateScreenshotScaleDebouncedRef = useRef(undefined);
 
@@ -101,7 +101,7 @@ const Inspector = (props) => {
     // If the screenshot has too much space to the right or bottom, adjust the max width
     // of its container, so the source tree always fills the remaining space.
     // This keeps everything looking tight.
-    const screenshotContainer = screenshotContainerEl.current;
+    const screenshotContainer = screenshotContainerElRef.current;
     if (!screenshotContainer) {
       return;
     }
@@ -161,8 +161,8 @@ const Inspector = (props) => {
       setAwaitingMjpegStream(false);
       updateScreenshotScaleDebounced();
       // stream obtained - can clear the refresh interval
-      clearInterval(mjpegStreamCheckInterval.current);
-      mjpegStreamCheckInterval.current = null;
+      clearInterval(mjpegStreamCheckIntervalRef.current);
+      mjpegStreamCheckIntervalRef.current = null;
     } else if (!imgReady && !isAwaitingMjpegStream) {
       setAwaitingMjpegStream(true);
     }
@@ -215,13 +215,16 @@ const Inspector = (props) => {
     updateScreenshotScaleDebounced();
     window.addEventListener('resize', updateScreenshotScaleDebounced);
     if (isUsingMjpegMode) {
-      mjpegStreamCheckInterval.current = setInterval(checkMjpegStream, MJPEG_STREAM_CHECK_INTERVAL);
+      mjpegStreamCheckIntervalRef.current = setInterval(
+        checkMjpegStream,
+        MJPEG_STREAM_CHECK_INTERVAL,
+      );
     }
     return () => {
       window.removeEventListener('resize', updateScreenshotScaleDebounced);
-      if (mjpegStreamCheckInterval.current) {
-        clearInterval(mjpegStreamCheckInterval.current);
-        mjpegStreamCheckInterval.current = null;
+      if (mjpegStreamCheckIntervalRef.current) {
+        clearInterval(mjpegStreamCheckIntervalRef.current);
+        mjpegStreamCheckIntervalRef.current = null;
       }
     };
   }, [checkMjpegStream, isUsingMjpegMode, updateScreenshotScaleDebounced, windowSize]);
@@ -292,7 +295,7 @@ const Inspector = (props) => {
       <div
         id="screenshotContainer"
         className={styles.screenshotContainer}
-        ref={screenshotContainerEl}
+        ref={screenshotContainerElRef}
       >
         {screenShotControls}
         {showScreenshot && <Screenshot {...props} scaleRatio={scaleRatio} />}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement.jsx
@@ -51,7 +51,7 @@ const SelectedElement = (props) => {
     downloadFile(href, filename);
   };
 
-  const sendKeys = useRef(null);
+  const sendKeysRef = useRef(null);
 
   const isDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
 
@@ -250,7 +250,7 @@ const SelectedElement = (props) => {
               disabled={isDisabled}
               placeholder={t('Enter Keys to Send')}
               allowClear={true}
-              onChange={(e) => (sendKeys.current = e.target.value)}
+              onChange={(e) => (sendKeysRef.current = e.target.value)}
             />
             <Tooltip title={t('Send Keys')}>
               <Button
@@ -261,7 +261,7 @@ const SelectedElement = (props) => {
                   applyClientMethod({
                     methodName: 'elementSendKeys',
                     elementId: selectedElementId,
-                    args: [sendKeys.current || ''],
+                    args: [sendKeysRef.current || ''],
                   })
                 }
               />


### PR DESCRIPTION
This fixes all lint issues caused by incorrect ref variable names (they should end with `Ref`). However, this renaming revealed new lint issues, so the following adjustments were also needed:
* In `Commands.jsx`, the `driverCommands` and `driverExecuteMethods` values are now state variables instead of refs, which properly trigger a re-render upon being updated.
* In `HighlighterRects.jsx`, the container's `getBoundingClientRect()` calls have been removed. They were only used to calculate an offset, but it will always be set to 0, as the left edge of the image and its container are the same. Removing these calls allows to also remove a ref in `Screenshot.jsx`.

Both changes were tested and confirmed to cause no differences.