### PR TITLE
docs: direct users away from browser version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,20 @@ When inspecting a mobile app, the Inspector looks like this:
 
 ## Installation
 
-Appium Inspector is released in 3 formats:
+Appium Inspector is released in two formats:
 
 1. Standalone desktop application for macOS, Windows, and Linux - download it from the
    [**Releases**](https://github.com/appium/appium-inspector/releases) section
-2. Web application - **<https://inspector.appiumpro.com>** (note that
-   [CORS must be enabled](https://appium.github.io/appium-inspector/latest/troubleshooting/#cannot-start-a-session-using-browser-inspector)
-   in order to connect to an Appium server)
-3. Appium server plugin - see the [**plugin README**](./plugins/README.md) for details
+2. Appium server plugin - see the [**plugin README**](./plugins/README.md) for details
 
 Check the [System Requirements](https://appium.github.io/appium-inspector/latest/quickstart/requirements/)
 and [Installation](https://appium.github.io/appium-inspector/latest/quickstart/installation/)
 documentation for more details.
+
+> [!NOTE]
+>
+> The Inspector was also formerly released as a web application hosted at <https://inspector.appiumpro.com>. The Appium team no longer has developer access to this site, so even though it remains operational, it is highly unlikely to be updated to a newer Inspector version, and may be taken down without notice. We recommend migrating to the standalone app or the plugin version.
+> The Appium team is exploring the idea of hosting an up-to-date version of the web app in the future.
 
 ## Features
 

--- a/docs/menu-bar.md
+++ b/docs/menu-bar.md
@@ -5,14 +5,14 @@ hide:
 title: Menu Bar
 ---
 
-The **Menu Bar** is the always shown either at the top of the application window (Windows) or in the
-system menu bar (macOS).
+The **Menu Bar** is the always shown either at the top of the application window (Windows/Linux) or
+in the system menu bar (macOS).
 
 ![macOS Menu Bar](assets/images/menu-bar-macos.png)
 
 !!! note
 
-    The menu bar is not available in the [web app version](./overview.md#formats) of the Inspector.
+    The menu bar is only available in the [standalone app version](./overview.md#formats) of the Inspector.
 
 Several standard menu bar options are included, mainly related to window and text management.
 However, there are a few specific options as well:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,15 +14,18 @@ with a graphical user interface and additional features.
 
 ## Formats
 
-The Inspector is distributed in 3 formats:
+The Inspector is distributed in two formats:
 
 - Standalone desktop application for Windows, macOS, and Linux, available for download from
   [its GitHub repo](https://github.com/appium/appium-inspector/releases)
-- Web application, available at <https://inspector.appiumpro.com>
 - Appium server plugin, available for installation using
   [Appium's Extension CLI](https://appium.io/docs/en/latest/cli/extensions/)
 
-Note that the web application may not be fully up-to-date with the desktop application.
+!!! note
+
+    The Inspector was also formerly released as a web application hosted at <https://inspector.appiumpro.com>. The Appium team no longer has developer access to this site, so even though it remains operational, it is highly unlikely to be updated to a newer Inspector version, and may be taken down without notice. We recommend migrating to the standalone app or the plugin version.
+
+    The Appium team is exploring the idea of hosting an up-to-date version of the web app in the future.
 
 ## GUI Overview
 

--- a/docs/quickstart/installation.md
+++ b/docs/quickstart/installation.md
@@ -25,18 +25,21 @@ Like all Appium plugins, the Inspector plugin can be installed and activated usi
 2.  Launch the Appium server with the plugin activated:
 
     ```bash
-    appium --use-plugins=inspector --allow-cors
+    appium --use-plugins=inspector
     ```
 
 3.  Open the Inspector URL in your web browser:
     ```
-    http://localhost:4723/inspector
+    http://127.0.0.1:4723/inspector
     ```
 
 !!! info
 
     Make sure the above **host URL** and **port** match those of the Appium server. The server's
     **base path** value is irrelevant, as the plugin always uses the `/inspector` path.
+
+    Check [the Troubleshooting guide](../troubleshooting.md#cannot-start-a-session-using-plugin-version)
+    if you are unable to create a session.
 
 ## Desktop App
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,19 +11,17 @@ This page aims to act as a reference for issues that may be encountered when usi
 
 Please refer to the [Installation guide](./quickstart/installation.md).
 
-## Cannot start a session using browser Inspector
+## Cannot start a session using plugin version
 
 The reason for this issue is [cross-origin resource sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS)
-(CORS). Web browsers have security features which prevent CORS. The browser version of the Inspector
-needs to make requests to the Appium server directly from the browser via JavaScript, but these
-requests are typically not made to the same host (for example, the Inspector is accessed at
-`appiumpro.com`, whereas your local Appium server is `localhost:4723`).
+(CORS). The browser will prevent you from connecting to the Appium server if the base URLs of
+the Inspector and the Appium server do not match (typically `127.0.0.1`).
 
-In this scenario, you will be unable to start a session, because the browser will prevent it. You
-can resolve this issue by starting your Appium server with the `--allow-cors` flag:
+If you want to access the Inspector using another base URL (such as `localhost`), you can do so by
+adding the `--allow-cors` flag when starting the server:
 
 ```
-appium --allow-cors
+appium --use-plugins=inspector --allow-cors
 ```
 
 This will instruct the server to sent the correct CORS-related headers, and it should be possible to


### PR DESCRIPTION
The browser version is probably not going to get any more updates, so it is best to let users know about this.
I've also adjusted the plugin version documentation, since the CORS flag is not needed if the Inspector is accessed from the same base URL.