### PR TITLE
feat: add Tap By Element screenshot interaction mode

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -79,6 +79,7 @@
   "Show Element Handles": "Show Element Handles",
   "Hide Element Handles": "Hide Element Handles",
   "Select Elements": "Select Elements",
+  "Tap By Element": "Tap By Element",
   "Tap/Swipe By Coordinates": "Tap/Swipe By Coordinates",
   "Download Screenshot": "Download Screenshot",
   "Back": "Back",

--- a/app/common/renderer/actions/SessionInspector.js
+++ b/app/common/renderer/actions/SessionInspector.js
@@ -120,8 +120,42 @@ export const SET_AUTO_SESSION_RESTART = 'SET_AUTO_SESSION_RESTART';
 const KEEP_ALIVE_PING_INTERVAL = 20 * 1000;
 const NO_NEW_COMMAND_LIMIT = 24 * 60 * 60 * 1000; // Set timeout to 24 hours
 
-// A debounced function that calls findElement and gets info about the element
-const findElement = debounce(async function (strategyMap, dispatch, getState, path) {
+// Sets the selected element in the source tree/state based on its path, and
+// calculates the locator strategies that can later be used to look it up via Appium.
+// Shared by selectElement and tapElement.
+// Returns the computed strategy map.
+function prepareElementSelection(path, dispatch, getState) {
+  const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} =
+    getState().inspector;
+  const isNative = currentContext === NATIVE_APP;
+  // Set the selected element in the source tree
+  const selectedElement = findJSONElementByPath(path, sourceJSON);
+  dispatch({type: SELECT_ELEMENT, selectedElement});
+
+  // Expand all of this element's ancestors so that it's visible in the source tree
+  // Make a copy of the array to avoid state mutation
+  const copiedExpandedPaths = [...expandedPaths];
+  let pathArr = path.split('.').slice(0, path.length - 1);
+  while (pathArr.length > 1) {
+    pathArr.splice(pathArr.length - 1);
+    let ancestorPath = pathArr.join('.');
+    if (!copiedExpandedPaths.includes(ancestorPath)) {
+      copiedExpandedPaths.push(ancestorPath);
+    }
+  }
+  dispatch({type: SET_EXPANDED_PATHS, paths: copiedExpandedPaths});
+
+  // Calculate the recommended locator strategies
+  const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative, automationName);
+  dispatch({type: SET_OPTIMAL_LOCATORS, strategyMap});
+
+  return strategyMap;
+}
+
+// Calls Appium's findElement for each candidate strategy/selector until one succeeds,
+// caches the resulting elementId, and returns it (or null if none of them worked).
+// Shared by selectElement (debounced below) and tapElement (called immediately).
+async function resolveElementId(strategyMap, dispatch, getState, path) {
   for (let [strategy, selector] of strategyMap) {
     // Get the information about the element
     const action = callClientMethod({
@@ -133,47 +167,51 @@ const findElement = debounce(async function (strategyMap, dispatch, getState, pa
     // Set the elementId for the selected element
     // (check first that the selectedElementPath didn't change, to avoid race conditions)
     if (elementId && getState().inspector.selectedElementPath === path) {
-      return dispatch({type: SET_SELECTED_ELEMENT_ID, elementId});
+      dispatch({type: SET_SELECTED_ELEMENT_ID, elementId});
+      return elementId;
     }
   }
 
-  return dispatch({type: SET_INTERACTIONS_NOT_AVAILABLE});
-}, 1000);
+  dispatch({type: SET_INTERACTIONS_NOT_AVAILABLE});
+  return null;
+}
+
+// A debounced wrapper around resolveElementId, used while browsing/selecting elements
+// one at a time (Element Mode), so that quickly selecting several elements in a row
+// doesn't trigger a redundant Appium findElement call for each one.
+const debouncedResolveElementId = debounce(resolveElementId, 1000);
 
 export function selectElement(path) {
   return async (dispatch, getState) => {
-    const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} =
-      getState().inspector;
-    const isNative = currentContext === NATIVE_APP;
-    // Set the selected element in the source tree
-    const selectedElement = findJSONElementByPath(path, sourceJSON);
-    dispatch({type: SELECT_ELEMENT, selectedElement});
-
-    // Expand all of this element's ancestors so that it's visible in the source tree
-    // Make a copy of the array to avoid state mutation
-    const copiedExpandedPaths = [...expandedPaths];
-    let pathArr = path.split('.').slice(0, path.length - 1);
-    while (pathArr.length > 1) {
-      pathArr.splice(pathArr.length - 1);
-      let path = pathArr.join('.');
-      if (!copiedExpandedPaths.includes(path)) {
-        copiedExpandedPaths.push(path);
-      }
-    }
-    dispatch({type: SET_EXPANDED_PATHS, paths: copiedExpandedPaths});
-
-    // Calculate the recommended locator strategies
-    const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative, automationName);
-    dispatch({type: SET_OPTIMAL_LOCATORS, strategyMap});
+    const strategyMap = prepareElementSelection(path, dispatch, getState);
 
     // Debounce find element so that if another element is selected shortly after, cancel the previous search
-    await findElement(strategyMap, dispatch, getState, path);
+    await debouncedResolveElementId(strategyMap, dispatch, getState, path);
   };
 }
 
 export function unselectElement() {
   return (dispatch) => {
     dispatch({type: UNSELECT_ELEMENT});
+  };
+}
+
+// Selects the element at the given source path and immediately taps it (elementClick),
+// in a single action. Used by the 'Tap By Element' screenshot interaction mode, where
+// every click is a deliberate one-shot action rather than a browsing/hover selection,
+// so (unlike selectElement) this resolves the element right away instead of debouncing.
+export function tapElement(path) {
+  return async (dispatch, getState) => {
+    const strategyMap = prepareElementSelection(path, dispatch, getState);
+
+    // Cancel any pending debounced resolution left over from Element Mode, so it can't
+    // race with (and overwrite the result of) this immediate resolution.
+    debouncedResolveElementId.cancel();
+    const elementId = await resolveElementId(strategyMap, dispatch, getState, path);
+    if (elementId) {
+      const tapAction = applyClientMethod({methodName: 'elementClick', elementId});
+      await tapAction(dispatch, getState);
+    }
   };
 }
 

