### PR TITLE
fix: align lines connecting source tree nodes

### DIFF
--- a/app/common/renderer/components/SessionInspector/SourceTab/Source.module.css
+++ b/app/common/renderer/components/SessionInspector/SourceTab/Source.module.css
@@ -60,7 +60,6 @@
   flex: 1;
   overflow: auto;
   --ant-tree-title-height: 18px !important;
-  --ant-tree-indent-size: 18px !important;
 }
 
 .sourceTree :global(.ant-tree-treenode) {


### PR DESCRIPTION
#2824 only fixed the issue with source tree icons not rotating, but there was another issue where the lines used to connect source tree sibling nodes were misaligned. This fixes the misalignment.