### PR TITLE
chore: replace deprecated antd Select.Option

### DIFF
--- a/app/common/renderer/components/SessionBuilder/AttachToSessionTab/AttachToSession.jsx
+++ b/app/common/renderer/components/SessionBuilder/AttachToSessionTab/AttachToSession.jsx
@@ -34,18 +34,15 @@ const AttachToSession = ({
               placeholder={t('enterYourSessionId')}
               value={attachSessId || undefined}
               onChange={(value) => setAttachSessId(value)}
-            >
-              {runningAppiumSessions
+              options={runningAppiumSessions
                 .slice()
                 .reverse()
-                .map((session) => (
+                .map((session) =>
                   // list is reversed in order to place the most recent sessions at the top
                   // slice() is added because reverse() mutates the original array
-                  <Select.Option key={session.id} value={session.id}>
-                    <div>{getSessionInfo(session, serverType)}</div>
-                  </Select.Option>
-                ))}
-            </Select>
+                  ({value: session.id, label: getSessionInfo(session, serverType)}),
+                )}
+            />
           </Col>
           <Col span={1}>
             <Tooltip title={t('Reload')}>

--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -119,14 +119,13 @@ const CapabilityEditor = (props) => {
                     disabled={isEditingDesiredCaps}
                     value={cap.type}
                     onChange={(val) => handleSetType(setCapabilityParam, cap, val)}
-                  >
-                    <Select.Option value={CAPABILITY_TYPES.TEXT}>{t('text')}</Select.Option>
-                    <Select.Option value={CAPABILITY_TYPES.BOOL}>{t('boolean')}</Select.Option>
-                    <Select.Option value={CAPABILITY_TYPES.NUM}>{t('number')}</Select.Option>
-                    <Select.Option value={CAPABILITY_TYPES.OBJECT}>
-                      {t('JSON object')}
-                    </Select.Option>
-                  </Select>
+                    options={[
+                      {value: CAPABILITY_TYPES.TEXT, label: t('text')},
+                      {value: CAPABILITY_TYPES.BOOL, label: t('boolean')},
+                      {value: CAPABILITY_TYPES.NUM, label: t('number')},
+                      {value: CAPABILITY_TYPES.OBJECT, label: t('JSON object')},
+                    ]}
+                  />
                 </Form.Item>
               </Col>
               <Col flex="1">

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
@@ -596,27 +596,24 @@ const GestureEditor = (props) => {
   const tickType = (tick) => (
     <center>
       <Select
-        className={styles.tickPointerInput}
+        styles={{
+          root: {width: '100%'},
+          content: {justifyContent: 'center'},
+          popup: {listItem: {textAlign: 'center'}},
+        }}
         placeholder={t('Action Type')}
         value={tick.type}
         defaultValue={tick.type}
         size="middle"
         popupMatchSelectWidth={false}
         onChange={(e) => updateTick(tick, TICK_PROPS.POINTER_TYPE, e)}
-      >
-        <Select.Option className={styles.optionInput} value={POINTER_MOVE}>
-          {t(POINTER_TYPES_MAP.pointerMove)}
-        </Select.Option>
-        <Select.Option className={styles.optionInput} value={POINTER_DOWN}>
-          {t(POINTER_TYPES_MAP.pointerDown)}
-        </Select.Option>
-        <Select.Option className={styles.optionInput} value={POINTER_UP}>
-          {t(POINTER_TYPES_MAP.pointerUp)}
-        </Select.Option>
-        <Select.Option className={styles.optionInput} value={PAUSE}>
-          {t(POINTER_TYPES_MAP.pause)}
-        </Select.Option>
-      </Select>
+        options={[
+          {value: POINTER_MOVE, label: t(POINTER_TYPES_MAP.pointerMove)},
+          {value: POINTER_DOWN, label: t(POINTER_TYPES_MAP.pointerDown)},
+          {value: POINTER_UP, label: t(POINTER_TYPES_MAP.pointerUp)},
+          {value: PAUSE, label: t(POINTER_TYPES_MAP.pause)},
+        ]}
+      />
     </center>
   );
 

--- a/app/common/renderer/components/SessionInspector/GesturesTab/Gestures.module.css
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/Gestures.module.css
@@ -54,14 +54,6 @@
   text-align: center;
 }
 
-.tickPointerInput {
-  width: 100%;
-}
-
-.optionInput {
-  text-align: center;
-}
-
 .tickCard :global(.ant-card-head) {
   min-height: unset;
   padding: 0px;

--- a/app/common/renderer/components/SessionInspector/Header/Header.module.css
+++ b/app/common/renderer/components/SessionInspector/Header/Header.module.css
@@ -17,10 +17,6 @@
   max-width: 400px;
 }
 
-.headerContextSelector {
-  width: 350px;
-}
-
 .headerButtons {
   display: flex;
   flex-direction: column;

--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -144,20 +144,18 @@ const HeaderButtons = (props) => {
       {contexts && contexts.length > 1 && (
         <>
           <Select
-            className={styles.headerContextSelector}
+            styles={{root: {width: 350}}}
             value={currentContext}
             popupMatchSelectWidth={false}
             onChange={(value) => {
               setContext(value);
               applyClientMethod({methodName: 'switchAppiumContext', args: [value]});
             }}
-          >
-            {contexts.map(({id, title}) => (
-              <Select.Option key={id} value={id}>
-                {title ? `${title} (${id})` : id}
-              </Select.Option>
-            ))}
-          </Select>
+            options={contexts.map(({id, title}) => ({
+              value: id,
+              label: title ? `${title} (${id})` : id,
+            }))}
+          />
           <Tooltip
             title={
               <>


### PR DESCRIPTION
Apparently this component has been deprecated for a while now, but warnings were only added in antd 6.2.2.