### PR TITLE
ci: add workflow to disallow on hold PRs

### DIFF
--- a/.github/workflows/on-hold.yml
+++ b/.github/workflows/on-hold.yml
@@ -1,0 +1,15 @@
+name: Disallow "On Hold" PRs
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+    branches: [master]
+
+jobs:
+  label-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for "On Hold" label
+        uses: egmacke/action-check-label@v5
+        with:
+          label: on hold
+          state: absent


### PR DESCRIPTION
Similar to the workflow on the main monorepo.