### PR TITLE
refactor: merge TS support into JS - WebdriverIO recorder

### DIFF
--- a/app/common/renderer/lib/client-frameworks/js-wdio.js
+++ b/app/common/renderer/lib/client-frameworks/js-wdio.js
@@ -3,15 +3,17 @@ import refractorJs from 'refractor/javascript';
 import CommonClientFramework from './common.js';
 
 export default class JsWdIoFramework extends CommonClientFramework {
-  static readableName = 'JS - WebdriverIO';
+  static readableName = 'JS/TS - WebdriverIO';
   static refractorLang = 'js';
   static refractorLib = refractorJs;
 
   wrapWithBoilerplate(code) {
     return `// This sample code supports WebdriverIO client >=9.7.0
 // (npm i --save webdriverio)
-// Then paste this into a .js file and run with Node:
+// Then paste this into a .js or .ts file and run with Node
+// (modern Node can run TypeScript files directly if types are strippable):
 // node <file>.js
+// or: node <file>.ts
 
 import {remote} from 'webdriverio';
 async function main () {


### PR DESCRIPTION
# refactor: merge TS support into JS - WebdriverIO recorder

Closes #3038

## What

This PR updates `JsWdIoFramework` (`app/common/renderer/lib/client-frameworks/js-wdio.js`) to
explicitly document support for both JavaScript and TypeScript, instead of introducing a separate
`JsWdIoTsFramework` class (the approach in the previous version of this PR).

Changes:

- `static readableName`: `'JS - WebdriverIO'` → `'JS/TS - WebdriverIO'`
- `wrapWithBoilerplate()` run instructions now mention both `.js` and `.ts` files (modern Node can
  run TypeScript directly when types are strippable)
- `static refractorLang` / `static refractorLib` are unchanged (`'js'` / `refractor/javascript`)
- Removed `js-wdio-ts.js`, and the now-unused `JS_WDIO_TS` references in
  `constants/session-inspector.js` and `lib/client-frameworks/map.js`

## Why

@eglitise reviewed the original approach and pointed out that the generated code was identical
between the JS and TS versions, and suggested editing the existing JS recorder's strings rather
than maintaining a separate class:

> Overall, I don't see the benefits of a separate TS recorder, so I would suggest simply modifying
> the few JS-specific strings in the JS recorder, so that it's clear that the code applies to both
> JS and TS.

This PR implements that suggestion.

## Test plan

- [x] `npm run test:lint` — 0 errors (pre-existing jsdoc warnings only, unrelated to this change)
- [x] `npm run test:format` (prettier -c) — passes
- [x] `npm run test:unit` — 192/192 passing
- [x] Manually verified in the running Inspector app: started an Android emulator + local Appium
      server, recorded a session in the browser-based Inspector, and confirmed the Recorder tab's
      language dropdown shows `JS/TS - WebdriverIO` with the updated run instructions
- [x] Took the actual recorded output (e.g. `driver.$("accessibility id:Chrome")`) embedded in the
      updated `wrapWithBoilerplate()` template and type-checked it with `tsc --noEmit --strict`
      against `webdriverio`'s bundled types, for both `.ts` and `.mts` extensions — no errors
