### PR TITLE
fix: ensure Capability Editor does not always open in narrow mode

### DIFF
--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -84,11 +84,16 @@ const CapabilityEditor = (props) => {
     isDuplicateCapsName,
   } = props;
 
-  const onSaveAsOk = () => saveSession({server, serverType, caps, name: saveAsText}, true);
-  const latestCapFieldRef = useRef(null);
   const {t} = useTranslation();
 
-  const [isNarrow, setIsNarrow] = useState(window.innerWidth < NARROW_LAYOUT_BREAKPOINT);
+  const latestCapFieldRef = useRef(null);
+
+  const [isNarrow, setIsNarrow] = useState(
+    window.innerWidth > 0 && window.innerWidth < NARROW_LAYOUT_BREAKPOINT,
+  );
+
+  const onSaveAsOk = () => saveSession({server, serverType, caps, name: saveAsText}, true);
+
   useEffect(() => {
     // Deliberately not debounced: Splitter measures its container via its
     // own ResizeObserver, which can fire before a debounced update here


### PR DESCRIPTION
Small follow-up to #3063 - I noticed that the Electron app may open in narrow mode on first launch. Changing the window size in any way sets it back to standard mode. What's interesting is that this issue only appears in the final packaged app version, and not in dev or preview versions.

In any case, it seems that guarding the narrow mode flag to `window.innerWidth > 0` fixed the problem.