### PR TITLE
chore: tune electron-builder Linux options

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -41,7 +41,16 @@
   },
   "linux": {
     "target": ["AppImage", "tar.gz"],
-    "category": "Development"
+    "category": "Development",
+    "desktop": {
+      "entry": {
+        "Name": "Appium Inspector",
+        "Comment": "GUI inspector for apps, powered by Appium",
+        "Categories": "Development",
+        "Terminal": false,
+        "Type": "Application"
+      }
+    }
   },
   "publish": {
     "provider": "github",

--- a/package.json
+++ b/package.json
@@ -119,5 +119,9 @@
   "engines": {
     "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
     "npm": ">=10.x"
+  },
+  "desktopName": "io.appium.inspector",
+  "allowScripts": {
+    "electron": true
   }
 }


### PR DESCRIPTION
* Add `desktopName` in `package.json` for window association: https://www.electron.build/docs/linux#window-association-desktopname
* Add details for the Linux `.desktop` file: https://www.electron.build/docs/linux#desktop-file-customization
* Add `allowScripts` in `package.json` for `electron` (not needed for `electron-build`, only `electron-vite` on npm v12)