### PR TITLE
fix: make the Session Inspector screen responsive on narrow windows

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -91,6 +91,8 @@
   "Search for element": "Search for element",
   "App Source": "App Source",
   "Collapse All": "Collapse All",
+  "Collapse Panel": "Collapse Panel",
+  "Expand Panel": "Expand Panel",
   "Toggle Attributes": "Toggle Attributes",
   "Copy XML Source to Clipboard": "Copy XML Source to Clipboard",
   "Download Source as .XML File": "Download Source as .XML File",

--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -5,8 +5,6 @@ body.dark {
 }
 
 body {
-  min-height: 610px;
-  min-width: 870px;
   color: #222 !important;
   box-sizing: border-box;
 }

--- a/app/common/renderer/components/SessionInspector/Header/Header.module.css
+++ b/app/common/renderer/components/SessionInspector/Header/Header.module.css
@@ -5,11 +5,12 @@
 .headerButtons {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: safe center;
   padding: 10px 0;
   gap: 10px;
   width: 100%;
   height: 50px;
+  overflow-x: auto;
   -webkit-app-region: drag;
 }
 

--- a/app/common/renderer/components/SessionInspector/Header/Header.module.css
+++ b/app/common/renderer/components/SessionInspector/Header/Header.module.css
@@ -9,8 +9,7 @@
   padding: 10px 0;
   gap: 10px;
   width: 100%;
-  height: 50px;
-  overflow-x: auto;
+  min-height: 50px;
   -webkit-app-region: drag;
 }
 

--- a/app/common/renderer/components/SessionInspector/Header/Header.module.css
+++ b/app/common/renderer/components/SessionInspector/Header/Header.module.css
@@ -13,6 +13,10 @@
   -webkit-app-region: drag;
 }
 
+.headerButtonsSpace {
+  justify-content: center;
+}
+
 .headerButtons :global(.ant-divider-horizontal) {
   margin: 0px;
 }

