### PR TITLE
fix(security): 2 improvements across 1 files

### DIFF
--- a/app/electron/main/helpers.js
+++ b/app/electron/main/helpers.js
@@ -11,7 +11,14 @@ export function setupIPCListeners(getOpenFilePath) {
   ipcMain.handle('settings:has', async (_evt, key) => await settings.has(key));
   ipcMain.handle('settings:set', async (_evt, key, value) => await settings.set(key, value));
   ipcMain.handle('settings:get', async (_evt, key) => await settings.get(key));
-  ipcMain.on('electron:openLink', (_evt, link) => shell.openExternal(link));
+  ipcMain.on('electron:openLink', (_evt, link) => {
+    try {
+      const url = new URL(link);
+      if (url.protocol === 'https:') {
+        shell.openExternal(url.toString());
+      }
+    } catch {}
+  });
   ipcMain.on('electron:setTheme', (_evt, theme) => (nativeTheme.themeSource = theme));
   ipcMain.handle('sessionfile:loadIfOpened', async () => {
     const openFilePath = getOpenFilePath();


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 1 files

## Problem

**Severity**: `High` | **File**: `app/electron/main/helpers.js:L13`

The main process accepts an arbitrary `link` from renderer code and passes it directly to `shell.openExternal(link)`. If renderer content is compromised (e.g., XSS or dependency compromise), an attacker could trigger opening `file:`, custom URI schemes, or other unsafe targets, potentially leading to phishing or execution via registered protocol handlers.

## Solution

Validate and allowlist URL schemes/hosts before calling `shell.openExternal` (e.g., only `https:` to trusted domains). Reject or log-and-drop all other inputs. Consider moving link-opening to a strict IPC API with predefined constants rather than arbitrary strings.

## Changes

- `app/electron/main/helpers.js` (modified)