### PR TITLE
chore: tune electron-builder macOS options

### DIFF
--- a/build/entitlements.mac.inherit.plist
+++ b/build/entitlements.mac.inherit.plist
@@ -2,10 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <!-- Required for JIT compilation (e.g., V8 in Electron) -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
-  <!-- Required for unsigned executable memory (some Electron internals) -->
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
 </dict>

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -15,7 +15,8 @@
     }
   ],
   "mac": {
-    "category": "public.app-category.developer-tools"
+    "category": "public.app-category.developer-tools",
+    "darkModeSupport": true
   },
   "dmg": {
     "contents": [

--- a/electron-builder.json
+++ b/electron-builder.json
@@ -15,8 +15,7 @@
     }
   ],
   "mac": {
-    "category": "public.app-category.developer-tools",
-    "darkModeSupport": true
+    "category": "public.app-category.developer-tools"
   },
   "dmg": {
     "contents": [


### PR DESCRIPTION
* Adjust entitlement files as per template: https://www.electron.build/docs/mac#entitlements