### PR TITLE
style: increase gesture tick density at window widths >=1920px

### DIFF
--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor.jsx
@@ -658,11 +658,11 @@ const GestureEditor = (props) => {
   const pointerTicksGrid = (pointer) => (
     <Row gutter={[24, 24]}>
       {pointer.ticks.map((tick) => (
-        <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} key={tick.id}>
+        <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3} key={tick.id}>
           {tickCard(tick)}
         </Col>
       ))}
-      <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
+      <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3}>
         <div className={styles.tickPlusBtnWrapper}>
           <Tooltip title={t('Add')}>
             <Button icon={<IconPlus size={18} />} onClick={() => addTick(pointer.id)} />


### PR DESCRIPTION
This is a minor styling update to add support for antd's `xxxl` breakpoint, which is set at a width of `1920` pixels. There are three locations where this app uses other antd breakpoints:
* Grid of discovered sessions
* Grid of supported driver commands/execute methods
* Grid of ticks in the gesture editor

The former two generally use long text strings, so adding this breakpoint only resulted in additional linebreaks. However, this isn't an issue for gesture editor ticks, so I have added the breakpoint there. The end result is that at window widths of 1920px or more, the gesture editor will now show 8 ticks per row, instead of 6.