--- a/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementCentroid.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementCentroid.jsx
@@ -52,8 +52,7 @@ const ElementCentroid = (props) => {
     selectedElementPath,
     element,
     elementProperties,
-    selectElement,
-    unselectElement,
+    onElementInteract,
     centroidType,
     selectedCentroid,
     selectCentroid,
@@ -68,11 +67,7 @@ const ElementCentroid = (props) => {
         selectCentroid(elementProperties.path);
       }
     } else {
-      if (elementProperties.path === selectedElementPath) {
-        unselectElement();
-      } else {
-        selectElement(elementProperties.path);
-      }
+      onElementInteract(elementProperties.path);
     }
   };
 

--- a/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementOverlays.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementOverlays.jsx
@@ -1,10 +1,11 @@
-import {RENDER_CENTROID_AS} from '../../../../constants/screenshot.js';
+import {RENDER_CENTROID_AS, SCREENSHOT_INTERACTION_MODE} from '../../../../constants/screenshot.js';
 import {parseCoordinates} from '../../../../utils/other.js';
 import ElementCentroid from './ElementCentroid.jsx';
 import ElementRect from './ElementRect.jsx';
 import FoundElementRect from './FoundElementRect.jsx';
 
 const {CENTROID, OVERLAP, EXPAND} = RENDER_CENTROID_AS;
