### PR TITLE
chore(deps): update @eslint-react/eslint-plugin to v5

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig([
       },
       'react-x': {
         compilationMode: 'all',
-      }
+      },
     },
   },
   {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -28,6 +28,9 @@ export default defineConfig([
       react: {
         version: 'detect',
       },
+      'react-x': {
+        compilationMode: 'all',
+      }
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@appium/eslint-config-appium-ts": "3.2.1",
         "@appium/fake-driver": "6.1.3",
         "@appium/support": "7.2.1",
-        "@eslint-react/eslint-plugin": "2.13.0",
+        "@eslint-react/eslint-plugin": "5.7.2",
         "@tomjs/electron-devtools-installer": "4.0.1",
         "@types/lodash": "4.17.24",
         "@types/react": "19.2.14",
@@ -2175,130 +2175,153 @@
       }
     },
     "node_modules/@eslint-react/ast": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.13.0.tgz",
-      "integrity": "sha512-43+5gmqV3MpatTzKnu/V2i/jXjmepvwhrb9MaGQvnXHQgq9J7/C7VVCCcwp6Rvp2QHAFquAAdvQDSL8IueTpeA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-5.7.2.tgz",
+      "integrity": "sha512-iFb8ux+Bw7cm2fJhncOgejb6v7Otf1cSWgAQRJYq8WnKiWL4Ks5y+B20X6s6WLQZN3w70XepowJpk4zENbSElA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/typescript-estree": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/typescript-estree": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "string-ts": "^2.3.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/@eslint-react/core": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.13.0.tgz",
-      "integrity": "sha512-m62XDzkf1hpzW4sBc7uh7CT+8rBG2xz/itSADuEntlsg4YA7Jhb8hjU6VHf3wRFDwyfx5VnbV209sbJ7Azey0Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-5.7.2.tgz",
+      "integrity": "sha512-E8anHWfFOd513434m+KsajTvmxqpmLLuYY+cxKpnNOgKt1hHlZeECRblAfAprGCNwGmZdKqZ1o0IKf6dg2Z/8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/jsx": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
-    "node_modules/@eslint-react/eff": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.13.0.tgz",
-      "integrity": "sha512-rEH2R8FQnUAblUW+v3ZHDU1wEhatbL1+U2B1WVuBXwSKqzF7BGaLqCPIU7o9vofumz5MerVfaCtJgI8jYe2Btg==",
+    "node_modules/@eslint-react/eslint": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint/-/eslint-5.7.2.tgz",
+      "integrity": "sha512-efSLsaQgEG2IgXnMUoVkSmllUy4s63uf6VPasVxO7Ke/ZfZDXuLgprr+ra2u++UeuIN2cT3yi6Wd+Q8EuwnO1Q==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.59.1"
+      },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/@eslint-react/eslint-plugin": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.13.0.tgz",
-      "integrity": "sha512-iaMXpqnJCTW7317hg8L4wx7u5aIiPzZ+d1p59X8wXFgMHzFX4hNu4IfV8oygyjmWKdLsjKE9sEpv/UYWczlb+A==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-5.7.2.tgz",
+      "integrity": "sha512-ToMjDlouAurC7rGw0XZX5AZFxIxJtQz6ItWrMgPdYA33TsdhZtJB+bOL4YBevveS/XShgzCa/eVuFtZiaoks/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "eslint-plugin-react-dom": "2.13.0",
-        "eslint-plugin-react-hooks-extra": "2.13.0",
-        "eslint-plugin-react-naming-convention": "2.13.0",
-        "eslint-plugin-react-rsc": "2.13.0",
-        "eslint-plugin-react-web-api": "2.13.0",
-        "eslint-plugin-react-x": "2.13.0",
-        "ts-api-utils": "^2.4.0"
+        "@eslint-react/shared": "5.7.2",
+        "eslint-plugin-react-dom": "5.7.2",
+        "eslint-plugin-react-jsx": "5.7.2",
+        "eslint-plugin-react-naming-convention": "5.7.2",
+        "eslint-plugin-react-rsc": "5.7.2",
+        "eslint-plugin-react-web-api": "5.7.2",
+        "eslint-plugin-react-x": "5.7.2"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
-    "node_modules/@eslint-react/shared": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.13.0.tgz",
-      "integrity": "sha512-IOloCqrZ7gGBT4lFf9+0/wn7TfzU7JBRjYwTSyb9SDngsbeRrtW95ZpgUpS8/jen1wUEm6F08duAooTZ2FtsWA==",
+    "node_modules/@eslint-react/jsx": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/jsx/-/jsx-5.7.2.tgz",
+      "integrity": "sha512-4xRzmOWKdX0eti/VdEjJyopLmeEadDNmJUNkXakQVdEXH0MmbhbI+j16ZhZcDo8hr7ZHgOVsLNt+ZiTGy/y9eA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eff": "2.13.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0",
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@eslint-react/var": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.13.0.tgz",
-      "integrity": "sha512-dM+QaeiHR16qPQoJYg205MkdHYSWVa2B7ore5OFpOPlSwqDV3tLW7I+475WjbK7potq5QNPTxRa7VLp9FGeQqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/shared": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-5.7.2.tgz",
+      "integrity": "sha512-5glWeGhn/8FCU6H9DNank6VHN+yG6CVprtEbreRLuFWbVm7NYSUxv6RXTUMBdN5tpL7mLUFCWGl8CT7LXuXy/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/eslint": "5.7.2",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0",
+        "zod": "^4.4.3"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
+      }
+    },
+    "node_modules/@eslint-react/var": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-5.7.2.tgz",
+      "integrity": "sha512-lg412EydDOC0805aU2ztC0dlJyCww5HNu1zW7QcwCAVmyoNxBvgylczN9y/WOR9RFz2NS4/CITfkLG7UBpw8wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "ts-pattern": "^5.9.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/@eslint/compat": {
@@ -9571,29 +9594,26 @@
       }
     },
     "node_modules/eslint-plugin-react-dom": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.13.0.tgz",
