### PR TITLE
chore(deps): bump electron-vite to 6.0.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "electron": "41.10.3",
         "electron-builder": "26.15.3",
-        "electron-vite": "5.0.0",
+        "electron-vite": "6.0.0-beta.1",
         "eslint": "10.8.0",
         "eslint-plugin-react-hooks": "7.1.1",
         "eslint-plugin-simple-import-sort": "14.0.0",
@@ -6655,13 +6655,13 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -8194,17 +8194,17 @@
       }
     },
     "node_modules/electron-vite": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-5.0.0.tgz",
-      "integrity": "sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==",
+      "version": "6.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-6.0.0-beta.1.tgz",
+      "integrity": "sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.4",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "cac": "^6.7.14",
+        "cac": "^7.0.0",
         "esbuild": "^0.25.11",
-        "magic-string": "^0.30.19",
+        "magic-string": "^0.30.21",
         "picocolors": "^1.1.1"
       },
       "bin": {
@@ -8215,7 +8215,7 @@
       },
       "peerDependencies": {
         "@swc/core": "^1.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@swc/core": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "babel-plugin-react-compiler": "1.0.0",
     "electron": "41.10.3",
     "electron-builder": "26.15.3",
-    "electron-vite": "5.0.0",
+    "electron-vite": "6.0.0-beta.1",
     "eslint": "10.8.0",
     "eslint-plugin-react-hooks": "7.1.1",
     "eslint-plugin-simple-import-sort": "14.0.0",


### PR DESCRIPTION
Even though this is a beta version, it builds the dev, preview and packed app versions just fine, so it's worth updating to in order to unblock the Vite-related package bumps.