+const {TAP_ELEMENT} = SCREENSHOT_INTERACTION_MODE;
 
 const isElementOverElement = (element1, element2) => {
   const right1 = element1.left + element1.width;
@@ -164,11 +165,21 @@ const ElementOverlays = (props) => {
     selectedElementPath,
     selectElement,
     unselectElement,
+    tapElement,
+    screenshotInteractionMode,
     scaleRatio,
     showCentroids,
     isLocatorSearchModalVisible,
     isSiriCommandModalVisible,
   } = props;
+
+  // In 'Tap By Element' mode, clicking a highlighter immediately taps that element
+  // (selects it and calls elementClick). Otherwise (Element Mode), clicking toggles
+  // selection, only updating the Selected Element panel.
+  const onElementInteract =
+    screenshotInteractionMode === TAP_ELEMENT
+      ? tapElement
+      : (path) => (path === selectedElementPath ? unselectElement() : selectElement(path));
 
   const highlighterRects = [];
   const highlighterCentroids = [];
@@ -186,6 +197,7 @@ const ElementOverlays = (props) => {
             element={elem.element}
             key={elem.properties.path}
             {...props}
+            onElementInteract={onElementInteract}
           />,
         );
       }
@@ -198,8 +210,7 @@ const ElementOverlays = (props) => {
           elemProperties={elem.properties}
           key={elem.properties.path}
           selectedElementPath={selectedElementPath}
-          selectElement={selectElement}
-          unselectElement={unselectElement}
+          onElementInteract={onElementInteract}
         />,
       );
     }

