### PR TITLE
ci: tune docs publish workflow

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0 # ensure the docs branch is also fetched
       - name: Use GH Actions credentials
         run: |
           git config user.name github-actions
@@ -28,7 +30,5 @@ jobs:
         run: npm ci
       - name: Install dependencies (Python)
         run: npm run install-docs-deps
-      - name: Fetch docs branch
-        run: git fetch origin docs-site:docs-site || true
       - name: Build and deploy docs
         run: npm run publish:docs


### PR DESCRIPTION
When comparing the current docs publishing workflow against those used in other drivers, which don't have issues with the docs revision date, it seems like `fetch-depth` is the key missing property.
This PR aligns the workflow to hopefully fix the issue.