### PR TITLE
style: fix broken tab content height after antd update

### DIFF
--- a/app/common/renderer/components/SessionBuilder/SessionBuilder.module.css
+++ b/app/common/renderer/components/SessionBuilder/SessionBuilder.module.css
@@ -40,25 +40,12 @@
   max-width: 95%;
 }
 
-.serverTabs :global(.ant-tabs-bar) {
-  padding-top: 2em;
-  margin-top: -1em;
-}
-
 .serverTabs :global(.ant-tabs-nav-wrap) {
   -webkit-app-region: drag;
 }
 
 .serverTabs :global(.ant-tabs-tab) {
   -webkit-app-region: no-drag;
-}
-
-.serverTabs :global(.ant-form > .ant-row > div) {
-  padding-bottom: 12px;
-}
-
-.serverTabs :global(.ant-form-item) {
-  margin: 0;
 }
 
 .scrollingTabCont {
@@ -70,11 +57,7 @@
   overflow: auto;
 }
 
-.scrollingTabCont :global(.ant-tabs-bar) {
-  margin-bottom: 0px;
-}
-
-.scrollingTabCont :global(.ant-tabs-content) {
+.scrollingTabCont :global(.ant-tabs-body) {
   height: 100%;
 }
 

--- a/app/common/renderer/components/SessionInspector/SessionInspector.module.css
+++ b/app/common/renderer/components/SessionInspector/SessionInspector.module.css
@@ -85,11 +85,11 @@
   height: 100%;
 }
 
-.inspectorTabsContainer :global(.ant-tabs-content) {
+.inspectorTabsContainer :global(.ant-tabs-body) {
   height: 100%;
 }
 
-.inspectorTabsContainer :global(.ant-tabs-tabpane) {
+.inspectorTabsContainer :global(.ant-tabs-content) {
   height: 100%;
 }
 


### PR DESCRIPTION
antd 6.5.0 added semantic DOM support for Tabs, which changed some CSS class names that the Inspector was relying on. This PR fixes the class names, and removes styles for some classes that no longer exist.