--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -38,7 +38,7 @@ const HeaderButtons = (props) => {
 
   return (
     <div className={styles.headerButtons}>
-      <Space size="middle">
+      <Space size="middle" wrap>
         <DeviceControlsGroup
           driver={driver}
           applyClientMethod={applyClientMethod}

--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -38,7 +38,7 @@ const HeaderButtons = (props) => {
 
   return (
     <div className={styles.headerButtons}>
-      <Space size="middle" wrap>
+      <Space size="middle" wrap className={styles.headerButtonsSpace}>
         <DeviceControlsGroup
           driver={driver}
           applyClientMethod={applyClientMethod}

--- a/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.module.css
+++ b/app/common/renderer/components/SessionInspector/Screenshot/Screenshot.module.css
@@ -1,6 +1,7 @@
 .screenshotContainer {
   max-width: 500px;
   max-height: calc(100% - 50px);
+  min-width: 200px;
   flex-grow: 1;
   flex-shrink: 2;
   flex-basis: 400px;

--- a/app/common/renderer/components/SessionInspector/SessionInspector.module.css
+++ b/app/common/renderer/components/SessionInspector/SessionInspector.module.css
@@ -15,6 +15,7 @@
   padding: 1em;
   max-width: 100%;
   height: calc(100% - 50px);
+  overflow-x: auto;
 }
 
 .inspectorMain :global(.ant-card-head-wrapper) {

--- a/app/common/renderer/components/SessionInspector/SessionInspector.module.css
+++ b/app/common/renderer/components/SessionInspector/SessionInspector.module.css
@@ -14,7 +14,7 @@
   flex-direction: row;
   padding: 1em;
   max-width: 100%;
-  height: calc(100% - 50px);
+  min-height: 0;
   overflow-x: auto;
 }
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSource.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSource.jsx
@@ -5,10 +5,15 @@ import AppSourceTreeWrapper from './AppSourceTreeWrapper.jsx';
  * Shows the app source as a tree with search and attribute toggles.
  */
 const AppSource = (props) => {
-  const {sourceXML} = props;
+  const {sourceXML, collapsible, collapsed, onToggleCollapse} = props;
 
   return (
-    <AppSourceCard sourceXML={sourceXML}>
+    <AppSourceCard
+      sourceXML={sourceXML}
+      collapsible={collapsible}
+      collapsed={collapsed}
+      onToggleCollapse={onToggleCollapse}
+    >
       <AppSourceTreeWrapper {...props} />
     </AppSourceCard>
   );

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
@@ -32,9 +32,12 @@ const AppSourcePanelTitle = () => {
 };
 
 /**
- * Header action buttons for source XML copy and download.
+ * Header action buttons for source XML copy and download, plus (when panels
+ * are stacked) the toggle that collapses/expands the card body while keeping
+ * its header visible - the side-by-side layout already offers a full
+ * collapse via the Splitter divider.
  */
-const AppSourceHeaderButtons = ({sourceXML}) => {
+const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleCollapse}) => {
   const {t} = useTranslation();
 
   return (
@@ -55,27 +58,16 @@ const AppSourceHeaderButtons = ({sourceXML}) => {
           onClick={() => downloadXML(sourceXML)}
         />
       </Tooltip>
+      {collapsible && (
+        <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+          <Button
+            type="text"
+            icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
+            onClick={onToggleCollapse}
+          />
+        </Tooltip>
+      )}
     </span>
-  );
-};
-
-/**
- * Toggle button that collapses/expands the card body while keeping its
- * header visible. Only shown when panels are stacked (narrow layout),
- * since the side-by-side layout already offers a full collapse via the
- * Splitter divider.
- */
-const CollapseToggleButton = ({collapsed, onClick}) => {
-  const {t} = useTranslation();
-
-  return (
-    <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
-      <Button
-        type="text"
-        icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
-        onClick={onClick}
-      />
-    </Tooltip>
   );
 };
 
@@ -86,10 +78,12 @@ const AppSourceCard = ({sourceXML, collapsible, collapsed, onToggleCollapse, chi
   <Card
     title={<AppSourcePanelTitle />}
     extra={
-      <span>
-        <AppSourceHeaderButtons sourceXML={sourceXML} />
-        {collapsible && <CollapseToggleButton collapsed={collapsed} onClick={onToggleCollapse} />}
-      </span>
+      <AppSourceHeaderButtons
+        sourceXML={sourceXML}
+        collapsible={collapsible}
+        collapsed={collapsed}
+        onToggleCollapse={onToggleCollapse}
+      />
     }
   >
     {!collapsed && children}

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
@@ -1,4 +1,10 @@
-import {IconDownload, IconFiles, IconFileText} from '@tabler/icons-react';
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconDownload,
+  IconFiles,
+  IconFileText,
+} from '@tabler/icons-react';
 import {Button, Card, Flex, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
@@ -54,11 +60,39 @@ const AppSourceHeaderButtons = ({sourceXML}) => {
 };
 
 /**
+ * Toggle button that collapses/expands the card body while keeping its
+ * header visible. Only shown when panels are stacked (narrow layout),
+ * since the side-by-side layout already offers a full collapse via the
+ * Splitter divider.
+ */
+const CollapseToggleButton = ({collapsed, onClick}) => {
+  const {t} = useTranslation();
+
+  return (
+    <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+      <Button
+        type="text"
+        icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
+        onClick={onClick}
+      />
+    </Tooltip>
+  );
+};
+
+/**
  * Wrapper card for the app source tree.
  */
-const AppSourceCard = ({sourceXML, children}) => (
-  <Card title={<AppSourcePanelTitle />} extra={<AppSourceHeaderButtons sourceXML={sourceXML} />}>
-    {children}
+const AppSourceCard = ({sourceXML, collapsible, collapsed, onToggleCollapse, children}) => (
+  <Card
+    title={<AppSourcePanelTitle />}
+    extra={
+      <span>
+        <AppSourceHeaderButtons sourceXML={sourceXML} />
+        {collapsible && <CollapseToggleButton collapsed={collapsed} onClick={onToggleCollapse} />}
+      </span>
+    }
+  >
+    {!collapsed && children}
   </Card>
 );
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.jsx
@@ -30,6 +30,9 @@ const SelectedElement = (props) => {
     elementInteractionsNotAvailable,
     selectedElementSearchInProgress,
     sessionSettings,
+    collapsible,
+    collapsed,
+    onToggleCollapse,
   } = props;
 
   const elementActionsDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
@@ -59,6 +62,9 @@ const SelectedElement = (props) => {
       selectedElementId={selectedElementId}
       elementAttributesData={elementAttributesData}
       elementActionsDisabled={elementActionsDisabled}
+      collapsible={collapsible}
+      collapsed={collapsed}
+      onToggleCollapse={onToggleCollapse}
     >
       <Space className={inspectorStyles.spaceContainer} orientation="vertical" size="middle">
         <SnapshotMaxDepthReachedMessage

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
@@ -1,4 +1,10 @@
-import {IconDownload, IconFiles, IconTag} from '@tabler/icons-react';
+import {
+  IconChevronDown,
+  IconChevronUp,
+  IconDownload,
+  IconFiles,
+  IconTag,
+} from '@tabler/icons-react';
 import {Button, Card, Flex, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
@@ -66,6 +72,26 @@ const SelectedElementHeaderButtons = ({
 };
 
 /**
+ * Toggle button that collapses/expands the card body while keeping its
+ * header visible. Only shown when panels are stacked (narrow layout),
+ * since the side-by-side layout already offers a full collapse via the
+ * Splitter divider.
+ */
+const CollapseToggleButton = ({collapsed, onClick}) => {
+  const {t} = useTranslation();
+
+  return (
+    <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+      <Button
+        type="text"
+        icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
+        onClick={onClick}
+      />
+    </Tooltip>
+  );
+};
+
+/**
  * The selected element panel's wrapper card, with title and action buttons.
  */
 const SelectedElementCard = ({
@@ -73,21 +99,27 @@ const SelectedElementCard = ({
   selectedElementId,
   elementActionsDisabled,
   elementAttributesData,
+  collapsible,
+  collapsed,
+  onToggleCollapse,
   children,
 }) => (
   <Card
     title={<SelectedElementPanelTitle />}
     className={styles.selectedElementCard}
     extra={
-      <SelectedElementHeaderButtons
-        elementAttributesData={elementAttributesData}
-        elementActionsDisabled={elementActionsDisabled}
-        selectedElementId={selectedElementId}
-        applyClientMethod={applyClientMethod}
-      />
+      <span>
+        <SelectedElementHeaderButtons
+          elementAttributesData={elementAttributesData}
+          elementActionsDisabled={elementActionsDisabled}
+          selectedElementId={selectedElementId}
+          applyClientMethod={applyClientMethod}
+        />
+        {collapsible && <CollapseToggleButton collapsed={collapsed} onClick={onToggleCollapse} />}
+      </span>
     }
   >
-    {children}
+    {!collapsed && children}
   </Card>
 );
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
@@ -26,13 +26,19 @@ const SelectedElementPanelTitle = () => {
 };
 
 /**
- * Buttons shown in the selected element's wrapper card.
+ * Buttons shown in the selected element's wrapper card, plus (when panels
+ * are stacked) the toggle that collapses/expands the card body while keeping
+ * its header visible - the side-by-side layout already offers a full
+ * collapse via the Splitter divider.
  */
 const SelectedElementHeaderButtons = ({
   elementAttributesData,
   elementActionsDisabled,
   selectedElementId,
   applyClientMethod,
+  collapsible,
+  collapsed,
+  onToggleCollapse,
 }) => {
   const {t} = useTranslation();
 
@@ -67,27 +73,16 @@ const SelectedElementHeaderButtons = ({
           onClick={() => downloadElementScreenshot(selectedElementId)}
         />
       </Tooltip>
+      {collapsible && (
+        <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+          <Button
+            type="text"
+            icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
+            onClick={onToggleCollapse}
+          />
+        </Tooltip>
+      )}
     </span>
-  );
-};
-
-/**
- * Toggle button that collapses/expands the card body while keeping its
- * header visible. Only shown when panels are stacked (narrow layout),
- * since the side-by-side layout already offers a full collapse via the
- * Splitter divider.
- */
-const CollapseToggleButton = ({collapsed, onClick}) => {
-  const {t} = useTranslation();
-
-  return (
-    <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
-      <Button
-        type="text"
-        icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
-        onClick={onClick}
-      />
-    </Tooltip>
   );
 };
 
@@ -108,15 +103,15 @@ const SelectedElementCard = ({
     title={<SelectedElementPanelTitle />}
     className={styles.selectedElementCard}
     extra={
-      <span>
-        <SelectedElementHeaderButtons
-          elementAttributesData={elementAttributesData}
-          elementActionsDisabled={elementActionsDisabled}
-          selectedElementId={selectedElementId}
-          applyClientMethod={applyClientMethod}
-        />
-        {collapsible && <CollapseToggleButton collapsed={collapsed} onClick={onToggleCollapse} />}
-      </span>
+      <SelectedElementHeaderButtons
+        elementAttributesData={elementAttributesData}
+        elementActionsDisabled={elementActionsDisabled}
+        selectedElementId={selectedElementId}
+        applyClientMethod={applyClientMethod}
+        collapsible={collapsible}
+        collapsed={collapsed}
+        onToggleCollapse={onToggleCollapse}
+      />
     }
   >
     {!collapsed && children}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
@@ -10,7 +10,7 @@ import styles from './SourceTab.module.css';
 // against this tab's own container width (not the window's), since the tab
 // shares horizontal space with the screenshot, whose width can vary
 // independently (e.g. portrait vs landscape orientation).
-const NARROW_LAYOUT_BREAKPOINT = 700;
+const NARROW_LAYOUT_BREAKPOINT = 600;
 
 // Height of a card's header row (title + action buttons). Used as the
 // collapsed size for a stacked panel, so its header stays visible while its

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
@@ -1,7 +1,6 @@
 import {Splitter} from 'antd';
 import {useEffect, useState} from 'react';
 
-import {debounce} from '../../../utils/common.js';
 import AppSource from './AppSource/AppSource.jsx';
 import SelectedElement from './SelectedElement/SelectedElement.jsx';
 
@@ -21,15 +20,15 @@ const SourceTab = (props) => {
 
   const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
   useEffect(() => {
-    const updateIsNarrow = debounce(
-      () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT),
-      100,
-    );
+    // Deliberately not debounced: Splitter measures its container via its
+    // own ResizeObserver, which can fire before a debounced update here
+    // would land. If that happens while this is still reporting the old
+    // orientation, Splitter reads the wrong axis (width vs height) and
+    // caches a stale container size, leaving panels stuck at the wrong
+    // size until another resize happens to nudge it again.
+    const updateIsNarrow = () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
     window.addEventListener('resize', updateIsNarrow);
-    return () => {
-      window.removeEventListener('resize', updateIsNarrow);
-      updateIsNarrow.cancel();
-    };
+    return () => window.removeEventListener('resize', updateIsNarrow);
   }, []);
 
   const [appSourceCollapsed, setAppSourceCollapsed] = useState(false);
@@ -64,12 +63,7 @@ const SourceTab = (props) => {
   const canAccordionCollapse = isNarrow && hasSelectedElement;
 
   return (
-    // Remounting on orientation change avoids Splitter retaining stale panel
-    // sizes/state from the previous layout when switching back and forth.
-    <Splitter
-      key={isNarrow ? 'vertical' : 'horizontal'}
-      layout={isNarrow ? 'vertical' : 'horizontal'}
-    >
+    <Splitter orientation={isNarrow ? 'vertical' : 'horizontal'}>
       <Splitter.Panel
         collapsible={
           !isNarrow && hasSelectedElement

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
@@ -1,25 +1,109 @@
 import {Splitter} from 'antd';
+import {useEffect, useState} from 'react';
 
+import {debounce} from '../../../utils/common.js';
 import AppSource from './AppSource/AppSource.jsx';
 import SelectedElement from './SelectedElement/SelectedElement.jsx';
+
+// Below this window width, the selected element panel no longer has enough
+// room to sit beside the app source panel, so it wraps below it instead.
+const NARROW_LAYOUT_BREAKPOINT = 700;
+
+// Height of a card's header row (title + action buttons). Used as the
+// collapsed size for a stacked panel, so its header stays visible while its
+// body is hidden and the other panel gets the freed space.
+const PANEL_HEADER_HEIGHT = 55;
 
 const SourceTab = (props) => {
   const {selectedElement = {}} = props;
 
   const hasSelectedElement = Object.keys(selectedElement).length > 0;
 
+  const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
+  useEffect(() => {
+    const updateIsNarrow = debounce(
+      () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT),
+      100,
+    );
+    window.addEventListener('resize', updateIsNarrow);
+    return () => {
+      window.removeEventListener('resize', updateIsNarrow);
+      updateIsNarrow.cancel();
+    };
+  }, []);
+
+  const [appSourceCollapsed, setAppSourceCollapsed] = useState(false);
+  const [selectedElementCollapsed, setSelectedElementCollapsed] = useState(false);
+
+  // Splitter can't shrink both panels to their collapsed size at once (with
+  // neither panel left to absorb the freed space, it resets both back to
+  // their default size) - so collapsing one always re-expands the other,
+  // keeping exactly one panel expanded at a time.
+  const toggleAppSourceCollapse = () => {
+    setAppSourceCollapsed((collapsed) => {
+      const next = !collapsed;
+      if (next) {
+        setSelectedElementCollapsed(false);
+      }
+      return next;
+    });
+  };
+  const toggleSelectedElementCollapse = () => {
+    setSelectedElementCollapsed((collapsed) => {
+      const next = !collapsed;
+      if (next) {
+        setAppSourceCollapsed(false);
+      }
+      return next;
+    });
+  };
+
+  // Accordion-style collapse (header stays, body hides, other panel grows
+  // into the freed space) only makes sense when panels are stacked and both
+  // are present - otherwise fall back to the Splitter's own full collapse.
+  const canAccordionCollapse = isNarrow && hasSelectedElement;
+
   return (
-    <Splitter>
+    // Remounting on orientation change avoids Splitter retaining stale panel
+    // sizes/state from the previous layout when switching back and forth.
+    <Splitter
+      key={isNarrow ? 'vertical' : 'horizontal'}
+      layout={isNarrow ? 'vertical' : 'horizontal'}
+    >
       <Splitter.Panel
-        collapsible={hasSelectedElement}
-        size={hasSelectedElement ? undefined : 100}
-        min={210}
+        collapsible={
+          !isNarrow && hasSelectedElement
+            ? {start: true, end: true, showCollapsibleIcon: true}
+            : false
+        }
+        size={
+          canAccordionCollapse && appSourceCollapsed
+            ? PANEL_HEADER_HEIGHT
+            : hasSelectedElement
+              ? undefined
+              : 100
+        }
+        min={canAccordionCollapse && appSourceCollapsed ? PANEL_HEADER_HEIGHT : 210}
       >
-        <AppSource {...props} />
+        <AppSource
+          {...props}
+          collapsible={canAccordionCollapse}
+          collapsed={canAccordionCollapse && appSourceCollapsed}
+          onToggleCollapse={toggleAppSourceCollapse}
+        />
       </Splitter.Panel>
       {hasSelectedElement && (
-        <Splitter.Panel collapsible={true} min={250}>
-          <SelectedElement {...props} />
+        <Splitter.Panel
+          collapsible={!isNarrow ? {start: true, end: true, showCollapsibleIcon: true} : false}
+          size={canAccordionCollapse && selectedElementCollapsed ? PANEL_HEADER_HEIGHT : undefined}
+          min={canAccordionCollapse && selectedElementCollapsed ? PANEL_HEADER_HEIGHT : 250}
+        >
+          <SelectedElement
+            {...props}
+            collapsible={canAccordionCollapse}
+            collapsed={canAccordionCollapse && selectedElementCollapsed}
+            onToggleCollapse={toggleSelectedElementCollapse}
+          />
         </Splitter.Panel>
       )}
     </Splitter>

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
@@ -1,11 +1,15 @@
 import {Splitter} from 'antd';
-import {useEffect, useState} from 'react';
+import {useEffect, useRef, useState} from 'react';
 
 import AppSource from './AppSource/AppSource.jsx';
 import SelectedElement from './SelectedElement/SelectedElement.jsx';
+import styles from './SourceTab.module.css';
 
-// Below this window width, the selected element panel no longer has enough
-// room to sit beside the app source panel, so it wraps below it instead.
+// Below this width, the selected element panel no longer has enough room to
+// sit beside the app source panel, so it wraps below it instead. Measured
+// against this tab's own container width (not the window's), since the tab
+// shares horizontal space with the screenshot, whose width can vary
+// independently (e.g. portrait vs landscape orientation).
 const NARROW_LAYOUT_BREAKPOINT = 700;
 
 // Height of a card's header row (title + action buttons). Used as the
@@ -18,19 +22,8 @@ const SourceTab = (props) => {
 
   const hasSelectedElement = Object.keys(selectedElement).length > 0;
 
-  const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
-  useEffect(() => {
-    // Deliberately not debounced: Splitter measures its container via its
-    // own ResizeObserver, which can fire before a debounced update here
-    // would land. If that happens while this is still reporting the old
-    // orientation, Splitter reads the wrong axis (width vs height) and
-    // caches a stale container size, leaving panels stuck at the wrong
-    // size until another resize happens to nudge it again.
-    const updateIsNarrow = () => setIsNarrow(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
-    window.addEventListener('resize', updateIsNarrow);
-    return () => window.removeEventListener('resize', updateIsNarrow);
-  }, []);
-
+  const containerRef = useRef(null);
+  const [isNarrow, setIsNarrow] = useState(false);
   const [appSourceCollapsed, setAppSourceCollapsed] = useState(false);
   const [selectedElementCollapsed, setSelectedElementCollapsed] = useState(false);
 
@@ -62,45 +55,75 @@ const SourceTab = (props) => {
   // are present - otherwise fall back to the Splitter's own full collapse.
   const canAccordionCollapse = isNarrow && hasSelectedElement;
 
+  // Splitter's own collapse (via the divider) fully hides a panel, header
+  // included, which only makes sense side-by-side with both panels present.
+  const splitterCollapsible =
+    !isNarrow && hasSelectedElement ? {start: true, end: true, showCollapsibleIcon: true} : false;
+
+  // Shared size/min for a panel that supports the accordion-style collapse:
+  // shrink to just its header height when collapsed, otherwise fall back to
+  // its own default size/min.
+  const getPanelSizing = (collapsed, defaultSize, defaultMin) => ({
+    size: canAccordionCollapse && collapsed ? PANEL_HEADER_HEIGHT : defaultSize,
+    min: canAccordionCollapse && collapsed ? PANEL_HEADER_HEIGHT : defaultMin,
+  });
+
+  const appSourceSizing = getPanelSizing(
+    appSourceCollapsed,
+    hasSelectedElement ? undefined : 100,
+    210,
+  );
+  const selectedElementSizing = getPanelSizing(selectedElementCollapsed, undefined, 250);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    // Deliberately not debounced: Splitter measures its container via its
+    // own ResizeObserver, which can fire before a debounced update here
+    // would land. If that happens while this is still reporting the old
+    // orientation, Splitter reads the wrong axis (width vs height) and
+    // caches a stale container size, leaving panels stuck at the wrong
+    // size until another resize happens to nudge it again.
+    const observer = new ResizeObserver(([entry]) => {
+      setIsNarrow(entry.contentRect.width < NARROW_LAYOUT_BREAKPOINT);
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   return (
-    <Splitter orientation={isNarrow ? 'vertical' : 'horizontal'}>
-      <Splitter.Panel
-        collapsible={
-          !isNarrow && hasSelectedElement
-            ? {start: true, end: true, showCollapsibleIcon: true}
-            : false
-        }
-        size={
-          canAccordionCollapse && appSourceCollapsed
-            ? PANEL_HEADER_HEIGHT
-            : hasSelectedElement
-              ? undefined
-              : 100
-        }
-        min={canAccordionCollapse && appSourceCollapsed ? PANEL_HEADER_HEIGHT : 210}
-      >
-        <AppSource
-          {...props}
-          collapsible={canAccordionCollapse}
-          collapsed={canAccordionCollapse && appSourceCollapsed}
-          onToggleCollapse={toggleAppSourceCollapse}
-        />
-      </Splitter.Panel>
-      {hasSelectedElement && (
+    <div ref={containerRef} className={styles.sourceTabContainer}>
+      <Splitter orientation={isNarrow ? 'vertical' : 'horizontal'}>
         <Splitter.Panel
-          collapsible={!isNarrow ? {start: true, end: true, showCollapsibleIcon: true} : false}
-          size={canAccordionCollapse && selectedElementCollapsed ? PANEL_HEADER_HEIGHT : undefined}
-          min={canAccordionCollapse && selectedElementCollapsed ? PANEL_HEADER_HEIGHT : 250}
+          collapsible={splitterCollapsible}
+          size={appSourceSizing.size}
+          min={appSourceSizing.min}
         >
-          <SelectedElement
+          <AppSource
             {...props}
             collapsible={canAccordionCollapse}
-            collapsed={canAccordionCollapse && selectedElementCollapsed}
-            onToggleCollapse={toggleSelectedElementCollapse}
+            collapsed={canAccordionCollapse && appSourceCollapsed}
+            onToggleCollapse={toggleAppSourceCollapse}
           />
         </Splitter.Panel>
-      )}
-    </Splitter>
+        {hasSelectedElement && (
+          <Splitter.Panel
+            collapsible={splitterCollapsible}
+            size={selectedElementSizing.size}
+            min={selectedElementSizing.min}
+          >
+            <SelectedElement
+              {...props}
+              collapsible={canAccordionCollapse}
+              collapsed={canAccordionCollapse && selectedElementCollapsed}
+              onToggleCollapse={toggleSelectedElementCollapse}
+            />
+          </Splitter.Panel>
+        )}
+      </Splitter>
+    </div>
   );
 };
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.module.css
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.module.css
@@ -1,0 +1,3 @@
+.sourceTabContainer {
+  height: 100%;
+}


### PR DESCRIPTION
## What

Fixes the post-session Session Inspector screen's layout so it adapts to narrow windows instead of overlapping, in the browser build.

- Removed the `body` `min-width`/`min-height` floor in `main.css` (same reasoning as #3063 - redundant for Electron, harmful for the browser build).
- **Header buttons row**: now scrolls (`overflow-x: auto`) and uses `align-items: safe center` instead of `center`. Previously, once the button row was wider than the window, it overflowed symmetrically on both sides and the left-side icons became permanently unreachable (browsers don't allow negative `scrollLeft`).
- **Screenshot toolbar**: the screenshot container now has a sane `min-width` instead of collapsing to near-zero width, and the main row (`screenshot | source/selected-element`) scrolls horizontally as a fallback. Previously the container could shrink so far that its toolbar buttons rendered on top of the adjacent panel.
- **Source tab (App Source / Selected Element)**: the `Splitter` now switches to a vertical layout below a 700px width breakpoint, stacking the panels instead of squeezing them side-by-side. It's remounted (`key`) on each orientation change, since `Splitter` otherwise retains stale panel sizes from the previous orientation.
- **Stacked-layout collapse**: each panel's card gets its own collapse toggle when stacked, which hides only the body while keeping the header visible (`Splitter`'s own collapse hides the header too, which isn't useful for an accordion-style layout). The collapsed state is lifted to `SourceTab`, which also drives the `Splitter.Panel`'s `size`, so the freed space goes to the other panel. Collapsing one panel always re-expands the other first, since `Splitter` can't shrink both panels to their collapsed size simultaneously without a panel left over to absorb the freed space (confirmed by testing - without this, collapsing both panels at once silently resets both back to their default size).
- Also made the horizontal-layout `Splitter`'s own collapse arrows always visible (`showCollapsibleIcon: true`) instead of hover-only - the divider was otherwise a near-invisible line, easy to miss.

Closes #3062

## Test plan

- [x] `npm run test:lint` / `test:format` / `test:unit` all pass (192/192)
- [x] Manually verified in the browser build (`npm run dev:browser`), connected to a real Android emulator via a local Appium server, at a range of widths (1200 → 320px, both English and Japanese locale):
  - Header buttons and screenshot toolbar no longer overlap adjacent content at any width, and remain fully reachable via scroll
  - App Source / Selected Element stack vertically below 700px, each keeping its header visible when its own collapse toggle is used
  - Collapsing one stacked panel correctly grows the other to fill the freed space; collapsing both in sequence re-expands the first instead of resetting both to their default size
  - Repeatedly narrowing/widening past the breakpoint doesn't leave anything stuck at a stale size