### PR TITLE
fix: make the New Session screen responsive on narrow windows

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -5,8 +5,6 @@ body.dark {
 }
 
 body {
-  min-height: 610px;
-  min-width: 870px;
   color: #222 !important;
   box-sizing: border-box;
 }

--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -12,14 +12,19 @@ import {
   Splitter,
   Tooltip,
 } from 'antd';
-import {useEffect, useRef} from 'react';
+import {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {CAPABILITY_TYPES} from '../../../constants/session-builder.js';
+import {debounce} from '../../../utils/common.js';
 import CapabilityJSON from '../CapabilityJSON/CapabilityJSON.jsx';
 import builderStyles from '../SessionBuilder.module.css';
 import styles from './CapabilityBuilderTab.module.css';
 import CapabilityControl from './CapabilityControl.jsx';
+
+// Below this window width, the JSON preview panel no longer has enough room
+// to sit beside the capability builder panel, so it wraps below it instead.
+const NARROW_LAYOUT_BREAKPOINT = 700;
 
 const whitespaces = /^\s|\s$/;
 
@@ -84,6 +89,19 @@ const CapabilityEditor = (props) => {
   const latestCapFieldRef = useRef(null);
   const {t} = useTranslation();
 
+  const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
+  useEffect(() => {
+    const updateIsNarrow = debounce(
+      () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT),
+      100,
+    );
+    window.addEventListener('resize', updateIsNarrow);
+    return () => {
+      window.removeEventListener('resize', updateIsNarrow);
+      updateIsNarrow.cancel();
+    };
+  }, []);
+
   // if we have more than one cap and the most recent cap name is empty,
   // it means we've just added a new cap field, so focus that input element
   useEffect(() => {
@@ -93,7 +111,12 @@ const CapabilityEditor = (props) => {
   }, [caps.length, latestCapFieldRef]);
 
   return (
-    <Splitter>
+    // Remounting on orientation change avoids Splitter retaining stale panel
+    // sizes/state from the previous layout when switching back and forth.
+    <Splitter
+      key={isNarrow ? 'vertical' : 'horizontal'}
+      layout={isNarrow ? 'vertical' : 'horizontal'}
+    >
       <Splitter.Panel collapsible resizable={false}>
         <Form className={styles.newSessionForm}>
           {caps.map((cap, index) => (

--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -16,7 +16,6 @@ import {useEffect, useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 
 import {CAPABILITY_TYPES} from '../../../constants/session-builder.js';
-import {debounce} from '../../../utils/common.js';
 import CapabilityJSON from '../CapabilityJSON/CapabilityJSON.jsx';
 import builderStyles from '../SessionBuilder.module.css';
 import styles from './CapabilityBuilderTab.module.css';
@@ -91,15 +90,15 @@ const CapabilityEditor = (props) => {
 
   const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
   useEffect(() => {
-    const updateIsNarrow = debounce(
-      () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT),
-      100,
-    );
+    // Deliberately not debounced: Splitter measures its container via its
+    // own ResizeObserver, which can fire before a debounced update here
+    // would land. If that happens while this is still reporting the old
+    // orientation, Splitter reads the wrong axis (width vs height) and
+    // caches a stale container size, leaving panels stuck at the wrong
+    // size until another resize happens to nudge it again.
+    const updateIsNarrow = () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
     window.addEventListener('resize', updateIsNarrow);
-    return () => {
-      window.removeEventListener('resize', updateIsNarrow);
-      updateIsNarrow.cancel();
-    };
+    return () => window.removeEventListener('resize', updateIsNarrow);
   }, []);
 
   // if we have more than one cap and the most recent cap name is empty,
@@ -111,12 +110,7 @@ const CapabilityEditor = (props) => {
   }, [caps.length, latestCapFieldRef]);
 
   return (
-    // Remounting on orientation change avoids Splitter retaining stale panel
-    // sizes/state from the previous layout when switching back and forth.
-    <Splitter
-      key={isNarrow ? 'vertical' : 'horizontal'}
-      layout={isNarrow ? 'vertical' : 'horizontal'}
-    >
+    <Splitter orientation={isNarrow ? 'vertical' : 'horizontal'}>
       <Splitter.Panel collapsible resizable={false}>
         <Form className={styles.newSessionForm}>
           {caps.map((cap, index) => (

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
@@ -2,6 +2,33 @@
   width: 100%;
 }
 
+.serverRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.serverHostGroup {
+  flex: 1 1 240px;
+}
+
+.serverPortPathGroup {
+  display: flex;
+  flex: 2 1 320px;
+  align-items: center;
+  gap: 8px;
+}
+
+.serverPortInput {
+  width: 4.5em;
+  flex: 0 0 auto;
+}
+
+.serverPathCompact {
+  flex: 1 1 auto;
+  min-width: 120px;
+}
+
 .advancedSettingsContainer :global(.ant-form-item) {
   margin: 0;
 }

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
@@ -15,18 +15,19 @@
 .serverPortPathGroup {
   display: flex;
   flex: 2 1 320px;
-  align-items: center;
   gap: 8px;
 }
 
 .serverPortInput {
-  width: 4.5em;
-  flex: 0 0 auto;
+  width: 5em;
 }
 
 .serverPathCompact {
   flex: 1 1 auto;
-  min-width: 120px;
+}
+
+.serverPathInput {
+  min-width: 50px;
 }
 
 .advancedSettingsContainer :global(.ant-form-item) {

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerDetails.module.css
@@ -22,10 +22,6 @@
   width: 5em;
 }
 
-.serverPathCompact {
-  flex: 1 1 auto;
-}
-
 .serverPathInput {
   min-width: 50px;
 }

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
@@ -34,6 +34,7 @@ const ServerTabCustom = ({server, setServerParam}) => {
           <Space.Addon>{t('Remote Path')}</Space.Addon>
           <Input
             id="customServerPath"
+            className={styles.serverPathInput}
             placeholder={DEFAULT_SERVER_PROPS.path}
             value={server.remote.path}
             onChange={(e) => setServerParam('path', e.target.value)}

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
@@ -1,4 +1,4 @@
-import {Checkbox, Col, Input, Row, Space} from 'antd';
+import {Checkbox, Input, Space} from 'antd';
 import {useTranslation} from 'react-i18next';
 
 import {DEFAULT_SERVER_PROPS} from '../../../constants/webdriver.js';
@@ -7,8 +7,8 @@ import styles from './ServerDetails.module.css';
 const ServerTabCustom = ({server, setServerParam}) => {
   const {t} = useTranslation();
   return (
-    <Row gutter={8}>
-      <Col span={9}>
+    <div className={styles.serverRow}>
+      <div className={styles.serverHostGroup}>
         <Space.Compact block>
           <Space.Addon>{t('Remote Host')}</Space.Addon>
           <Input
@@ -18,20 +18,19 @@ const ServerTabCustom = ({server, setServerParam}) => {
             onChange={(e) => setServerParam('hostname', e.target.value)}
           />
         </Space.Compact>
-      </Col>
-      <Col span={4}>
-        <Space.Compact block>
+      </div>
+      <div className={styles.serverPortPathGroup}>
+        <Space.Compact>
           <Space.Addon>{t('Remote Port')}</Space.Addon>
           <Input
             id="customServerPort"
+            className={styles.serverPortInput}
             placeholder={DEFAULT_SERVER_PROPS.port}
             value={server.remote.port}
             onChange={(e) => setServerParam('port', e.target.value)}
           />
         </Space.Compact>
-      </Col>
-      <Col span={9}>
-        <Space.Compact block>
+        <Space.Compact block className={styles.serverPathCompact}>
           <Space.Addon>{t('Remote Path')}</Space.Addon>
           <Input
             id="customServerPath"
@@ -40,8 +39,6 @@ const ServerTabCustom = ({server, setServerParam}) => {
             onChange={(e) => setServerParam('path', e.target.value)}
           />
         </Space.Compact>
-      </Col>
-      <Col span={2}>
         <Checkbox
           className={styles.addonCheckbox}
           id="customServerSSL"
@@ -51,8 +48,8 @@ const ServerTabCustom = ({server, setServerParam}) => {
         >
           {t('SSL')}
         </Checkbox>
-      </Col>
-    </Row>
+      </div>
+    </div>
   );
 };
 

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/ServerTabCustom.jsx
@@ -30,7 +30,7 @@ const ServerTabCustom = ({server, setServerParam}) => {
             onChange={(e) => setServerParam('port', e.target.value)}
           />
         </Space.Compact>
-        <Space.Compact block className={styles.serverPathCompact}>
+        <Space.Compact block>
           <Space.Addon>{t('Remote Path')}</Space.Addon>
           <Input
             id="customServerPath"


### PR DESCRIPTION
## What

Fixes the New Session screen's layout so it adapts to narrow windows instead of overlapping, in the browser build.

- Removed the `body` `min-width`/`min-height` floor in `main.css`. It's redundant for the Electron build (which enforces its own native window `minWidth`/`minHeight`), and actively harmful for the browser build (nothing prevents the actual viewport from going narrower than that forced floor, e.g. via a narrow browser tab, embedding, or zoom - and the CSS-mandated body size did nothing but prevent the page from shrinking to match).
- `ServerTabCustom.jsx` / `ServerDetails.module.css`: replaced the percentage-based `Row`/`Col` grid for Remote Host/Port/Path/SSL with a `flex-wrap` layout. Remote Port is now a small fixed-width field (fits a 4-5 digit port); Remote Port/Remote Path/SSL are grouped so they wrap together onto a new line below Remote Host once space runs out.
- `CapabilityEditor.jsx`: the Capability Builder / JSON Representation `Splitter` now switches to a vertical layout below a width breakpoint (700px), so the JSON preview stacks below the builder instead of becoming unreadably narrow. The `Splitter` is remounted (`key`) on each orientation change - without this it retains stale panel sizes from the previous orientation, so resizing the window back and forth could leave it stuck showing a shrunken panel even at a wide width.

Closes #3061

## Test plan

- [x] `npm run test:lint` / `test:format` / `test:unit` all pass (192/192)
- [x] Manually verified in the browser build (`npm run dev:browser`) at a range of widths (1200 → 320px, both English and Japanese locale) that:
  - Remote Host/Port/Path/SSL no longer overlap at any width, and wrap as expected below ~700px
  - The JSON Representation panel stacks below the Capability Builder panel below the same breakpoint
  - Repeatedly narrowing/widening the window past the breakpoint no longer leaves either panel stuck at a stale size