### PR TITLE
feat: allow selecting installation directory for Windows installer

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -36,6 +36,7 @@
     "target": ["nsis", "zip"]
   },
   "nsis": {
+    "allowToChangeInstallationDirectory": true,
     "oneClick": false
   },
   "linux": {


### PR DESCRIPTION
Resolves #2771. Tested this and confirmed that the installation wizard now includes the directory choice screen.