### PR TITLE
fix: adjust responsiveness in Session Inspector

### DIFF
--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSource.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSource.jsx
@@ -5,15 +5,10 @@ import AppSourceTreeWrapper from './AppSourceTreeWrapper.jsx';
  * Shows the app source as a tree with search and attribute toggles.
  */
 const AppSource = (props) => {
-  const {sourceXML, collapsible, collapsed, onToggleCollapse} = props;
+  const {sourceXML} = props;
 
   return (
-    <AppSourceCard
-      sourceXML={sourceXML}
-      collapsible={collapsible}
-      collapsed={collapsed}
-      onToggleCollapse={onToggleCollapse}
-    >
+    <AppSourceCard sourceXML={sourceXML}>
       <AppSourceTreeWrapper {...props} />
     </AppSourceCard>
   );

--- a/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/AppSource/AppSourceCard.jsx
@@ -1,4 +1,4 @@
-import {IconChevronDown, IconChevronUp, IconDownload, IconFiles, IconFileText} from '@tabler/icons-react';
+import {IconDownload, IconFiles, IconFileText} from '@tabler/icons-react';
 import {Button, Card, Flex, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
@@ -26,16 +26,12 @@ const AppSourcePanelTitle = () => {
 };
 
 /**
- * Header action buttons for source XML copy and download, plus (when panels
- * are stacked) the toggle that collapses/expands the card body while keeping
- * its header visible - the side-by-side layout already offers a full
- * collapse via the Splitter divider.
+ * Header action buttons for source XML copy and download.
  */
-const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleCollapse}) => {
+const AppSourceHeaderButtons = ({sourceXML}) => {
   const {t} = useTranslation();
   const copyXmlLabel = t('Copy XML Source to Clipboard');
   const downloadLabel = t('Download Source as .XML File');
-  const togglePanelLabel = collapsed ? t('Expand Panel') : t('Collapse Panel');
 
   return (
     <span>
@@ -57,16 +53,6 @@ const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleColl
           onClick={() => downloadXML(sourceXML)}
         />
       </Tooltip>
-      {collapsible && (
-        <Tooltip title={togglePanelLabel}>
-          <Button
-            aria-label={togglePanelLabel}
-            type="text"
-            icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
-            onClick={onToggleCollapse}
-          />
-        </Tooltip>
-      )}
     </span>
   );
 };
@@ -74,19 +60,9 @@ const AppSourceHeaderButtons = ({sourceXML, collapsible, collapsed, onToggleColl
 /**
  * Wrapper card for the app source tree.
  */
-const AppSourceCard = ({sourceXML, collapsible, collapsed, onToggleCollapse, children}) => (
-  <Card
-    title={<AppSourcePanelTitle />}
-    extra={
-      <AppSourceHeaderButtons
-        sourceXML={sourceXML}
-        collapsible={collapsible}
-        collapsed={collapsed}
-        onToggleCollapse={onToggleCollapse}
-      />
-    }
-  >
-    {!collapsed && children}
+const AppSourceCard = ({sourceXML, children}) => (
+  <Card title={<AppSourcePanelTitle />} extra={<AppSourceHeaderButtons sourceXML={sourceXML} />}>
+    {children}
   </Card>
 );
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElement.jsx
@@ -31,9 +31,6 @@ const SelectedElement = (props) => {
     elementInteractionsNotAvailable,
     selectedElementSearchInProgress,
     sessionSettings,
-    collapsible,
-    collapsed,
-    onToggleCollapse,
   } = props;
 
   const elementActionsDisabled = selectedElementSearchInProgress || isFindingElementsTimes;
@@ -63,9 +60,6 @@ const SelectedElement = (props) => {
       selectedElementId={selectedElementId}
       elementAttributesData={elementAttributesData}
       elementActionsDisabled={elementActionsDisabled}
-      collapsible={collapsible}
-      collapsed={collapsed}
-      onToggleCollapse={onToggleCollapse}
     >
       <Space className={inspectorStyles.spaceContainer} orientation="vertical" size="middle">
         <SnapshotMaxDepthReachedMessage selectedElementPath={selectedElementPath} sessionSettings={sessionSettings} />

--- a/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SelectedElement/SelectedElementCard.jsx
@@ -1,4 +1,4 @@
-import {IconChevronDown, IconChevronUp, IconDownload, IconFiles, IconTag} from '@tabler/icons-react';
+import {IconDownload, IconFiles, IconTag} from '@tabler/icons-react';
 import {Button, Card, Flex, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
@@ -21,24 +21,17 @@ const SelectedElementPanelTitle = () => {
 };
 
 /**
- * Buttons shown in the selected element's wrapper card, plus (when panels
- * are stacked) the toggle that collapses/expands the card body while keeping
- * its header visible - the side-by-side layout already offers a full
- * collapse via the Splitter divider.
+ * Buttons shown in the selected element's wrapper card.
  */
 const SelectedElementHeaderButtons = ({
   elementAttributesData,
   elementActionsDisabled,
   selectedElementId,
   applyClientMethod,
-  collapsible,
-  collapsed,
-  onToggleCollapse,
 }) => {
   const {t} = useTranslation();
   const copyAttrsLabel = t('Copy Attributes to Clipboard');
   const downloadLabel = t('Download Screenshot');
-  const togglePanelLabel = collapsed ? t('Expand Panel') : t('Collapse Panel');
 
   const downloadElementScreenshot = async (elementId) => {
     const elemScreenshot = await applyClientMethod({
@@ -73,16 +66,6 @@ const SelectedElementHeaderButtons = ({
           onClick={() => downloadElementScreenshot(selectedElementId)}
         />
       </Tooltip>
-      {collapsible && (
-        <Tooltip title={togglePanelLabel}>
-          <Button
-            aria-label={togglePanelLabel}
-            type="text"
-            icon={collapsed ? <IconChevronDown size={18} /> : <IconChevronUp size={18} />}
-            onClick={onToggleCollapse}
-          />
-        </Tooltip>
-      )}
     </span>
   );
 };
@@ -95,9 +78,6 @@ const SelectedElementCard = ({
   selectedElementId,
   elementActionsDisabled,
   elementAttributesData,
-  collapsible,
-  collapsed,
-  onToggleCollapse,
   children,
 }) => (
   <Card
@@ -109,13 +89,10 @@ const SelectedElementCard = ({
         elementActionsDisabled={elementActionsDisabled}
         selectedElementId={selectedElementId}
         applyClientMethod={applyClientMethod}
-        collapsible={collapsible}
-        collapsed={collapsed}
-        onToggleCollapse={onToggleCollapse}
       />
     }
   >
-    {!collapsed && children}
+    {children}
   </Card>
 );
 

--- a/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
+++ b/app/common/renderer/components/SessionInspector/SourceTab/SourceTab.jsx
@@ -13,64 +13,15 @@ import styles from './SourceTab.module.css';
 // independently (e.g. portrait vs landscape orientation).
 const NARROW_LAYOUT_BREAKPOINT = 600;
 
-// Height of a card's header row (title + action buttons). Used as the
-// collapsed size for a stacked panel, so its header stays visible while its
-// body is hidden and the other panel gets the freed space.
-const PANEL_HEADER_HEIGHT = 55;
-
 const SourceTab = (props) => {
   const {selectedElement = {}} = props;
 
-  const hasSelectedElement = Object.keys(selectedElement).length > 0;
-
   const containerRef = useRef(null);
   const [isNarrow, setIsNarrow] = useState(false);
-  const [appSourceCollapsed, setAppSourceCollapsed] = useState(false);
-  const [selectedElementCollapsed, setSelectedElementCollapsed] = useState(false);
 
-  // Splitter can't shrink both panels to their collapsed size at once (with
-  // neither panel left to absorb the freed space, it resets both back to
-  // their default size) - so collapsing one always re-expands the other,
-  // keeping exactly one panel expanded at a time.
-  const toggleAppSourceCollapse = () => {
-    setAppSourceCollapsed((collapsed) => {
-      const next = !collapsed;
-      if (next) {
-        setSelectedElementCollapsed(false);
-      }
-      return next;
-    });
-  };
-  const toggleSelectedElementCollapse = () => {
-    setSelectedElementCollapsed((collapsed) => {
-      const next = !collapsed;
-      if (next) {
-        setAppSourceCollapsed(false);
-      }
-      return next;
-    });
-  };
-
-  // Accordion-style collapse (header stays, body hides, other panel grows
-  // into the freed space) only makes sense when panels are stacked and both
-  // are present - otherwise fall back to the Splitter's own full collapse.
-  const canAccordionCollapse = isNarrow && hasSelectedElement;
-
-  // Splitter's own collapse (via the divider) fully hides a panel, header
-  // included, which only makes sense side-by-side with both panels present.
-  const splitterCollapsible =
-    !isNarrow && hasSelectedElement ? {start: true, end: true, showCollapsibleIcon: true} : false;
-
-  // Shared size/min for a panel that supports the accordion-style collapse:
-  // shrink to just its header height when collapsed, otherwise fall back to
-  // its own default size/min.
-  const getPanelSizing = (collapsed, defaultSize, defaultMin) => ({
-    size: canAccordionCollapse && collapsed ? PANEL_HEADER_HEIGHT : defaultSize,
-    min: canAccordionCollapse && collapsed ? PANEL_HEADER_HEIGHT : defaultMin,
-  });
-
-  const appSourceSizing = getPanelSizing(appSourceCollapsed, hasSelectedElement ? undefined : 100, 210);
-  const selectedElementSizing = getPanelSizing(selectedElementCollapsed, undefined, 250);
+  const hasSelectedElement = Object.keys(selectedElement).length > 0;
+  // We always want to show the collapsible icon, so a simple 'true' is not enough
+  const isCollapsible = hasSelectedElement ? {start: true, end: true, showCollapsibleIcon: true} : false;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -84,7 +35,7 @@ const SourceTab = (props) => {
     // caches a stale container size, leaving panels stuck at the wrong
     // size until another resize happens to nudge it again.
     const observer = new ResizeObserver(([entry]) => {
-      setIsNarrow(entry.contentRect.width < NARROW_LAYOUT_BREAKPOINT);
+      setIsNarrow(entry.contentRect.width > 0 && entry.contentRect.width < NARROW_LAYOUT_BREAKPOINT);
     });
     observer.observe(container);
     return () => observer.disconnect();
@@ -93,26 +44,16 @@ const SourceTab = (props) => {
   return (
     <div ref={containerRef} className={styles.sourceTabContainer}>
       <Splitter orientation={isNarrow ? 'vertical' : 'horizontal'}>
-        <Splitter.Panel collapsible={splitterCollapsible} size={appSourceSizing.size} min={appSourceSizing.min}>
-          <AppSource
-            {...props}
-            collapsible={canAccordionCollapse}
-            collapsed={canAccordionCollapse && appSourceCollapsed}
-            onToggleCollapse={toggleAppSourceCollapse}
-          />
+        <Splitter.Panel
+          collapsible={isCollapsible}
+          size={hasSelectedElement ? undefined : '100%'}
+          min={isNarrow ? 170 : 210}
+        >
+          <AppSource {...props} />
         </Splitter.Panel>
         {hasSelectedElement && (
-          <Splitter.Panel
-            collapsible={splitterCollapsible}
-            size={selectedElementSizing.size}
-            min={selectedElementSizing.min}
-          >
-            <SelectedElement
-              {...props}
-              collapsible={canAccordionCollapse}
-              collapsed={canAccordionCollapse && selectedElementCollapsed}
-              onToggleCollapse={toggleSelectedElementCollapse}
-            />
+          <Splitter.Panel collapsible={isCollapsible} min={isNarrow ? 160 : 250}>
+            <SelectedElement {...props} />
           </Splitter.Panel>
         )}
       </Splitter>


### PR DESCRIPTION
This is a follow-up to #3064 and focuses on two things:
* Remove the custom expand/collapse buttons in the panel headers when in narrow mode. It's largely unnecessary when the standard vertical Splitter can do the same thing, and is consistent with the normal width behavior. The collapsible icons are still shown at all times to inform the user of their position when in narrow mode.
* Fix a bug in normal width where, upon switching to another tab and back, the source panel (or source+selected element panel combined) was reset to the width matching the minimum window width. This was due to `entry.contentRect.width` being set to 0 while in other tabs, resulting in `isNarrow` being set. Fixed by only allowing `isNarrow` to be changed when `entry.contentRect.width` is above 0.