--- a/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementRect.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Overlays/ElementRect.jsx
@@ -15,14 +15,8 @@ const getHighlighterClass = (elemPath, selectedElementPath) => {
  * A single rectangle overlaid on the app screenshot,
  * highlighting the bounding box of an element in the app source.
  */
-const ElementRect = ({selectedElementPath, selectElement, unselectElement, elemProperties}) => {
-  const onClickHighlighter = () => {
-    if (elemProperties.path === selectedElementPath) {
-      unselectElement();
-    } else {
-      selectElement(elemProperties.path);
-    }
-  };
+const ElementRect = ({selectedElementPath, onElementInteract, elemProperties}) => {
+  const onClickHighlighter = () => onElementInteract(elemProperties.path);
 
   const highlighterClass = getHighlighterClass(elemProperties.path, selectedElementPath);
   const highlighterStyle = {

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -2,6 +2,7 @@ import {
   IconCrosshair,
   IconDownload,
   IconEyePlus,
+  IconHandClick,
   IconMovie,
   IconObjectScan,
   IconPhoto,
@@ -14,7 +15,7 @@ import {SCREENSHOT_INTERACTION_MODE} from '../../../constants/screenshot.js';
 import {downloadFile} from '../../../utils/file-handling.js';
 import styles from './Screenshot.module.css';
 
-const {SELECT, TAP_SWIPE} = SCREENSHOT_INTERACTION_MODE;
+const {SELECT, TAP_SWIPE, TAP_ELEMENT} = SCREENSHOT_INTERACTION_MODE;
 
 const downloadScreenshot = (screenshot) => {
   const href = `data:image/png;base64,${screenshot}`;
@@ -85,8 +86,8 @@ const ToggleElementHandlesButton = ({
 };
 
 /**
- * Button allowing to switch between the Element Mode and Coordinates Mode
- * when interacting with the screenshot.
+ * Button allowing to switch between the Element Mode, Tap By Element Mode, and
+ * Coordinates Mode when interacting with the screenshot.
  */
 const ScreenshotInteractionModeControls = ({
   screenshotInteractionMode,
@@ -108,6 +109,14 @@ const ScreenshotInteractionModeControls = ({
           icon={<IconObjectScan size={18} />}
           onClick={() => screenshotInteractionChange(SELECT)}
           type={screenshotInteractionMode === SELECT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
+          disabled={isGestureEditorVisible}
+        />
+      </Tooltip>
+      <Tooltip title={t('Tap By Element')}>
+        <Button
+          icon={<IconHandClick size={18} />}
+          onClick={() => screenshotInteractionChange(TAP_ELEMENT)}
+          type={screenshotInteractionMode === TAP_ELEMENT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           disabled={isGestureEditorVisible}
         />
       </Tooltip>

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -2,10 +2,10 @@ import {
   IconCrosshair,
   IconDownload,
   IconEyePlus,
-  IconHandClick,
   IconMovie,
   IconObjectScan,
   IconPhoto,
+  IconSquarePlus,
 } from '@tabler/icons-react';
 import {Button, Space, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
@@ -114,7 +114,7 @@ const ScreenshotInteractionModeControls = ({
       </Tooltip>
       <Tooltip title={t('Tap By Element')}>
         <Button
-          icon={<IconHandClick size={18} />}
+          icon={<IconSquarePlus size={18} />}
           onClick={() => screenshotInteractionChange(TAP_ELEMENT)}
           type={screenshotInteractionMode === TAP_ELEMENT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           disabled={isGestureEditorVisible}
@@ -171,7 +171,7 @@ const ScreenshotControls = (props) => {
 
   return (
     <div className={styles.screenshotControls}>
-      <Space size="middle">
+      <Space size="small">
         {serverDetails.mjpegScreenshotUrl !== null && (
           <ScreenshotCaptureModeControls
             setMjpegState={setMjpegState}

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotImgWithOverlays.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotImgWithOverlays.jsx
@@ -15,7 +15,7 @@ import TapSwipeTrail from './Overlays/TapSwipeTrail.jsx';
 import styles from './Screenshot.module.css';
 
 const {POINTER_UP, POINTER_DOWN, PAUSE, POINTER_MOVE} = POINTER_TYPES;
-const {TAP, SELECT, SWIPE, TAP_SWIPE} = SCREENSHOT_INTERACTION_MODE;
+const {TAP, SELECT, SWIPE, TAP_SWIPE, TAP_ELEMENT} = SCREENSHOT_INTERACTION_MODE;
 
 const handleTapOnScreenshot = async (tapPoint, applyClientMethod) => {
   const {POINTER_NAME, DURATION_1, DURATION_2, BUTTON} = DEFAULT_TAP;
@@ -111,7 +111,7 @@ const ScreenshotImgWithOverlays = (props) => {
   };
 
   const handleScreenshotCoordsUpdate = (e) => {
-    if (screenshotInteractionMode !== SELECT) {
+    if (screenshotInteractionMode !== SELECT && screenshotInteractionMode !== TAP_ELEMENT) {
       const offsetX = e.nativeEvent.offsetX;
       const offsetY = e.nativeEvent.offsetY;
       const newX = offsetX * scaleRatio;
@@ -151,9 +151,13 @@ const ScreenshotImgWithOverlays = (props) => {
           onClick={handleScreenshotClick}
           className={styles.screenshotBox}
         >
-          {screenshotInteractionMode !== SELECT && <CoordinatesContainer x={x} y={y} />}
+          {screenshotInteractionMode !== SELECT && screenshotInteractionMode !== TAP_ELEMENT && (
+            <CoordinatesContainer x={x} y={y} />
+          )}
           <img src={screenSrc} id="screenshot" />
-          {screenshotInteractionMode === SELECT && <ElementOverlays {...props} />}
+          {(screenshotInteractionMode === SELECT || screenshotInteractionMode === TAP_ELEMENT) && (
+            <ElementOverlays {...props} />
+          )}
           {screenshotInteractionMode === TAP_SWIPE && (
             <TapSwipeTrail
               coordStart={coordStart}

--- a/app/common/renderer/constants/screenshot.js
+++ b/app/common/renderer/constants/screenshot.js
@@ -1,11 +1,13 @@
 // Screenshot interaction modes
 // TAP_SWIPE refers to both TAP and SWIPE
+// TAP_ELEMENT refers to tapping an element highlighter to both select and tap it in one action
 // GESTURE refers to playback via gesture editor
 export const SCREENSHOT_INTERACTION_MODE = {
   SELECT: 'select',
   SWIPE: 'swipe',
   TAP: 'tap',
   TAP_SWIPE: 'tap_swipe',
+  TAP_ELEMENT: 'tap_element',
   GESTURE: 'gesture',
 };
 

--- a/docs/session-inspector/header.md
+++ b/docs/session-inspector/header.md
@@ -131,6 +131,7 @@ and translate them into code that can be used with various [Appium clients](http
 Interactions that can be recorded include:
 
 - Actions for a specific element (tap/send keys/clear)
+- Tapping an element directly on the screenshot, in [Tap By Element Mode](./screenshot.md#interaction-mode)
 - Generic tap/swipe actions on the application screenshot
 - [Mobile device system actions](#device-system-buttons)
 - [Driver commands](./commands.md)

--- a/docs/session-inspector/header.md
+++ b/docs/session-inspector/header.md
@@ -131,7 +131,6 @@ and translate them into code that can be used with various [Appium clients](http
 Interactions that can be recorded include:
 
 - Actions for a specific element (tap/send keys/clear)
-- Tapping an element directly on the screenshot, in [Tap By Element Mode](./screenshot.md#interaction-mode)
 - Generic tap/swipe actions on the application screenshot
 - [Mobile device system actions](#device-system-buttons)
 - [Driver commands](./commands.md)

--- a/docs/session-inspector/screenshot.md
+++ b/docs/session-inspector/screenshot.md
@@ -55,7 +55,7 @@ This button toggles the visibility of highlighter handles for all identified ele
 
 !!! info
 
-    Highlighter handles are only visible in [Element Mode](#interaction-mode).
+    Highlighter handles are only visible in [Element Mode and Tap By Element Mode](#interaction-mode).
 
 ![Screenshot With Element Handles](./assets/images/screenshot/app-screenshot-highlighters.png)
 
@@ -70,13 +70,14 @@ enabling the selection of each individual element.
 
 ![Screenshot Interaction Mode Buttons](./assets/images/screenshot/interaction-mode-buttons.png)
 
-The Interaction Mode buttons allow switching between the default Element Mode, and the Coordinates
-Mode. The differences are as follows:
+The Interaction Mode buttons allow switching between the default Element Mode, Tap By Element Mode,
+and the Coordinates Mode. The differences are as follows:
 
-| <div style="width:9em">Mode</div> | Description                                                                                                                                                                                                                                                                                              |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Element Mode                      | In this mode, hovering over the screenshot will highlight any detected elements. Clicking on any highlighter will then select the corresponding element in the [application source](./source.md#application-source), and show its details in the [selected element panel](./source.md#selected-element). |
-| Coordinates Mode                  | In this mode, the top left corner of the screenshot will show an coordinates overlay. Hovering over the screenshot will update this overlay with the coordinates on the device screen, and clicking or swiping the screenshot will execute a tap/swipe action on the device.                             |
+| <div style="width:9em">Mode</div> | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Element Mode                      | In this mode, hovering over the screenshot will highlight any detected elements. Clicking on any highlighter will then select the corresponding element in the [application source](./source.md#application-source), and show its details in the [selected element panel](./source.md#selected-element).                                                                                                                                                                      |
+| Tap By Element Mode               | In this mode, hovering over the screenshot will highlight any detected elements, just like in Element Mode. However, clicking on a highlighter immediately selects **and** taps that element (equivalent to clicking [Tap Element](./source.md#element-action-buttons) in the selected element panel), using its element locator rather than raw coordinates. This is useful for quickly recording a sequence of element taps while [recording](./header.md#toggle-recorder). |
+| Coordinates Mode                  | In this mode, the top left corner of the screenshot will show an coordinates overlay. Hovering over the screenshot will update this overlay with the coordinates on the device screen, and clicking or swiping the screenshot will execute a tap/swipe action on the device.                                                                                                                                                                                                  |
 
 ### Download Screenshot
 


### PR DESCRIPTION
Closes #3037

## Summary

Adds a new **Tap By Element** screenshot interaction mode, so that tapping an element
highlighter on the app screenshot immediately selects *and* taps the element
(`elementClick`) in one click, instead of requiring the existing two-step flow (switch to
Element Mode → click highlighter to select → click **Tap** in the Selected Element panel).

This gives the Recorder tab a fast, single-click way to produce locator-based code
(`driver.$('~someId').click()`-style) for a sequence of taps, as an alternative to the
existing **Tap/Swipe By Coordinates** mode, which always records raw `x, y` coordinates
because it never resolves an element.

Related discussion: see #3037 for the full "why" and prior art (#1342, #615).

## What changed

- `constants/screenshot.js`: added `TAP_ELEMENT: 'tap_element'` to
  `SCREENSHOT_INTERACTION_MODE`.
- `actions/SessionInspector.js`: extracted the element-selection prep (`prepareElementSelection`)
  and the Appium `findElement`-based resolution (`resolveElementId`) out of `selectElement` into
  shared helpers. `selectElement` keeps its existing debounced behavior unchanged. Added a new
  `tapElement(path)` action that resolves the element immediately (no debounce — a tap is a
  single deliberate action, not a browsing/hover selection) and then performs
  `applyClientMethod({methodName: 'elementClick', elementId})`, reusing the existing recording
  pipeline (`findAndAssign` + `RECORD_ACTION`) with zero changes to it.
- `components/.../Screenshot/ScreenshotControls.jsx`: added a third interaction-mode button
  ("Tap By Element", `IconHandClick`) alongside the existing "Select Elements" and
  "Tap/Swipe By Coordinates" buttons.
- `components/.../Screenshot/ScreenshotImgWithOverlays.jsx`: show the element highlighter
  overlays (and hide the raw-coordinates overlay) in the new mode too, same as Element Mode.
- `components/.../Screenshot/Overlays/ElementOverlays.jsx`,
  `Overlays/ElementRect.jsx`, `Overlays/ElementCentroid.jsx`: compute a mode-aware click handler
  — in Element Mode it keeps the existing select/unselect toggle behavior; in Tap By Element mode
  it calls `tapElement(path)` directly. Group ("+/-") handles for overlapping elements are
  unchanged (still just expand/collapse) in both modes.
- `public/locales/en/translation.json`: added the `"Tap By Element"` tooltip string (English
  only — other languages are managed via Crowdin).
- `docs/session-inspector/screenshot.md`, `docs/session-inspector/header.md`: documented the new
  mode alongside the existing two.

## Design notes

- Reused the existing element-resolution machinery (`findElement`/`getSuggestedLocators`/
  `InspectorDriver`) rather than trying to resolve an element from raw tap coordinates. This
  keeps the change additive and low-risk: the Recorder's `applyClientMethod` recording branch
  (`strategy && selector` → `findAndAssign`) and every client-framework code generator
  (`lib/client-frameworks/*.js`) needed **no changes**.
- `selectElement`'s existing 1-second debounce exists to avoid redundant Appium calls while a
  user browses several elements in a row in Element Mode. That debounce implementation
  (`utils/common.js` `debounce`) returns synchronously and doesn't resolve a promise tied to the
  actual (delayed) invocation, so simply `await`-ing the existing debounced `selectElement` would
  not reliably yield a usable `elementId` in time for a true "one click = one tap" experience.
  `tapElement` therefore calls the shared resolution logic directly (undebounced), and cancels
  any pending debounced call left over from Element Mode to avoid a race.
- Overlapping-element group handles ("+/-") are left as pure UI disambiguation in both modes;
  only leaf element handles trigger a tap. See the "Known limitation" note in the issue proposal.

## Test plan

- [x] `npm run test:lint` — 0 errors (pre-existing `jsdoc/require-jsdoc` warnings only, none new)
- [x] `npm run test:format` — passes (prettier-formatted the docs table after editing it)
- [x] `npm run test:unit` — 192/192 passing, no regressions
- [x] `npm run test:integration` / manual real-device verification — not run in this environment;
      recommended before merge: connect a real session, switch to **Tap By Element** mode, tap a
      few elements while recording is enabled, and confirm the Recorder tab emits
      `findAndAssign` + `elementClick` (locator-based) lines rather than raw coordinates, for at
      least one Android (uiautomator2) and one iOS (XCUITest) session.
- [x] Manual UX check for overlapping elements (group handle expand/collapse still works, and
      leaf handles tap correctly) once expanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
