### PR TITLE
fix: reinstate source tree expand icon rotation

### DIFF
--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource.jsx
@@ -245,7 +245,14 @@ const AppSource = (props) => {
               <Tree
                 defaultExpandAll={true}
                 showLine={true}
-                switcherIcon={<CaretDownOutlined />}
+                switcherIcon={({expanded}) => (
+                  <CaretDownOutlined
+                    style={{
+                      transform: `rotate(${expanded ? 0 : -90}deg)`,
+                      transition: 'transform 0.3s',
+                    }}
+                  />
+                )}
                 onExpand={onExpand}
                 expandedKeys={expandedKeys}
                 autoExpandParent={autoExpandParent}

--- a/app/common/renderer/components/SessionInspector/SourceTab/Source.module.css
+++ b/app/common/renderer/components/SessionInspector/SourceTab/Source.module.css
@@ -69,9 +69,9 @@
 
 .sourceTree :global(.ant-tree-node-content-wrapper) {
   margin: 0 0 2px 4px;
+  padding: 0;
 }
 
-.sourceTree :global(.ant-tree-switcher-icon) {
-  font-size: 14px !important;
-  vertical-align: middle !important;
+.sourceTree :global(.ant-tree-switcher-line-icon) {
+  vertical-align: -0.2em;
 }


### PR DESCRIPTION
Seems like one of the recent antd versions (likely 6.3.4) broke rotation for the expand icon used in the source tree.
This PR fixes it according to the antd docs.