### PR TITLE
chore: tune release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,9 +1,6 @@
 # Configuration for automatically generated release notes
 
 changelog:
-  exclude:
-    labels:
-      - dependencies
   categories:
     - title: 🚀 New Features
       labels:
@@ -23,3 +20,6 @@ changelog:
     - title: 🔍 Other Changes
       labels:
         - '*'
+      exclude:
+        authors:
+          - renovate[bot]


### PR DESCRIPTION
Currently the autogenerated release notes excludes all commits that have the `dependencies` label, even if they have any other labels, which requires them to be added manually. With this change, the notes will only exclude all Renovate commits, thereby preserving any other commits with the `dependencies` label.