-      "integrity": "sha512-+2IZzQ1WEFYOWatW+xvNUqmZn55YBCufzKA7hX3XQ/8eu85Mp4vnlOyNvdVHEOGhUnGuC6+9+zLK+IlEHKdKLQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-5.7.2.tgz",
+      "integrity": "sha512-W+tzjZssqqRPGxEi9j7oIq4f9IQ6Yzt3wlsYgvQdckz6aLqbhAGGXNioMNyshmxkCqlJD+ujYed9wCj4oapp0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "ts-pattern": "^5.9.0"
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/jsx": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
+        "compare-versions": "^6.1.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -9616,135 +9636,129 @@
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
-    "node_modules/eslint-plugin-react-hooks-extra": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.13.0.tgz",
-      "integrity": "sha512-qIbha1nzuyhXM9SbEfrcGVqmyvQu7GAOB2sy9Y4Qo5S8nCqw4fSBxq+8lSce5Tk5Y7XzIkgHOhNyXEvUHRWFMQ==",
+    "node_modules/eslint-plugin-react-jsx": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-jsx/-/eslint-plugin-react-jsx-5.7.2.tgz",
+      "integrity": "sha512-Vl4mmmKmgUwc1tZ+4BS9DJ9zJMSu5iLDiBNhMdE1TqCn3hZeRMsjTjpdmITnPVa4pGBReMubZSAk2iY45G1Yww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/core": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/jsx": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.13.0.tgz",
-      "integrity": "sha512-uSd25JzSg2R4p81s3Wqck0AdwRlO9Yc+cZqTEXv7vW8exGGAM3mWnF6hgrgdqVJqBEGJIbS/Vx1r5BdKcY/MHA==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-5.7.2.tgz",
+      "integrity": "sha512-tS0XqJVHFWpEL+jDdSBKbBPMy2MFLfKEUUAeP/D1fyaptZDYkS+UNk7FvTiJgHm9ie0HAyY6joykSg9VtclNCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "compare-versions": "^6.1.1",
-        "string-ts": "^2.3.1",
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/core": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-rsc": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-2.13.0.tgz",
-      "integrity": "sha512-RaftgITDLQm1zIgYyvR51sBdy4FlVaXFts5VISBaKbSUB0oqXyzOPxMHasfr9BCSjPLKus9zYe+G/Hr6rjFLXQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-rsc/-/eslint-plugin-react-rsc-5.7.2.tgz",
+      "integrity": "sha512-ewlQOMTtLPxFH1d4sRLYK8C5vR8bWabEcbgt16lloMT6OSxWwmKinyHEUPgBuY071jIZgaMxcCgTPN3TtEXViw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
-        "ts-pattern": "^5.9.0"
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/core": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-web-api": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.13.0.tgz",
-      "integrity": "sha512-nmJbzIAte7PeAkp22CwcKEASkKi49MshSdiDGO1XuN3f4N4/8sBfDcWbQuLPde6JiuzDT/0+l7Gi8wwTHtR1kg==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-5.7.2.tgz",
+      "integrity": "sha512-diUCluITK/2n7W4rGBISVRnA0kpzZhSa3603fGxGgRvIlRemM2jNCMyH+3fm5MOCCPwAehtO6lsTYKvZ39wsXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/core": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "birecord": "^0.1.1",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-react-x": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.13.0.tgz",
-      "integrity": "sha512-cMNX0+ws/fWTgVxn52qAQbaFF2rqvaDAtjrPUzY6XOzPjY0rJQdR2tSlWJttz43r2yBfqu+LGvHlGpWL2wfpTQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-5.7.2.tgz",
+      "integrity": "sha512-eAhkTZm7w+8JHFLu6qE8mABn7di4xyZHYP/V5OQpwjvCNTLcmA/C9eFE+bQFN5AT+Zbejar5s6LpCqX52c8XfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.13.0",
-        "@eslint-react/core": "2.13.0",
-        "@eslint-react/eff": "2.13.0",
-        "@eslint-react/shared": "2.13.0",
-        "@eslint-react/var": "2.13.0",
-        "@typescript-eslint/scope-manager": "^8.55.0",
-        "@typescript-eslint/type-utils": "^8.55.0",
-        "@typescript-eslint/types": "^8.55.0",
-        "@typescript-eslint/utils": "^8.55.0",
+        "@eslint-react/ast": "5.7.2",
+        "@eslint-react/core": "5.7.2",
+        "@eslint-react/eslint": "5.7.2",
+        "@eslint-react/jsx": "5.7.2",
+        "@eslint-react/shared": "5.7.2",
+        "@eslint-react/var": "5.7.2",
+        "@typescript-eslint/scope-manager": "^8.59.1",
+        "@typescript-eslint/type-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/typescript-estree": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "compare-versions": "^6.1.1",
-        "is-immutable-type": "^5.0.1",
-        "ts-api-utils": "^2.4.0",
+        "string-ts": "^2.3.1",
+        "ts-api-utils": "^2.5.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^10.2.1",
+        "typescript": "*"
       }
     },
     "node_modules/eslint-plugin-simple-import-sort": {
@@ -11576,22 +11590,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/is-immutable-type": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/is-immutable-type/-/is-immutable-type-5.0.1.tgz",
-      "integrity": "sha512-LkHEOGVZZXxGl8vDs+10k3DvP++SEoYEAJLRk6buTFi6kD7QekThV7xHS0j6gpnUCQ0zpud/gMDGiV4dQneLTg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@typescript-eslint/type-utils": "^8.0.0",
-        "ts-api-utils": "^2.0.0",
-        "ts-declaration-location": "^1.0.4"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "typescript": ">=4.7.4"
       }
     },
     "node_modules/is-interactive": {
@@ -17417,9 +17415,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@appium/eslint-config-appium-ts": "3.2.1",
     "@appium/fake-driver": "6.1.3",
     "@appium/support": "7.2.1",
-    "@eslint-react/eslint-plugin": "2.13.0",
+    "@eslint-react/eslint-plugin": "5.7.2",
     "@tomjs/electron-devtools-installer": "4.0.1",
     "@types/lodash": "4.17.24",
     "@types/react": "19.2.14",


### PR DESCRIPTION
Replaces #2817. While this is a bump of 3 major versions, in reality it only adds 1 new lint warning.