### PR TITLE
style: set a max width for box model

### DIFF
--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.module.css
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.module.css
@@ -46,6 +46,8 @@
 
 .selectedElemBoxModelWrapper {
   height: 90px;
+  max-width: 300px;
+  margin: auto;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
The selected element box model can look too horizontally stretched at large window sizes. This adds a max width to it, making it a bit easier to reference the values.