### PR TITLE
style: switch external icon source to Tabler

### DIFF
--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -10,10 +10,15 @@ import {
   SearchOutlined,
   VideoCameraOutlined,
 } from '@ant-design/icons';
+import {
+  IconChevronLeft,
+  IconCircle,
+  IconHome,
+  IconMessageChatbot,
+  IconRecycle,
+  IconSquare,
+} from '@tabler/icons-react';
 import {Button, Divider, Select, Space, Tooltip} from 'antd';
-import {BiCircle, BiRecycle, BiSquare} from 'react-icons/bi';
-import {HiOutlineHome, HiOutlineMicrophone} from 'react-icons/hi';
-import {IoChevronBackOutline} from 'react-icons/io5';
 
 import {BUTTON} from '../../../constants/antd-types.js';
 import {LINKS} from '../../../constants/common.js';
@@ -51,7 +56,7 @@ const HeaderButtons = (props) => {
           <Tooltip title={t('Press Home Button')}>
             <Button
               id="btnPressHomeButton"
-              icon={<HiOutlineHome className={styles.headerBtnIcon} />}
+              icon={<IconHome size={18} />}
               onClick={() =>
                 applyClientMethod({
                   methodName: 'executeScript',
@@ -63,7 +68,7 @@ const HeaderButtons = (props) => {
           <Tooltip title={t('Execute Siri Command')}>
             <Button
               id="siriCommand"
-              icon={<HiOutlineMicrophone className={styles.headerBtnIcon} />}
+              icon={<IconMessageChatbot size={18} />}
               onClick={showSiriCommandModal}
             />
           </Tooltip>
@@ -74,7 +79,7 @@ const HeaderButtons = (props) => {
           <Tooltip title={t('Press Back Button')}>
             <Button
               id="btnPressHomeButton"
-              icon={<IoChevronBackOutline className={styles.headerBtnIcon} />}
+              icon={<IconChevronLeft size={20} />}
               onClick={() =>
                 applyClientMethod({
                   methodName: 'executeScript',
@@ -86,7 +91,7 @@ const HeaderButtons = (props) => {
           <Tooltip title={t('Press Home Button')}>
             <Button
               id="btnPressHomeButton"
-              icon={<BiCircle className={styles.headerBtnIcon} />}
+              icon={<IconCircle size={16} />}
               onClick={() =>
                 applyClientMethod({
                   methodName: 'executeScript',
@@ -98,7 +103,7 @@ const HeaderButtons = (props) => {
           <Tooltip title={t('Press App Switch Button')}>
             <Button
               id="btnPressHomeButton"
-              icon={<BiSquare className={styles.headerBtnIcon} />}
+              icon={<IconSquare size={16} />}
               onClick={() =>
                 applyClientMethod({
                   methodName: 'executeScript',
@@ -231,7 +236,7 @@ const HeaderButtons = (props) => {
     <Tooltip title={t('ToggleRestartSession')}>
       <Button
         id={autoSessionRestart ? 'btnDisableRestartSession' : 'btnEnableRestartSession'}
-        icon={<BiRecycle />}
+        icon={<IconRecycle size={16} />}
         type={autoSessionRestart ? BUTTON.PRIMARY : undefined}
         onClick={toggleAutoSessionRestart}
       />

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@ant-design/icons": "6.1.0",
         "@reduxjs/toolkit": "2.11.2",
+        "@tabler/icons-react": "3.36.1",
         "@wdio/protocols": "9.16.2",
         "@xmldom/xmldom": "0.9.8",
         "antd": "6.1.4",
@@ -31,7 +32,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-i18next": "16.5.2",
-        "react-icons": "5.5.0",
         "react-redux": "9.2.0",
         "react-router": "7.12.0",
         "sanitize-filename": "1.6.3",
@@ -4315,6 +4315,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@tabler/icons": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.36.1.tgz",
+      "integrity": "sha512-f4Jg3Fof/Vru5ioix/UO4GX+sdDsF9wQo47FbtvG+utIYYVQ/QVAC0QYgcBbAjQGfbdOh2CCf0BgiFOF9Ixtjw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      }
+    },
+    "node_modules/@tabler/icons-react": {
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.36.1.tgz",
+      "integrity": "sha512-/8nOXeNeMoze9xY/QyEKG65wuvRhkT3q9aytaur6Gj8bYU2A98YVJyLc9MRmc5nVvpy+bRlrrwK/Ykr8WGyUWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tabler/icons": ""
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/codecalm"
+      },
+      "peerDependencies": {
+        "react": ">= 16"
       }
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
@@ -14174,15 +14200,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-icons": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   "dependencies": {
     "@ant-design/icons": "6.1.0",
     "@reduxjs/toolkit": "2.11.2",
+    "@tabler/icons-react": "3.36.1",
     "@wdio/protocols": "9.16.2",
     "@xmldom/xmldom": "0.9.8",
     "antd": "6.1.4",
@@ -86,7 +87,6 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-i18next": "16.5.2",
-    "react-icons": "5.5.0",
     "react-redux": "9.2.0",
     "react-router": "7.12.0",
     "sanitize-filename": "1.6.3",


### PR DESCRIPTION
This PR switches the external icons package from `react-icons` to `@tabler/icons-react`. It comes with a larger and more consistent icon set, and appears to have better tree-shaking, resulting in a smaller app bundle.

The affected icons look almost identical, except for the Siri button, which was intentionally changed (since I find that a chat assistant icon is more descriptive than a microphone icon):
<img width="405" height="50" alt="android-icons" src="https://github.com/user-attachments/assets/395b0ca0-15aa-4dfa-9ce0-6867f1c21214" />
<img width="363" height="44" alt="ios-icons" src="https://github.com/user-attachments/assets/52e77da3-6411-415c-9a15-3fe95ac472b2" />
