### PR TITLE
fix: add aria-label to icon-only buttons

### DIFF
--- a/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
+++ b/app/common/renderer/components/ErrorBoundary/ErrorMessage.jsx
@@ -10,6 +10,7 @@ import styles from './ErrorMessage.module.css';
 
 const ErrorMessage = ({error, copyTrace}) => {
   const {t} = useTranslation();
+  const copyErrLabel = t('Copy Error Trace');
 
   return (
     <div className={styles.errorMessage}>
@@ -27,8 +28,9 @@ const ErrorMessage = ({error, copyTrace}) => {
             <a onClick={(e) => e.preventDefault() || openLink(LINKS.CREATE_ISSUE)}>{LINKS.CREATE_ISSUE}</a>
             <br />
             {t('Full error trace:')}
-            <Tooltip title={t('Copy Error Trace')}>
+            <Tooltip title={copyErrLabel}>
               <Button
+                aria-label={copyErrLabel}
                 size="small"
                 className={styles.copyTraceBtn}
                 onClick={() => copyTrace(error.stack)}

--- a/app/common/renderer/components/SessionBuilder/AppSettings/AppSettings.jsx
+++ b/app/common/renderer/components/SessionBuilder/AppSettings/AppSettings.jsx
@@ -9,15 +9,16 @@ import ToggleTheme from './ToggleTheme.jsx';
 const AppSettings = () => {
   const [modalOpen, setModalOpen] = useState(false);
   const {t} = useTranslation();
+  const appSettingsLabel = t('App Settings');
 
   return (
     <>
-      <Tooltip title={t('App Settings')}>
-        <Button icon={<IconSettings size={18} />} onClick={() => setModalOpen(true)} />
+      <Tooltip title={appSettingsLabel}>
+        <Button aria-label={appSettingsLabel} icon={<IconSettings size={18} />} onClick={() => setModalOpen(true)} />
       </Tooltip>
 
       <Modal
-        title={t('App Settings')}
+        title={appSettingsLabel}
         styles={{title: {fontSize: '18px'}}}
         open={modalOpen}
         footer={null}

--- a/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityBuilderTab/CapabilityEditor.jsx
@@ -74,6 +74,8 @@ const CapabilityEditor = (props) => {
   } = props;
 
   const {t} = useTranslation();
+  const addLabel = t('Add');
+  const deleteLabel = t('Delete');
 
   const latestCapFieldRef = useRef(null);
 
@@ -160,8 +162,9 @@ const CapabilityEditor = (props) => {
                         onChange={(e) => setCapabilityParam(cap.id, 'enabled', e.target.checked)}
                       />
                     </Tooltip>
-                    <Tooltip title={t('Delete')} placement="right">
+                    <Tooltip title={deleteLabel} placement="right">
                       <Button
+                        aria-label={deleteLabel}
                         {...{disabled: caps.length <= 1 || isEditingDesiredCaps}}
                         icon={<IconTrash size={18} />}
                         onClick={() => removeCapability(cap.id)}
@@ -182,8 +185,9 @@ const CapabilityEditor = (props) => {
             </Col>
             <Col flex="40px">
               <Form.Item>
-                <Tooltip title={t('Add')} placement="right">
+                <Tooltip title={addLabel} placement="right">
                   <Button
+                    aria-label={addLabel}
                     disabled={isEditingDesiredCaps}
                     id="btnAddDesiredCapability"
                     icon={<IconPlus size={18} />}

--- a/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
+++ b/app/common/renderer/components/SessionBuilder/CapabilityJSON/CapabilityJSON.jsx
@@ -30,6 +30,10 @@ const CapabilityJSON = (props) => {
   } = props;
 
   const {t} = useTranslation();
+  const editLabel = t('Edit');
+  const cancelLabel = t('Cancel');
+  const saveLabel = t('Save');
+  const editRawLabel = t('Edit Raw JSON');
 
   const getHighlightedCaps = (caps) => {
     const formattedJson = JSON.stringify(getCapsObject(caps), null, 2);
@@ -64,8 +68,9 @@ const CapabilityJSON = (props) => {
       return null;
     } else if (!isEditingDesiredCapsName) {
       return (
-        <Tooltip title={t('Edit')}>
+        <Tooltip title={editLabel}>
           <Button
+            aria-label={editLabel}
             size="small"
             onClick={startDesiredCapsNameEditor}
             icon={<IconEdit size={14} />}
@@ -76,8 +81,9 @@ const CapabilityJSON = (props) => {
     } else {
       return (
         <>
-          <Tooltip title={t('Cancel')}>
+          <Tooltip title={cancelLabel}>
             <Button
+              aria-label={cancelLabel}
               size="small"
               color="danger"
               variant="outlined"
@@ -86,8 +92,9 @@ const CapabilityJSON = (props) => {
               className={styles.capsNameEditorButton}
             />
           </Tooltip>
-          <Tooltip title={t('Save')}>
+          <Tooltip title={saveLabel}>
             <Button
+              aria-label={saveLabel}
               size="small"
               color="primary"
               variant="outlined"
@@ -106,8 +113,9 @@ const CapabilityJSON = (props) => {
       <Card className={styles.formattedCaps} title={setCapsTitle()} extra={setCapsTitleButtons()}>
         <div className={styles.capsEditorControls}>
           {isEditingDesiredCaps && (
-            <Tooltip title={t('Cancel')}>
+            <Tooltip title={cancelLabel}>
               <Button
+                aria-label={cancelLabel}
                 color="danger"
                 variant="outlined"
                 onClick={abortDesiredCapsEditor}
@@ -117,8 +125,9 @@ const CapabilityJSON = (props) => {
             </Tooltip>
           )}
           {isEditingDesiredCaps && (
-            <Tooltip title={t('Save')}>
+            <Tooltip title={saveLabel}>
               <Button
+                aria-label={saveLabel}
                 color="primary"
                 variant="outlined"
                 onClick={() => saveRawDesiredCaps(caps, rawDesiredCaps)}
@@ -128,8 +137,8 @@ const CapabilityJSON = (props) => {
             </Tooltip>
           )}
           {!isEditingDesiredCaps && (
-            <Tooltip title={t('Edit Raw JSON')} placement="topRight">
-              <Button onClick={startDesiredCapsEditor} icon={<IconEdit size={18} />} />
+            <Tooltip title={editRawLabel} placement="topRight">
+              <Button aria-label={editRawLabel} onClick={startDesiredCapsEditor} icon={<IconEdit size={18} />} />
             </Tooltip>
           )}
         </div>

--- a/app/common/renderer/components/SessionBuilder/SavedCapabilitySetsTab/SavedCapabilitySets.jsx
+++ b/app/common/renderer/components/SessionBuilder/SavedCapabilitySetsTab/SavedCapabilitySets.jsx
@@ -45,6 +45,9 @@ const SavedCapabilitySets = (props) => {
   } = props;
 
   const {t} = useTranslation();
+  const editLabel = t('Edit');
+  const deleteLabel = t('Delete');
+  const exportLabel = t('Export to File');
 
   const handleCapsAndServer = (uuid) => {
     const {
@@ -100,8 +103,9 @@ const SavedCapabilitySets = (props) => {
       width: SAVED_SESSIONS_TABLE_VALUES.ACTIONS_COLUMN_WIDTH,
       render: (_, record) => (
         <Space.Compact>
-          <Tooltip zIndex={3} title={t('Edit')}>
+          <Tooltip zIndex={3} title={editLabel}>
             <Button
+              aria-label={editLabel}
               icon={<IconEdit size={18} />}
               onClick={() => {
                 handleCapsAndServer(record.key);
@@ -109,10 +113,14 @@ const SavedCapabilitySets = (props) => {
               }}
             />
           </Tooltip>
-          <Tooltip zIndex={3} title={t('Export to File')}>
-            <Button icon={<IconFileExport size={18} />} onClick={() => findAndExportSavedSession(record.key)} />
+          <Tooltip zIndex={3} title={exportLabel}>
+            <Button
+              aria-label={exportLabel}
+              icon={<IconFileExport size={18} />}
+              onClick={() => findAndExportSavedSession(record.key)}
+            />
           </Tooltip>
-          <Tooltip zIndex={3} title={t('Delete')}>
+          <Tooltip zIndex={3} title={deleteLabel}>
             <Popconfirm
               zIndex={4}
               title={t('confirmDeletion')}
@@ -120,7 +128,7 @@ const SavedCapabilitySets = (props) => {
               cancelText={t('Cancel')}
               onConfirm={() => deleteSavedSession(record.key)}
             >
-              <Button icon={<IconTrash size={18} />} />
+              <Button aria-label={deleteLabel} icon={<IconTrash size={18} />} />
             </Popconfirm>
           </Tooltip>
         </Space.Compact>

--- a/app/common/renderer/components/SessionBuilder/ServerDetails/CloudProviderSelector.jsx
+++ b/app/common/renderer/components/SessionBuilder/ServerDetails/CloudProviderSelector.jsx
@@ -58,7 +58,12 @@ const CloudProviderSelector = (props) => {
                 return (
                   provider && (
                     <Col span={12} key={providerName}>
-                      <Button role="checkbox" style={style} onClick={() => toggleVisibleProvider(providerName)}>
+                      <Button
+                        aria-label={providerName}
+                        role="checkbox"
+                        style={style}
+                        onClick={() => toggleVisibleProvider(providerName)}
+                      >
                         {provider.logo}
                       </Button>
                     </Col>

--- a/app/common/renderer/components/SessionInspector/CommandsTab/CommandResult/CommandResultModal.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/CommandResult/CommandResultModal.jsx
@@ -17,21 +17,29 @@ const stringifyValue = (val) => (typeof val === 'object' && val !== null ? JSON.
  */
 const CommandResultModalFooter = ({result, closeCommandModal, setFormatResult, formatResult, isPrimitive}) => {
   const {t} = useTranslation();
+  const tableFormatLabel = t('toggleTableFormatting');
+  const copyLabel = t('copyResultToClipboard');
 
   return (
     <Row>
       <Col span={12}>
         <Space>
-          <Tooltip title={t('toggleTableFormatting')}>
+          <Tooltip title={tableFormatLabel}>
             <Button
+              aria-label={tableFormatLabel}
               icon={<IconTable size={18} />}
               disabled={isPrimitive}
               type={formatResult ? BUTTON.PRIMARY : BUTTON.DEFAULT}
               onClick={() => setFormatResult(!formatResult)}
             />
           </Tooltip>
-          <Tooltip title={t('copyResultToClipboard')}>
-            <Button icon={<IconFiles size={18} />} disabled={formatResult} onClick={() => copyToClipboard(result)} />
+          <Tooltip title={copyLabel}>
+            <Button
+              aria-label={copyLabel}
+              icon={<IconFiles size={18} />}
+              disabled={formatResult}
+              onClick={() => copyToClipboard(result)}
+            />
           </Tooltip>
         </Space>
       </Col>

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorHeader.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorHeader.jsx
@@ -59,9 +59,18 @@ const convertPointerCoordsType = (newCoordType, coordType, windowSize, pointers)
 /**
  * Back button to return to the saved gestures list.
  */
-const GestureEditorBackButton = ({closeGestureEditor}) => (
-  <Button type="text" icon={<IconArrowLeft size={18} />} onClick={() => closeGestureEditor()} />
-);
+const GestureEditorBackButton = ({closeGestureEditor}) => {
+  const {t} = useTranslation();
+
+  return (
+    <Button
+      aria-label={t('Back')}
+      type="text"
+      icon={<IconArrowLeft size={18} />}
+      onClick={() => closeGestureEditor()}
+    />
+  );
+};
 
 /**
  * Editable title of the current gesture.
@@ -93,6 +102,7 @@ const GestureEditorHeaderButtons = ({
   loadedGesture,
 }) => {
   const {t} = useTranslation();
+  const playLabel = t('Play');
 
   return (
     <Space>
@@ -114,8 +124,13 @@ const GestureEditorHeaderButtons = ({
           </Button>
         </Tooltip>
       </Space.Compact>
-      <Tooltip title={t('Play')}>
-        <Button type="primary" icon={<IconPlayerPlay size={18} />} onClick={() => playCurrentGesture()} />
+      <Tooltip title={playLabel}>
+        <Button
+          aria-label={playLabel}
+          type="primary"
+          icon={<IconPlayerPlay size={18} />}
+          onClick={() => playCurrentGesture()}
+        />
       </Tooltip>
       <Space.Compact>
         <Button onClick={() => saveCurrentGestureAs()}>{t('saveAs')}</Button>

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
@@ -20,11 +20,16 @@ const addTick = (pointerKey, pointers, setPointers) => {
  */
 const AddNewTickButton = ({id, pointers, setPointers}) => {
   const {t} = useTranslation();
+  const addLabel = t('Add');
 
   return (
     <div className={styles.tickPlusBtnWrapper}>
-      <Tooltip title={t('Add')}>
-        <Button icon={<IconPlus size={18} />} onClick={() => addTick(id, pointers, setPointers)} />
+      <Tooltip title={addLabel}>
+        <Button
+          aria-label={addLabel}
+          icon={<IconPlus size={18} />}
+          onClick={() => addTick(id, pointers, setPointers)}
+        />
       </Tooltip>
     </div>
   );

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
@@ -27,12 +27,15 @@ const deleteTick = (pointerKey, tickKey, pointers, setPointers, unselectTick) =>
  */
 const GestureEditorTickCardHeaderButtons = ({tick, pointers, setPointers, selectedTick, selectTick, unselectTick}) => {
   const {t} = useTranslation();
+  const togglePickerLabel = t('toggleMoveActionCoordPicker');
+  const deleteLabel = t('Delete');
 
   return (
     <>
       {tick.type === POINTER_TYPES.POINTER_MOVE && (
-        <Tooltip title={t('toggleMoveActionCoordPicker')}>
+        <Tooltip title={togglePickerLabel}>
           <Button
+            aria-label={togglePickerLabel}
             size="small"
             type={selectedTick === tick.id ? 'primary' : 'text'}
             icon={<IconFocus2 size={18} />}
@@ -40,8 +43,9 @@ const GestureEditorTickCardHeaderButtons = ({tick, pointers, setPointers, select
           />
         </Tooltip>
       )}
-      <Tooltip title={t('Delete')}>
+      <Tooltip title={deleteLabel}>
         <Button
+          aria-label={deleteLabel}
           size="small"
           type="text"
           icon={<IconX size={18} />}

--- a/app/common/renderer/components/SessionInspector/GesturesTab/SavedGestureActionsCell.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/SavedGestureActionsCell.jsx
@@ -21,6 +21,10 @@ const SavedGestureActionsCell = (props) => {
     applyClientMethod,
   } = props;
   const {t} = useTranslation();
+  const playLabel = t('Play');
+  const editLabel = t('Edit');
+  const exportLabel = t('Export to File');
+  const deleteLabel = t('Delete');
 
   const playGesture = () => {
     const actions = {};
@@ -42,16 +46,26 @@ const SavedGestureActionsCell = (props) => {
 
   return (
     <Space.Compact>
-      <Tooltip zIndex={3} title={t('Play')}>
-        <Button key="play" type="primary" icon={<IconPlayerPlay size={18} />} onClick={() => playGesture()} />
+      <Tooltip zIndex={3} title={playLabel}>
+        <Button
+          aria-label={playLabel}
+          key="play"
+          type="primary"
+          icon={<IconPlayerPlay size={18} />}
+          onClick={() => playGesture()}
+        />
       </Tooltip>
-      <Tooltip zIndex={3} title={t('Edit')}>
-        <Button icon={<IconEdit size={18} />} onClick={() => loadGesture()} />
+      <Tooltip zIndex={3} title={editLabel}>
+        <Button aria-label={editLabel} icon={<IconEdit size={18} />} onClick={() => loadGesture()} />
       </Tooltip>
-      <Tooltip zIndex={3} title={t('Export to File')}>
-        <Button icon={<IconFileExport size={18} />} onClick={() => exportSavedGesture(gesture)} />
+      <Tooltip zIndex={3} title={exportLabel}>
+        <Button
+          aria-label={exportLabel}
+          icon={<IconFileExport size={18} />}
+          onClick={() => exportSavedGesture(gesture)}
+        />
       </Tooltip>
-      <Tooltip zIndex={3} title={t('Delete')}>
+      <Tooltip zIndex={3} title={deleteLabel}>
         <Popconfirm
           zIndex={4}
           title={t('confirmDeletion')}
@@ -60,7 +74,7 @@ const SavedGestureActionsCell = (props) => {
           cancelText={t('Cancel')}
           onConfirm={() => deleteGesture()}
         >
-          <Button icon={<IconTrash size={18} />} />
+          <Button aria-label={deleteLabel} icon={<IconTrash size={18} />} />
         </Popconfirm>
       </Tooltip>
     </Space.Compact>

--- a/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
@@ -13,10 +13,12 @@ import styles from './Header.module.css';
  */
 const NoContextsFoundButton = () => {
   const {t} = useTranslation();
+  const noContextsLabel = t('noAdditionalContextsFound');
 
   return (
-    <Tooltip title={t('noAdditionalContextsFound')} classNames={{root: styles.wideTooltip}}>
+    <Tooltip title={noContextsLabel} classNames={{root: styles.wideTooltip}}>
       <Button
+        aria-label={noContextsLabel}
         disabled
         icon={<IconExclamationCircle size={20} />}
         styles={{root: {backgroundColor: '#faad14', color: '#ffffff'}}}
@@ -30,6 +32,7 @@ const NoContextsFoundButton = () => {
  */
 const ContextDropdown = ({contexts, currentContext, setContext, applyClientMethod, openLink}) => {
   const {t} = useTranslation();
+  const contextLabel = t('contextDropdownInfo');
 
   return (
     <>
@@ -49,13 +52,14 @@ const ContextDropdown = ({contexts, currentContext, setContext, applyClientMetho
       <Tooltip
         title={
           <>
-            {t('contextDropdownInfo')}{' '}
+            {contextLabel}{' '}
             <a onClick={(e) => e.preventDefault() || openLink(LINKS.HYBRID_MODE_DOCS)}>{LINKS.HYBRID_MODE_DOCS}</a>
           </>
         }
         classNames={{root: styles.wideTooltip}}
       >
         <Button
+          aria-label={`${contextLabel} ${LINKS.HYBRID_MODE_DOCS}`}
           disabled
           icon={<IconInfoCircle size={20} />}
           styles={{root: {backgroundColor: 'var(--ant-color-primary)', color: '#ffffff'}}}
@@ -78,18 +82,22 @@ const ContextControlsGroup = ({
   openLink,
 }) => {
   const {t} = useTranslation();
+  const nativeModeLabel = t('Native App Mode');
+  const webModeLabel = t('Web/Hybrid App Mode');
 
   return (
     <Space.Compact>
-      <Tooltip title={t('Native App Mode')}>
+      <Tooltip title={nativeModeLabel}>
         <Button
+          aria-label={nativeModeLabel}
           icon={<IconTriangleSquareCircle size={18} />}
           onClick={() => selectAppMode(APP_MODE.NATIVE)}
           type={appMode === APP_MODE.NATIVE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
         />
       </Tooltip>
-      <Tooltip title={t('Web/Hybrid App Mode')}>
+      <Tooltip title={webModeLabel}>
         <Button
+          aria-label={webModeLabel}
           icon={<IconWorld size={18} />}
           onClick={() => selectAppMode(APP_MODE.WEB_HYBRID)}
           type={appMode === APP_MODE.WEB_HYBRID ? BUTTON.PRIMARY : BUTTON.DEFAULT}

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControlsGroup.jsx
@@ -9,11 +9,15 @@ import SiriCommandModal from './SiriCommandModal.jsx';
  */
 const AndroidControlsGroup = ({applyClientMethod}) => {
   const {t} = useTranslation();
+  const backLabel = t('Press Back Button');
+  const homeLabel = t('Press Home Button');
+  const appSwitchLabel = t('Press App Switch Button');
 
   return (
     <Space.Compact>
-      <Tooltip title={t('Press Back Button')}>
+      <Tooltip title={backLabel}>
         <Button
+          aria-label={backLabel}
           id="btnPressBackButton"
           icon={<IconChevronLeft size={20} />}
           onClick={() =>
@@ -24,8 +28,9 @@ const AndroidControlsGroup = ({applyClientMethod}) => {
           }
         />
       </Tooltip>
-      <Tooltip title={t('Press Home Button')}>
+      <Tooltip title={homeLabel}>
         <Button
+          aria-label={homeLabel}
           id="btnPressHomeButton"
           icon={<IconCircle size={16} />}
           onClick={() =>
@@ -36,8 +41,9 @@ const AndroidControlsGroup = ({applyClientMethod}) => {
           }
         />
       </Tooltip>
-      <Tooltip title={t('Press App Switch Button')}>
+      <Tooltip title={appSwitchLabel}>
         <Button
+          aria-label={appSwitchLabel}
           id="btnPressAppSwitchButton"
           icon={<IconSquare size={16} />}
           onClick={() =>
@@ -64,11 +70,14 @@ const IosControlsGroup = ({
   hideSiriCommandModal,
 }) => {
   const {t} = useTranslation();
+  const homeLabel = t('Press Home Button');
+  const siriLabel = t('Execute Siri Command');
 
   return (
     <Space.Compact>
-      <Tooltip title={t('Press Home Button')}>
+      <Tooltip title={homeLabel}>
         <Button
+          aria-label={homeLabel}
           id="btnPressHomeButton"
           icon={<IconHome size={18} />}
           onClick={() =>
@@ -79,8 +88,13 @@ const IosControlsGroup = ({
           }
         />
       </Tooltip>
-      <Tooltip title={t('Execute Siri Command')}>
-        <Button id="siriCommand" icon={<IconMessageChatbot size={18} />} onClick={showSiriCommandModal} />
+      <Tooltip title={siriLabel}>
+        <Button
+          aria-label={siriLabel}
+          id="siriCommand"
+          icon={<IconMessageChatbot size={18} />}
+          onClick={showSiriCommandModal}
+        />
       </Tooltip>
       <SiriCommandModal
         siriCommandValue={siriCommandValue}

--- a/app/common/renderer/components/SessionInspector/Header/DisplayControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DisplayControlsGroup.jsx
@@ -16,11 +16,13 @@ const DisplayControlsGroup = ({
   toggleMultiDisplayMode,
 }) => {
   const {t} = useTranslation();
+  const multiDisplayLabel = t('toggleMultiDisplayMode');
 
   return automationName === DRIVERS.UIAUTOMATOR2 ? (
     <Space.Compact>
-      <Tooltip title={t('toggleMultiDisplayMode')}>
+      <Tooltip title={multiDisplayLabel}>
         <Button
+          aria-label={multiDisplayLabel}
           icon={<IconCarouselHorizontal size={18} />}
           type={displays ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           onClick={() => toggleMultiDisplayMode(displays)}

--- a/app/common/renderer/components/SessionInspector/Header/GeneralControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/GeneralControlsGroup.jsx
@@ -10,18 +10,22 @@ import LocatorSearchModal from './LocatorSearch/LocatorSearchModal.jsx';
  */
 const ToggleAutomaticRefreshButton = ({isSourceRefreshOn, setRefreshingState}) => {
   const {t} = useTranslation();
+  const pauseRefreshLabel = t('Pause Refreshing Source');
+  const startRefreshLabel = t('Start Refreshing Source');
 
   return isSourceRefreshOn ? (
-    <Tooltip title={t('Pause Refreshing Source')}>
+    <Tooltip title={pauseRefreshLabel}>
       <Button
+        aria-label={pauseRefreshLabel}
         id="btnPauseRefreshing"
         icon={<IconPlayerPause size={18} />}
         onClick={() => setRefreshingState({source: false})}
       />
     </Tooltip>
   ) : (
-    <Tooltip title={t('Start Refreshing Source')}>
+    <Tooltip title={startRefreshLabel}>
       <Button
+        aria-label={startRefreshLabel}
         id="btnStartRefreshing"
         icon={<IconPlayerPlay size={18} />}
         onClick={() => setRefreshingState({source: true})}
@@ -35,10 +39,12 @@ const ToggleAutomaticRefreshButton = ({isSourceRefreshOn, setRefreshingState}) =
  */
 const ManualRefreshButton = ({applyClientMethod}) => {
   const {t} = useTranslation();
+  const refreshLabel = t('refreshSource');
 
   return (
-    <Tooltip title={t('refreshSource')}>
+    <Tooltip title={refreshLabel}>
       <Button
+        aria-label={refreshLabel}
         id="btnReload"
         icon={<IconRefresh size={18} />}
         onClick={() => applyClientMethod({methodName: 'getPageSource'})}
@@ -53,11 +59,17 @@ const ManualRefreshButton = ({applyClientMethod}) => {
 const SearchForElementButton = (props) => {
   const {showLocatorSearchModal} = props;
   const {t} = useTranslation();
+  const searchLabel = t('Search for element');
 
   return (
     <>
-      <Tooltip title={t('Search for element')}>
-        <Button id="searchForElement" icon={<IconSearch size={18} />} onClick={showLocatorSearchModal} />
+      <Tooltip title={searchLabel}>
+        <Button
+          aria-label={searchLabel}
+          id="searchForElement"
+          icon={<IconSearch size={18} />}
+          onClick={showLocatorSearchModal}
+        />
       </Tooltip>
       <LocatorSearchModal {...props} />
     </>
@@ -69,14 +81,23 @@ const SearchForElementButton = (props) => {
  */
 const ToggleRecordingButton = ({isRecording, startRecording, pauseRecording}) => {
   const {t} = useTranslation();
+  const pauseLabel = t('Pause Recording');
+  const startLabel = t('Start Recording');
 
   return isRecording ? (
-    <Tooltip title={t('Pause Recording')}>
-      <Button id="btnPause" icon={<IconVideo size={18} />} type={BUTTON.PRIMARY} danger onClick={pauseRecording} />
+    <Tooltip title={pauseLabel}>
+      <Button
+        aria-label={pauseLabel}
+        id="btnPause"
+        icon={<IconVideo size={18} />}
+        type={BUTTON.PRIMARY}
+        danger
+        onClick={pauseRecording}
+      />
     </Tooltip>
   ) : (
-    <Tooltip title={t('Start Recording')}>
-      <Button id="btnStartRecording" icon={<IconVideo size={18} />} onClick={startRecording} />
+    <Tooltip title={startLabel}>
+      <Button aria-label={startLabel} id="btnStartRecording" icon={<IconVideo size={18} />} onClick={startRecording} />
     </Tooltip>
   );
 };

--- a/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchFoundResults.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchFoundResults.jsx
@@ -67,21 +67,27 @@ const LocatorSearchResultsElementActions = ({
   applyClientMethod,
 }) => {
   const {t} = useTranslation();
+  const findAndSelectLabel = t('Find and Select in Source');
+  const tapLabel = t('Tap');
+  const sendKeysLabel = t('Send Keys');
+  const clearLabel = t('Clear');
 
   const sendKeysRef = useRef(null);
 
   return (
     <Row justify="center">
       <Space orientation="horizontal" size="small">
-        <Tooltip title={t('Find and Select in Source')} placement="bottom">
+        <Tooltip title={findAndSelectLabel} placement="bottom">
           <Button
+            aria-label={findAndSelectLabel}
             disabled={!locatedElement}
             icon={<IconListSearch size={18} />}
             onClick={() => findLocatedElementInSource(sourceJSON, sourceXML, searchedForElementBounds, locatedElement)}
           />
         </Tooltip>
-        <Tooltip title={t('Tap')} placement="bottom">
+        <Tooltip title={tapLabel} placement="bottom">
           <Button
+            aria-label={tapLabel}
             disabled={!locatedElement}
             icon={<IconFocus2 size={18} />}
             onClick={() => applyClientMethod({methodName: 'elementClick', elementId: locatedElement})}
@@ -95,8 +101,9 @@ const LocatorSearchResultsElementActions = ({
             allowClear={true}
             onChange={(e) => (sendKeysRef.current = e.target.value)}
           />
-          <Tooltip title={t('Send Keys')} placement="bottom">
+          <Tooltip title={sendKeysLabel} placement="bottom">
             <Button
+              aria-label={sendKeysLabel}
               disabled={!locatedElement}
               icon={<IconSend2 size={18} />}
               onClick={() =>
@@ -108,8 +115,9 @@ const LocatorSearchResultsElementActions = ({
               }
             />
           </Tooltip>
-          <Tooltip title={t('Clear')} placement="bottom">
+          <Tooltip title={clearLabel} placement="bottom">
             <Button
+              aria-label={clearLabel}
               disabled={!locatedElement}
               id="btnClearElement"
               icon={<IconEraser size={18} />}

--- a/app/common/renderer/components/SessionInspector/Header/SessionQuitControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/SessionQuitControlsGroup.jsx
@@ -7,18 +7,21 @@ import {useTranslation} from 'react-i18next';
  */
 const SessionQuitControlsGroup = ({quitSessionAndReturn}) => {
   const {t} = useTranslation();
+  const detachLabel = t('detachFromSession');
+  const quitLabel = t('Quit Session');
 
   return (
     <Space.Compact>
-      <Tooltip title={t('detachFromSession')}>
+      <Tooltip title={detachLabel}>
         <Button
+          aria-label={detachLabel}
           id="btnDetach"
           icon={<IconPlugConnectedX size={18} />}
           onClick={() => quitSessionAndReturn({detachOnly: true})}
         />
       </Tooltip>
-      <Tooltip title={t('Quit Session')}>
-        <Button id="btnClose" icon={<IconX size={18} />} onClick={quitSessionAndReturn} />
+      <Tooltip title={quitLabel}>
+        <Button aria-label={quitLabel} id="btnClose" icon={<IconX size={18} />} onClick={quitSessionAndReturn} />
       </Tooltip>
     </Space.Compact>
   );

--- a/app/common/renderer/components/SessionInspector/Header/SessionReloadButton.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/SessionReloadButton.jsx
@@ -9,10 +9,12 @@ import {BUTTON} from '../../../constants/antd-types.js';
  */
 const SessionReloadButton = ({autoSessionRestart, toggleAutoSessionRestart}) => {
   const {t} = useTranslation();
+  const toggleReloadLabel = t('ToggleRestartSession');
 
   return (
-    <Tooltip title={t('ToggleRestartSession')}>
+    <Tooltip title={toggleReloadLabel}>
       <Button
+        aria-label={toggleReloadLabel}
         id={autoSessionRestart ? 'btnDisableRestartSession' : 'btnEnableRestartSession'}
         icon={<IconRecycle size={16} />}
         type={autoSessionRestart ? BUTTON.PRIMARY : undefined}

--- a/app/common/renderer/components/SessionInspector/RecorderTab/RecorderTabCard.jsx
+++ b/app/common/renderer/components/SessionInspector/RecorderTab/RecorderTabCard.jsx
@@ -35,23 +35,27 @@ const RecorderTabHeaderButtons = ({
   clearRecording,
 }) => {
   const {t} = useTranslation();
+  const toggleBoilerplateLabel = t('Show/Hide Boilerplate Code');
+  const copyLabel = t('Copy code to clipboard');
+  const clearLabel = t('Clear Actions');
 
   return (
     <Space size="middle">
       {!!recordedActions.length && (
         <Space.Compact>
-          <Tooltip title={t('Show/Hide Boilerplate Code')}>
+          <Tooltip title={toggleBoilerplateLabel}>
             <Button
+              aria-label={toggleBoilerplateLabel}
               onClick={toggleShowBoilerplate}
               icon={<IconEyeCode size={18} />}
               type={showBoilerplate ? BUTTON.PRIMARY : BUTTON.DEFAULT}
             />
           </Tooltip>
-          <Tooltip title={t('Copy code to clipboard')}>
-            <Button icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
+          <Tooltip title={copyLabel}>
+            <Button aria-label={copyLabel} icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
           </Tooltip>
-          <Tooltip title={t('Clear Actions')}>
-            <Button icon={<IconEraser size={18} />} onClick={clearRecording} />
+          <Tooltip title={clearLabel}>
+            <Button aria-label={clearLabel} icon={<IconEraser size={18} />} onClick={clearRecording} />
           </Tooltip>
         </Space.Compact>
       )}

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -30,6 +30,8 @@ const downloadScreenshot = (screenshot) => {
  */
 const ScreenshotCaptureModeControls = ({setMjpegState, isUsingMjpegMode, setRefreshingState, applyClientMethod}) => {
   const {t} = useTranslation();
+  const useMjpegLabel = t('useMjpegStream');
+  const useScreenshotLabel = t('useScreenshotApi');
 
   const switchScreenCaptureMode = (shouldUseMjpeg) => {
     setMjpegState(shouldUseMjpeg);
@@ -41,15 +43,17 @@ const ScreenshotCaptureModeControls = ({setMjpegState, isUsingMjpegMode, setRefr
 
   return (
     <Space.Compact>
-      <Tooltip title={t('useMjpegStream')} placement="topLeft">
+      <Tooltip title={useMjpegLabel} placement="topLeft">
         <Button
+          aria-label={useMjpegLabel}
           icon={<IconMovie size={18} />}
           onClick={() => switchScreenCaptureMode(true)}
           type={isUsingMjpegMode ? BUTTON.PRIMARY : BUTTON.DEFAULT}
         />
       </Tooltip>
-      <Tooltip title={t('useScreenshotApi')} placement="topLeft">
+      <Tooltip title={useScreenshotLabel} placement="topLeft">
         <Button
+          aria-label={useScreenshotLabel}
           icon={<IconPhoto size={18} />}
           onClick={() => switchScreenCaptureMode(false)}
           type={!isUsingMjpegMode ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -64,10 +68,12 @@ const ScreenshotCaptureModeControls = ({setMjpegState, isUsingMjpegMode, setRefr
  */
 const ToggleElementHandlesButton = ({showCentroids, toggleShowCentroids, isGestureEditorVisible}) => {
   const {t} = useTranslation();
+  const toggleHandlesLabel = showCentroids ? t('Hide Element Handles') : t('Show Element Handles');
 
   return (
-    <Tooltip title={t(showCentroids ? 'Hide Element Handles' : 'Show Element Handles')}>
+    <Tooltip title={toggleHandlesLabel}>
       <Button
+        aria-label={toggleHandlesLabel}
         icon={<IconEyePlus size={18} />}
         onClick={() => toggleShowCentroids()}
         type={showCentroids ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -88,6 +94,9 @@ const ScreenshotInteractionModeControls = ({
   isGestureEditorVisible,
 }) => {
   const {t} = useTranslation();
+  const selectElemLabel = t('Select Elements');
+  const tapElemLabel = t('Tap By Element');
+  const tapCoordsLabel = t('Tap/Swipe By Coordinates');
 
   const screenshotInteractionChange = (mode) => {
     clearCoordAction(); // When the action changes, reset the swipe action
@@ -96,24 +105,27 @@ const ScreenshotInteractionModeControls = ({
 
   return (
     <Space.Compact>
-      <Tooltip title={t('Select Elements')}>
+      <Tooltip title={selectElemLabel}>
         <Button
+          aria-label={selectElemLabel}
           icon={<IconObjectScan size={18} />}
           onClick={() => screenshotInteractionChange(SELECT)}
           type={screenshotInteractionMode === SELECT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           disabled={isGestureEditorVisible}
         />
       </Tooltip>
-      <Tooltip title={t('Tap By Element')}>
+      <Tooltip title={tapElemLabel}>
         <Button
+          aria-label={tapElemLabel}
           icon={<IconSquarePlus size={18} />}
           onClick={() => screenshotInteractionChange(TAP_ELEMENT)}
           type={screenshotInteractionMode === TAP_ELEMENT ? BUTTON.PRIMARY : BUTTON.DEFAULT}
           disabled={isGestureEditorVisible}
         />
       </Tooltip>
-      <Tooltip title={t('Tap/Swipe By Coordinates')}>
+      <Tooltip title={tapCoordsLabel}>
         <Button
+          aria-label={tapCoordsLabel}
           icon={<IconCrosshair size={18} />}
           onClick={() => screenshotInteractionChange(TAP_SWIPE)}
           type={screenshotInteractionMode === TAP_SWIPE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
@@ -129,10 +141,12 @@ const ScreenshotInteractionModeControls = ({
  */
 const DownloadScreenshotButton = ({screenshot, showScreenshot, isUsingMjpegMode}) => {
   const {t} = useTranslation();
+  const downloadLabel = t('Download Screenshot');
 
   return (
-    <Tooltip title={t('Download Screenshot')}>
+    <Tooltip title={downloadLabel}>
       <Button
+        aria-label={downloadLabel}
         icon={<IconDownload size={18} />}
         onClick={() => downloadScreenshot(screenshot)}
         disabled={!showScreenshot || isUsingMjpegMode}

--- a/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoCodeBoxCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoCodeBoxCard.jsx
@@ -26,11 +26,12 @@ const SessionInfoCodeBoxPanelTitle = () => {
  */
 const SessionInfoCodeBoxHeaderOptions = ({clientCode, clientFramework, setClientFramework}) => {
   const {t} = useTranslation();
+  const copyLabel = t('Copy code to clipboard');
 
   return (
     <Space size="middle">
-      <Tooltip title={t('Copy code to clipboard')}>
-        <Button icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
+      <Tooltip title={copyLabel}>
+        <Button aria-label={copyLabel} icon={<IconFiles size={18} />} onClick={() => copyToClipboard(clientCode)} />
       </Tooltip>
       <Select
         defaultValue={clientFramework}

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
@@ -33,19 +33,24 @@ const AppSourcePanelTitle = () => {
  */
 const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleCollapse}) => {
   const {t} = useTranslation();
+  const copyXmlLabel = t('Copy XML Source to Clipboard');
+  const downloadLabel = t('Download Source as .XML File');
+  const togglePanelLabel = collapsed ? t('Expand Panel') : t('Collapse Panel');
 
   return (
     <span>
-      <Tooltip title={t('Copy XML Source to Clipboard')}>
+      <Tooltip title={copyXmlLabel}>
         <Button
+          aria-label={copyXmlLabel}
           type="text"
           id="btnSourceXML"
           icon={<IconFiles size={18} />}
           onClick={() => copyToClipboard(sourceXML)}
         />
       </Tooltip>
-      <Tooltip title={t('Download Source as .XML File')}>
+      <Tooltip title={downloadLabel}>
         <Button
+          aria-label={downloadLabel}
           type="text"
           id="btnDownloadSourceXML"
           icon={<IconDownload size={18} />}
@@ -53,8 +58,9 @@ const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleColl
         />
       </Tooltip>
       {collapsible && (
-        <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+        <Tooltip title={togglePanelLabel}>
           <Button
+            aria-label={togglePanelLabel}
             type="text"
             icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
             onClick={onToggleCollapse}

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceTreeActions.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceTreeActions.jsx
@@ -18,15 +18,23 @@ const AppSourceTreeActions = ({
   matchingElementsCount,
 }) => {
   const {t} = useTranslation();
+  const collapseLabel = t('Collapse All');
+  const toggleAttrsLabel = t('Toggle Attributes');
 
   return (
     <Row justify="center" type={ROW.FLEX} align="middle" className={styles.treeActions}>
       <Space.Compact>
-        <Tooltip title={t('Collapse All')}>
-          <Button id="btnCollapseAll" icon={<IconFold size={18} />} onClick={collapseAllNodes} />
-        </Tooltip>
-        <Tooltip title={t('Toggle Attributes')}>
+        <Tooltip title={collapseLabel}>
           <Button
+            aria-label={collapseLabel}
+            id="btnCollapseAll"
+            icon={<IconFold size={18} />}
+            onClick={collapseAllNodes}
+          />
+        </Tooltip>
+        <Tooltip title={toggleAttrsLabel}>
+          <Button
+            aria-label={toggleAttrsLabel}
             id="btnToggleAttrs"
             icon={<IconEyeCode size={18} />}
             onClick={toggleShowAttributes}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementActions.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementActions.jsx
@@ -21,6 +21,11 @@ const SelectedElementActions = (props) => {
     elementLocatorsData,
   } = props;
   const {t} = useTranslation();
+  const tapLabel = t('Tap');
+  const sendKeysLabel = t('Send Keys');
+  const clearLabel = t('Clear');
+  const getTimingLabel = t('Get Timing');
+
   const sendKeysRef = useRef(null);
 
   const tapButtonLoadingState =
@@ -28,8 +33,9 @@ const SelectedElementActions = (props) => {
 
   return (
     <Row justify="center" type={ROW.FLEX} align="middle" className={styles.selectedElemActions}>
-      <Tooltip title={t('Tap')}>
+      <Tooltip title={tapLabel}>
         <Button
+          aria-label={tapLabel}
           disabled={elementActionsDisabled}
           icon={<IconFocus2 size={18} />}
           loading={tapButtonLoadingState}
@@ -45,8 +51,9 @@ const SelectedElementActions = (props) => {
           allowClear={true}
           onChange={(e) => (sendKeysRef.current = e.target.value)}
         />
-        <Tooltip title={t('Send Keys')}>
+        <Tooltip title={sendKeysLabel}>
           <Button
+            aria-label={sendKeysLabel}
             disabled={elementActionsDisabled}
             id="btnSendKeysToElement"
             icon={<IconSend2 size={18} />}
@@ -59,8 +66,9 @@ const SelectedElementActions = (props) => {
             }
           />
         </Tooltip>
-        <Tooltip title={t('Clear')}>
+        <Tooltip title={clearLabel}>
           <Button
+            aria-label={clearLabel}
             disabled={elementActionsDisabled}
             id="btnClearElement"
             icon={<IconEraser size={18} />}
@@ -68,8 +76,9 @@ const SelectedElementActions = (props) => {
           />
         </Tooltip>
       </Space.Compact>
-      <Tooltip title={t('Get Timing')}>
+      <Tooltip title={getTimingLabel}>
         <Button
+          aria-label={getTimingLabel}
           disabled={elementActionsDisabled}
           id="btnGetTiming"
           icon={<IconStopwatch size={18} />}

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
@@ -36,6 +36,9 @@ const SelectedElementHeaderButtons = ({
   onToggleCollapse,
 }) => {
   const {t} = useTranslation();
+  const copyAttrsLabel = t('Copy Attributes to Clipboard');
+  const downloadLabel = t('Download Screenshot');
+  const togglePanelLabel = collapsed ? t('Expand Panel') : t('Collapse Panel');
 
   const downloadElementScreenshot = async (elementId) => {
     const elemScreenshot = await applyClientMethod({
@@ -50,8 +53,9 @@ const SelectedElementHeaderButtons = ({
 
   return (
     <span>
-      <Tooltip title={t('Copy Attributes to Clipboard')}>
+      <Tooltip title={copyAttrsLabel}>
         <Button
+          aria-label={copyAttrsLabel}
           type="text"
           disabled={elementActionsDisabled}
           id="btnCopyAttributes"
@@ -59,8 +63,9 @@ const SelectedElementHeaderButtons = ({
           onClick={() => copyToClipboard(JSON.stringify(elementAttributesData))}
         />
       </Tooltip>
-      <Tooltip title={t('Download Screenshot')}>
+      <Tooltip title={downloadLabel}>
         <Button
+          aria-label={downloadLabel}
           type="text"
           disabled={elementActionsDisabled}
           icon={<IconDownload size={18} />}
@@ -69,8 +74,9 @@ const SelectedElementHeaderButtons = ({
         />
       </Tooltip>
       {collapsible && (
-        <Tooltip title={t(collapsed ? 'Expand Panel' : 'Collapse Panel')}>
+        <Tooltip title={togglePanelLabel}>
           <Button
+            aria-label={togglePanelLabel}
             type="text"
             icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
             onClick={onToggleCollapse}


### PR DESCRIPTION
Supersedes #3035, with duplicated labels extracted into their own constants.

Fixes #3034.