### PR TITLE
fix: add accessible names to icon buttons

### DIFF
--- a/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
@@ -30,6 +30,7 @@ const ErrorMessage = ({error, copyTrace}) => {
             {t('Full error trace:')}
             <Tooltip title={t('Copy Error Trace')}>
               <Button
+                aria-label={t('Copy Error Trace')}
                 size="small"
                 className={styles.copyTraceBtn}
                 onClick={() => copyTrace(error.stack)}

--- a/app/common/renderer/components/SessionBuilder/AppSettings/AppSettings.jsx
+++ b/app/common/renderer/components/SessionBuilder/AppSettings/AppSettings.jsx
@@ -13,7 +13,11 @@ const AppSettings = () => {
   return (
     <>
       <Tooltip title={t('App Settings')}>
-        <Button icon={<IconSettings size={18} />} onClick={() => setModalOpen(true)} />
+        <Button
+          aria-label={t('App Settings')}
+          icon={<IconSettings size={18} />}
+          onClick={() => setModalOpen(true)}
+        />
       </Tooltip>
 
       <Modal

--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -153,6 +153,7 @@ const CapabilityEditor = (props) => {
                     </Tooltip>
                     <Tooltip title={t('Delete')} placement="right">
                       <Button
+                        aria-label={t('Delete')}
                         {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
                         icon={<IconTrash size={18} />}
                         onClick={() => removeCapability(cap.id)}
@@ -178,6 +179,7 @@ const CapabilityEditor = (props) => {
               <Form.Item>
                 <Tooltip title={t('Add')} placement="right">
                   <Button
+                    aria-label={t('Add')}
                     disabled={isEditingDesiredCaps}
                     id="btnAddDesiredCapability"
                     icon={<IconPlus size={18} />}

--- a/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
@@ -67,6 +67,7 @@ const CapabilityJSON = (props) => {
       return (
         <Tooltip title={t('Edit')}>
           <Button
+            aria-label={t('Edit')}
             size="small"
             onClick={startDesiredCapsNameEditor}
             icon={<IconEdit size={14} />}
@@ -79,6 +80,7 @@ const CapabilityJSON = (props) => {
         <>
           <Tooltip title={t('Cancel')}>
             <Button
+              aria-label={t('Cancel')}
               size="small"
               color="danger"
               variant="outlined"
@@ -89,6 +91,7 @@ const CapabilityJSON = (props) => {
           </Tooltip>
           <Tooltip title={t('Save')}>
             <Button
+              aria-label={t('Save')}
               size="small"
               color="primary"
               variant="outlined"
@@ -109,6 +112,7 @@ const CapabilityJSON = (props) => {
           {isEditingDesiredCaps && (
             <Tooltip title={t('Cancel')}>
               <Button
+                aria-label={t('Cancel')}
                 color="danger"
                 variant="outlined"
                 onClick={abortDesiredCapsEditor}
@@ -120,6 +124,7 @@ const CapabilityJSON = (props) => {
           {isEditingDesiredCaps && (
             <Tooltip title={t('Save')}>
               <Button
+                aria-label={t('Save')}
                 color="primary"
                 variant="outlined"
                 onClick={() => saveRawDesiredCaps(caps, rawDesiredCaps)}
@@ -130,7 +135,11 @@ const CapabilityJSON = (props) => {
           )}
           {!isEditingDesiredCaps && (
             <Tooltip title={t('Edit Raw JSON')} placement="topRight">
-              <Button onClick={startDesiredCapsEditor} icon={<IconEdit size={18} />} />
+              <Button
+                aria-label={t('Edit Raw JSON')}
+                onClick={startDesiredCapsEditor}
+                icon={<IconEdit size={18} />}
+              />
             </Tooltip>
           )}
         </div>

--- a/app/common/renderer/components/SessionBuilder/SavedCapabilitySetsTab/SavedCapabilitySets.jsx
+++ b/app/common/renderer/components/SessionBuilder/SavedCapabilitySetsTab/SavedCapabilitySets.jsx
@@ -101,6 +101,7 @@ const SavedCapabilitySets = (props) => {
         <Space.Compact>
           <Tooltip zIndex={3} title={t('Edit')}>
             <Button
+              aria-label={t('Edit')}
               icon={<IconEdit size={18} />}
               onClick={() => {
                 handleCapsAndServer(record.key);
@@ -110,6 +111,7 @@ const SavedCapabilitySets = (props) => {
           </Tooltip>
           <Tooltip zIndex={3} title={t('Export to File')}>
             <Button
+              aria-label={t('Export to File')}
               icon={<IconFileExport size={18} />}
               onClick={() => findAndExportSavedSession(record.key)}
             />
@@ -122,7 +124,7 @@ const SavedCapabilitySets = (props) => {
               cancelText={t('Cancel')}
               onConfirm={() => deleteSavedSession(record.key)}
             >
-              <Button icon={<IconTrash size={18} />} />
+              <Button aria-label={t('Delete')} icon={<IconTrash size={18} />} />
             </Popconfirm>
           </Tooltip>
         </Space.Compact>

--- a/app/common/renderer/components/SessionInspector/CommandsTab/CommandResult/CommandResultModal.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/CommandResult/CommandResultModal.jsx
@@ -30,6 +30,7 @@ const CommandResultModalFooter = ({
         <Space>
           <Tooltip title={t('toggleTableFormatting')}>
             <Button
+              aria-label={t('toggleTableFormatting')}
               icon={<IconTable size={18} />}
               disabled={isPrimitive}
               type={formatResult ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -38,6 +39,7 @@ const CommandResultModalFooter = ({
           </Tooltip>
           <Tooltip title={t('copyResultToClipboard')}>
             <Button
+              aria-label={t('copyResultToClipboard')}
               icon={<IconFiles size={18} />}
               disabled={formatResult}
               onClick={() => copyToClipboard(result)}

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorHeader.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorHeader.jsx
@@ -58,9 +58,18 @@ const convertPointerCoordsType = (newCoordType, coordType, windowSize, pointers)
 /**
  * Back button to return to the saved gestures list.
  */
-const GestureEditorBackButton = ({closeGestureEditor}) => (
-  <Button type="text" icon={<IconArrowLeft size={18} />} onClick={() => closeGestureEditor()} />
-);
+const GestureEditorBackButton = ({closeGestureEditor}) => {
+  const {t} = useTranslation();
+
+  return (
+    <Button
+      aria-label={t('Back')}
+      type="text"
+      icon={<IconArrowLeft size={18} />}
+      onClick={() => closeGestureEditor()}
+    />
+  );
+};
 
 /**
  * Editable title of the current gesture.
@@ -115,6 +124,7 @@ const GestureEditorHeaderButtons = ({
       </Space.Compact>
       <Tooltip title={t('Play')}>
         <Button
+          aria-label={t('Play')}
           type="primary"
           icon={<IconPlayerPlay size={18} />}
           onClick={() => playCurrentGesture()}

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
@@ -23,7 +23,11 @@ const AddNewTickButton = ({id, pointers, setPointers}) => {
   return (
     <div className={styles.tickPlusBtnWrapper}>
       <Tooltip title={t('Add')}>
-        <Button icon={<IconPlus size={18} />} onClick={() => addTick(id, pointers, setPointers)} />
+        <Button
+          aria-label={t('Add')}
+          icon={<IconPlus size={18} />}
+          onClick={() => addTick(id, pointers, setPointers)}
+        />
       </Tooltip>
     </div>
   );

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
@@ -39,6 +39,7 @@ const GestureEditorTickCardHeaderButtons = ({
       {tick.type === POINTER_TYPES.POINTER_MOVE && (
         <Tooltip title={t('toggleMoveActionCoordPicker')}>
           <Button
+            aria-label={t('toggleMoveActionCoordPicker')}
             size="small"
             type={selectedTick === tick.id ? 'primary' : 'text'}
             icon={<IconFocus2 size={18} />}
@@ -48,6 +49,7 @@ const GestureEditorTickCardHeaderButtons = ({
       )}
       <Tooltip title={t('Delete')}>
         <Button
+          aria-label={t('Delete')}
           size="small"
           type="text"
           icon={<IconX size={18} />}

--- a/app/common/renderer/components/SessionInspector/GesturesTab/SavedGestureActionsCell.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/SavedGestureActionsCell.jsx
@@ -44,6 +44,7 @@ const SavedGestureActionsCell = (props) => {
     <Space.Compact>
       <Tooltip zIndex={3} title={t('Play')}>
         <Button
+          aria-label={t('Play')}
           key="play"
           type="primary"
           icon={<IconPlayerPlay size={18} />}
@@ -51,10 +52,18 @@ const SavedGestureActionsCell = (props) => {
         />
       </Tooltip>
       <Tooltip zIndex={3} title={t('Edit')}>
-        <Button icon={<IconEdit size={18} />} onClick={() => loadGesture()} />
+        <Button
+          aria-label={t('Edit')}
+          icon={<IconEdit size={18} />}
+          onClick={() => loadGesture()}
+        />
       </Tooltip>
       <Tooltip zIndex={3} title={t('Export to File')}>
-        <Button icon={<IconFileExport size={18} />} onClick={() => exportSavedGesture(gesture)} />
+        <Button
+          aria-label={t('Export to File')}
+          icon={<IconFileExport size={18} />}
+          onClick={() => exportSavedGesture(gesture)}
+        />
       </Tooltip>
       <Tooltip zIndex={3} title={t('Delete')}>
         <Popconfirm
@@ -65,7 +74,7 @@ const SavedGestureActionsCell = (props) => {
           cancelText={t('Cancel')}
           onConfirm={() => deleteGesture()}
         >
-          <Button icon={<IconTrash size={18} />} />
+          <Button aria-label={t('Delete')} icon={<IconTrash size={18} />} />
         </Popconfirm>
       </Tooltip>
     </Space.Compact>

--- a/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
@@ -21,6 +21,7 @@ const NoContextsFoundButton = () => {
   return (
     <Tooltip title={t('noAdditionalContextsFound')} classNames={{root: styles.wideTooltip}}>
       <Button
+        aria-label={t('noAdditionalContextsFound')}
         disabled
         icon={<IconExclamationCircle size={20} />}
         styles={{root: {backgroundColor: '#faad14', color: '#ffffff'}}}
@@ -62,6 +63,7 @@ const ContextDropdown = ({contexts, currentContext, setContext, applyClientMetho
         classNames={{root: styles.wideTooltip}}
       >
         <Button
+          aria-label={t('contextDropdownInfo')}
           disabled
           icon={<IconInfoCircle size={20} />}
           styles={{root: {backgroundColor: 'var(--ant-color-primary)', color: '#ffffff'}}}
@@ -89,6 +91,7 @@ const ContextControlsGroup = ({
     <Space.Compact>
       <Tooltip title={t('Native App Mode')}>
         <Button
+          aria-label={t('Native App Mode')}
           icon={<IconTriangleSquareCircle size={18} />}
           onClick={() => selectAppMode(APP_MODE.NATIVE)}
           type={appMode === APP_MODE.NATIVE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -96,6 +99,7 @@ const ContextControlsGroup = ({
       </Tooltip>
       <Tooltip title={t('Web/Hybrid App Mode')}>
         <Button
+          aria-label={t('Web/Hybrid App Mode')}
           icon={<IconWorld size={18} />}
           onClick={() => selectAppMode(APP_MODE.WEB_HYBRID)}
           type={appMode === APP_MODE.WEB_HYBRID ? BUTTON.PRIMARY : BUTTON.DEFAULT}

--- a/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
@@ -63,7 +63,7 @@ const ContextDropdown = ({contexts, currentContext, setContext, applyClientMetho
         classNames={{root: styles.wideTooltip}}
       >
         <Button
-          aria-label={t('contextDropdownInfo')}
+          aria-label={`${t('contextDropdownInfo')} ${LINKS.HYBRID_MODE_DOCS}`}
           disabled
           icon={<IconInfoCircle size={20} />}
           styles={{root: {backgroundColor: 'var(--ant-color-primary)', color: '#ffffff'}}}

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControlsGroup.jsx
@@ -20,6 +20,7 @@ const AndroidControlsGroup = ({applyClientMethod}) => {
     <Space.Compact>
       <Tooltip title={t('Press Back Button')}>
         <Button
+          aria-label={t('Press Back Button')}
           id="btnPressBackButton"
           icon={<IconChevronLeft size={20} />}
           onClick={() =>
@@ -32,6 +33,7 @@ const AndroidControlsGroup = ({applyClientMethod}) => {
       </Tooltip>
       <Tooltip title={t('Press Home Button')}>
         <Button
+          aria-label={t('Press Home Button')}
           id="btnPressHomeButton"
           icon={<IconCircle size={16} />}
           onClick={() =>
@@ -44,6 +46,7 @@ const AndroidControlsGroup = ({applyClientMethod}) => {
       </Tooltip>
       <Tooltip title={t('Press App Switch Button')}>
         <Button
+          aria-label={t('Press App Switch Button')}
           id="btnPressAppSwitchButton"
           icon={<IconSquare size={16} />}
           onClick={() =>
@@ -75,6 +78,7 @@ const IosControlsGroup = ({
     <Space.Compact>
       <Tooltip title={t('Press Home Button')}>
         <Button
+          aria-label={t('Press Home Button')}
           id="btnPressHomeButton"
           icon={<IconHome size={18} />}
           onClick={() =>
@@ -87,6 +91,7 @@ const IosControlsGroup = ({
       </Tooltip>
       <Tooltip title={t('Execute Siri Command')}>
         <Button
+          aria-label={t('Execute Siri Command')}
           id="siriCommand"
           icon={<IconMessageChatbot size={18} />}
           onClick={showSiriCommandModal}

--- a/app/common/renderer/components/SessionInspector/Header/DisplayControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DisplayControlsGroup.jsx
@@ -21,6 +21,7 @@ const DisplayControlsGroup = ({
     <Space.Compact>
       <Tooltip title={t('toggleMultiDisplayMode')}>
         <Button
+          aria-label={t('toggleMultiDisplayMode')}
           icon={<IconCarouselHorizontal size={18} />}
           type={displays ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           onClick={() => toggleMultiDisplayMode(displays)}

--- a/app/common/renderer/components/SessionInspector/Header/GeneralControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/GeneralControlsGroup.jsx
@@ -20,6 +20,7 @@ const ToggleAutomaticRefreshButton = ({isSourceRefreshOn, setRefreshingState}) =
   return isSourceRefreshOn ? (
     <Tooltip title={t('Pause Refreshing Source')}>
       <Button
+        aria-label={t('Pause Refreshing Source')}
         id="btnPauseRefreshing"
         icon={<IconPlayerPause size={18} />}
         onClick={() => setRefreshingState({source: false})}
@@ -28,6 +29,7 @@ const ToggleAutomaticRefreshButton = ({isSourceRefreshOn, setRefreshingState}) =
   ) : (
     <Tooltip title={t('Start Refreshing Source')}>
       <Button
+        aria-label={t('Start Refreshing Source')}
         id="btnStartRefreshing"
         icon={<IconPlayerPlay size={18} />}
         onClick={() => setRefreshingState({source: true})}
@@ -45,6 +47,7 @@ const ManualRefreshButton = ({applyClientMethod}) => {
   return (
     <Tooltip title={t('refreshSource')}>
       <Button
+        aria-label={t('refreshSource')}
         id="btnReload"
         icon={<IconRefresh size={18} />}
         onClick={() => applyClientMethod({methodName: 'getPageSource'})}
@@ -64,6 +67,7 @@ const SearchForElementButton = (props) => {
     <>
       <Tooltip title={t('Search for element')}>
         <Button
+          aria-label={t('Search for element')}
           id="searchForElement"
           icon={<IconSearch size={18} />}
           onClick={showLocatorSearchModal}
@@ -83,6 +87,7 @@ const ToggleRecordingButton = ({isRecording, startRecording, pauseRecording}) =>
   return isRecording ? (
     <Tooltip title={t('Pause Recording')}>
       <Button
+        aria-label={t('Pause Recording')}
         id="btnPause"
         icon={<IconVideo size={18} />}
         type={BUTTON.PRIMARY}
@@ -92,7 +97,12 @@ const ToggleRecordingButton = ({isRecording, startRecording, pauseRecording}) =>
     </Tooltip>
   ) : (
     <Tooltip title={t('Start Recording')}>
-      <Button id="btnStartRecording" icon={<IconVideo size={18} />} onClick={startRecording} />
+      <Button
+        aria-label={t('Start Recording')}
+        id="btnStartRecording"
+        icon={<IconVideo size={18} />}
+        onClick={startRecording}
+      />
     </Tooltip>
   );
 };

--- a/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchFoundResults.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchFoundResults.jsx
@@ -75,6 +75,7 @@ const LocatorSearchResultsElementActions = ({
       <Space orientation="horizontal" size="small">
         <Tooltip title={t('Find and Select in Source')} placement="bottom">
           <Button
+            aria-label={t('Find and Select in Source')}
             disabled={!locatedElement}
             icon={<IconListSearch size={18} />}
             onClick={() =>
@@ -89,6 +90,7 @@ const LocatorSearchResultsElementActions = ({
         </Tooltip>
         <Tooltip title={t('Tap')} placement="bottom">
           <Button
+            aria-label={t('Tap')}
             disabled={!locatedElement}
             icon={<IconFocus2 size={18} />}
             onClick={() =>
@@ -106,6 +108,7 @@ const LocatorSearchResultsElementActions = ({
           />
           <Tooltip title={t('Send Keys')} placement="bottom">
             <Button
+              aria-label={t('Send Keys')}
               disabled={!locatedElement}
               icon={<IconSend2 size={18} />}
               onClick={() =>
@@ -119,6 +122,7 @@ const LocatorSearchResultsElementActions = ({
           </Tooltip>
           <Tooltip title={t('Clear')} placement="bottom">
             <Button
+              aria-label={t('Clear')}
               disabled={!locatedElement}
               id="btnClearElement"
               icon={<IconEraser size={18} />}

--- a/app/common/renderer/components/SessionInspector/Header/SessionQuitControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/SessionQuitControlsGroup.jsx
@@ -12,13 +12,19 @@ const SessionQuitControlsGroup = ({quitSessionAndReturn}) => {
     <Space.Compact>
       <Tooltip title={t('detachFromSession')}>
         <Button
+          aria-label={t('detachFromSession')}
           id="btnDetach"
           icon={<IconPlugConnectedX size={18} />}
           onClick={() => quitSessionAndReturn({detachOnly: true})}
         />
       </Tooltip>
       <Tooltip title={t('Quit Session')}>
-        <Button id="btnClose" icon={<IconX size={18} />} onClick={quitSessionAndReturn} />
+        <Button
+          aria-label={t('Quit Session')}
+          id="btnClose"
+          icon={<IconX size={18} />}
+          onClick={quitSessionAndReturn}
+        />
       </Tooltip>
     </Space.Compact>
   );

--- a/app/common/renderer/components/SessionInspector/Header/SessionReloadButton.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/SessionReloadButton.jsx
@@ -13,6 +13,7 @@ const SessionReloadButton = ({autoSessionRestart, toggleAutoSessionRestart}) => 
   return (
     <Tooltip title={t('ToggleRestartSession')}>
       <Button
+        aria-label={t('ToggleRestartSession')}
         id={autoSessionRestart ? 'btnDisableRestartSession' : 'btnEnableRestartSession'}
         icon={<IconRecycle size={16} />}
         type={autoSessionRestart ? BUTTON.PRIMARY : undefined}

--- a/app/common/renderer/components/SessionInspector/RecorderTab/RecorderTabCard.jsx
+++ b/app/common/renderer/components/SessionInspector/RecorderTab/RecorderTabCard.jsx
@@ -41,16 +41,25 @@ const RecorderTabHeaderButtons = ({
         <Space.Compact>
           <Tooltip title={t('Show/Hide Boilerplate Code')}>
             <Button
+              aria-label={t('Show/Hide Boilerplate Code')}
               onClick={toggleShowBoilerplate}
               icon={<IconEyeCode size={18} />}
               type={showBoilerplate ? BUTTON.PRIMARY : BUTTON.DEFAULT}
             />
           </Tooltip>
           <Tooltip title={t('Copy code to clipboard')}>
-            <Button icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
+            <Button
+              aria-label={t('Copy code to clipboard')}
+              icon={<IconFiles size={18} />}
+              onClick={() => copyToClipboard(clientCode)}
+            />
           </Tooltip>
           <Tooltip title={t('Clear Actions')}>
-            <Button icon={<IconEraser size={18} />} onClick={clearRecording} />
+            <Button
+              aria-label={t('Clear Actions')}
+              icon={<IconEraser size={18} />}
+              onClick={clearRecording}
+            />
           </Tooltip>
         </Space.Compact>
       )}

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -46,6 +46,7 @@ const ScreenshotCaptureModeControls = ({
     <Space.Compact>
       <Tooltip title={t('useMjpegStream')} placement="topLeft">
         <Button
+          aria-label={t('useMjpegStream')}
           icon={<IconMovie size={18} />}
           onClick={() => switchScreenCaptureMode(true)}
           type={isUsingMjpegMode ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -53,6 +54,7 @@ const ScreenshotCaptureModeControls = ({
       </Tooltip>
       <Tooltip title={t('useScreenshotApi')} placement="topLeft">
         <Button
+          aria-label={t('useScreenshotApi')}
           icon={<IconPhoto size={18} />}
           onClick={() => switchScreenCaptureMode(false)}
           type={!isUsingMjpegMode ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -75,6 +77,7 @@ const ToggleElementHandlesButton = ({
   return (
     <Tooltip title={t(showCentroids ? 'Hide Element Handles' : 'Show Element Handles')}>
       <Button
+        aria-label={t(showCentroids ? 'Hide Element Handles' : 'Show Element Handles')}
         icon={<IconEyePlus size={18} />}
         onClick={() => toggleShowCentroids()}
         type={showCentroids ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -105,6 +108,7 @@ const ScreenshotInteractionModeControls = ({
     <Space.Compact>
       <Tooltip title={t('Select Elements')}>
         <Button
+          aria-label={t('Select Elements')}
           icon={<IconObjectScan size={18} />}
           onClick={() => screenshotInteractionChange(SELECT)}
           type={screenshotInteractionMode === SELECT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -113,6 +117,7 @@ const ScreenshotInteractionModeControls = ({
       </Tooltip>
       <Tooltip title={t('Tap/Swipe By Coordinates')}>
         <Button
+          aria-label={t('Tap/Swipe By Coordinates')}
           icon={<IconCrosshair size={18} />}
           onClick={() => screenshotInteractionChange(TAP_SWIPE)}
           type={screenshotInteractionMode === TAP_SWIPE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -132,6 +137,7 @@ const DownloadScreenshotButton = ({screenshot, showScreenshot, isUsingMjpegMode}
   return (
     <Tooltip title={t('Download Screenshot')}>
       <Button
+        aria-label={t('Download Screenshot')}
         icon={<IconDownload size={18} />}
         onClick={() => downloadScreenshot(screenshot)}
         disabled={!showScreenshot || isUsingMjpegMode}

--- a/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoCodeBoxCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoCodeBoxCard.jsx
@@ -29,7 +29,11 @@ const SessionInfoCodeBoxHeaderOptions = ({clientCode, clientFramework, setClient
   return (
     <Space size="middle">
       <Tooltip title={t('Copy code to clipboard')}>
-        <Button icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
+        <Button
+          aria-label={t('Copy code to clipboard')}
+          icon={<IconFiles size={18} />}
+          onClick={() => copyToClipboard(clientCode)}
+        />
       </Tooltip>
       <Select
         defaultValue={clientFramework}

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
@@ -35,6 +35,7 @@ const AppSourceHeaderButtons = ({sourceXML}) => {
     <span>
       <Tooltip title={t('Copy XML Source to Clipboard')}>
         <Button
+          aria-label={t('Copy XML Source to Clipboard')}
           type="text"
           id="btnSourceXML"
           icon={<IconFiles size={18} />}
@@ -43,6 +44,7 @@ const AppSourceHeaderButtons = ({sourceXML}) => {
       </Tooltip>
       <Tooltip title={t('Download Source as .XML File')}>
         <Button
+          aria-label={t('Download Source as .XML File')}
           type="text"
           id="btnDownloadSourceXML"
           icon={<IconDownload size={18} />}

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceTreeActions.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceTreeActions.jsx
@@ -22,10 +22,16 @@ const AppSourceTreeActions = ({
     <Row justify="center" type={ROW.FLEX} align="middle" className={styles.treeActions}>
       <Space.Compact>
         <Tooltip title={t('Collapse All')}>
-          <Button id="btnCollapseAll" icon={<IconFold size={18} />} onClick={collapseAllNodes} />
+          <Button
+            aria-label={t('Collapse All')}
+            id="btnCollapseAll"
+            icon={<IconFold size={18} />}
+            onClick={collapseAllNodes}
+          />
         </Tooltip>
         <Tooltip title={t('Toggle Attributes')}>
           <Button
+            aria-label={t('Toggle Attributes')}
             id="btnToggleAttrs"
             icon={<IconEyeCode size={18} />}
             onClick={toggleShowAttributes}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementActions.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementActions.jsx
@@ -29,6 +29,7 @@ const SelectedElementActions = (props) => {
     <Row justify="center" type={ROW.FLEX} align="middle" className={styles.selectedElemActions}>
       <Tooltip title={t('Tap')}>
         <Button
+          aria-label={t('Tap')}
           disabled={elementActionsDisabled}
           icon={<IconFocus2 size={18} />}
           loading={tapButtonLoadingState}
@@ -48,6 +49,7 @@ const SelectedElementActions = (props) => {
         />
         <Tooltip title={t('Send Keys')}>
           <Button
+            aria-label={t('Send Keys')}
             disabled={elementActionsDisabled}
             id="btnSendKeysToElement"
             icon={<IconSend2 size={18} />}
@@ -62,6 +64,7 @@ const SelectedElementActions = (props) => {
         </Tooltip>
         <Tooltip title={t('Clear')}>
           <Button
+            aria-label={t('Clear')}
             disabled={elementActionsDisabled}
             id="btnClearElement"
             icon={<IconEraser size={18} />}
@@ -73,6 +76,7 @@ const SelectedElementActions = (props) => {
       </Space.Compact>
       <Tooltip title={t('Get Timing')}>
         <Button
+          aria-label={t('Get Timing')}
           disabled={elementActionsDisabled}
           id="btnGetTiming"
           icon={<IconStopwatch size={18} />}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
@@ -45,6 +45,7 @@ const SelectedElementHeaderButtons = ({
     <span>
       <Tooltip title={t('Copy Attributes to Clipboard')}>
         <Button
+          aria-label={t('Copy Attributes to Clipboard')}
           type="text"
           disabled={elementActionsDisabled}
           id="btnCopyAttributes"
@@ -54,6 +55,7 @@ const SelectedElementHeaderButtons = ({
       </Tooltip>
       <Tooltip title={t('Download Screenshot')}>
         <Button
+          aria-label={t('Download Screenshot')}
           type="text"
           disabled={elementActionsDisabled}
           icon={<IconDownload size={18} />}


### PR DESCRIPTION
## Summary

- add translated `aria-label` values to icon-only action buttons throughout the session inspector and session builder
- reuse each control's existing translated tooltip text so its visual and screen-reader descriptions stay aligned
- label icon controls that are nested inside confirmation popovers and the gesture editor back button

Closes #3034

## Validation

- `npm run test:lint` (passes with 104 pre-existing JSDoc warnings)
- `npm run test:format`
- `npm run test:unit` (192 tests)
- `npm run test:integration` (7 tests)