### PR TITLE
chore: upgrade to Electron 44

### DIFF
--- a/docs/quickstart/requirements.md
+++ b/docs/quickstart/requirements.md
@@ -9,7 +9,7 @@ Since the Inspector is released in [2 versions](../overview.md#formats), the req
 will differ:
 
 - Desktop app
-    - Works on Windows 10+, macOS 12+, Ubuntu 18.04+, Debian 10+, openSUSE 15.5+, or Fedora Linux 39+
+    - Works on Windows 10+, macOS 13+, Ubuntu 18.04+, Debian 10+, openSUSE 15.5+, or Fedora Linux 39+
         - [These requirements are taken from Chrome](https://support.google.com/chrome/a/answer/7100626),
           as the Inspector is built using Electron (which uses Chromium)
     - Around **500MB** of free space is required

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "@types/react-dom": "19.2.5",
         "@vitejs/plugin-react": "6.1.1",
         "asyncbox": "6.4.3",
-        "electron": "42.10.1",
+        "electron": "44.0.0",
         "electron-builder": "26.15.3",
         "electron-vite": "6.0.0-beta.1",
         "oxc-transform-react": "0.145.0",
@@ -7345,9 +7345,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.10.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.10.1.tgz",
-      "integrity": "sha512-ITc1HPeoDzsxCCaH6MFsN67Nq2nUiJf5N9pBWxzhUpFfKJF0IwiAkKT3emg1lPbvC4OfFE+Cdwe4vhgdOZ1YKg==",
+      "version": "44.0.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-44.0.0.tgz",
+      "integrity": "sha512-FkTqPrFPZYljdPI5b7KORGsJTd6FgUQDefl5MrU3Xz9R87pAj9JLreIjDqcRN8hJIkFHIou0o8kKzvcpT9qiRQ==",
       "license": "MIT",
       "dependencies": {
         "@electron-internal/extract-zip": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "@types/react-dom": "19.2.5",
     "@vitejs/plugin-react": "6.1.1",
     "asyncbox": "6.4.3",
-    "electron": "42.10.1",
+    "electron": "44.0.0",
     "electron-builder": "26.15.3",
     "electron-vite": "6.0.0-beta.1",
     "oxc-transform-react": "0.145.0",


### PR DESCRIPTION
With Electron 42 working fine, upgrading to 44 did not cause any difficulties. I still tested it in all combinations I could (Linux dev/preview/packed builds + macOS dev/preview builds).
The clipboard change in Electron 44 does not affect the app, since it was migrated to the recommended `navigator.clipboard` API in an earlier PR. Click-to-copy still works as expected.

Worth noting that Electron 44 drops support for macOS 12, which has been reflected in the docs.