### PR TITLE
fix: ensure notifications can be normally dismissed

### DIFF
--- a/app/common/renderer/assets/stylesheets/main.css
+++ b/app/common/renderer/assets/stylesheets/main.css
@@ -34,6 +34,14 @@ body::-webkit-scrollbar-corner {
   background-color: #662d91 !important;
 }
 
+/*
+Notifications can overlap the app header, whose drag region prevents interactions
+with anything overlapping it, unless excluded
+*/
+.ant-notification-list-content {
+  -webkit-app-region: no-drag;
+}
+
 .ant-spin,
 .ant-spin-container {
   height: 100%;

--- a/app/common/renderer/components/SessionInspector/Header/Header.module.css
+++ b/app/common/renderer/components/SessionInspector/Header/Header.module.css
@@ -6,7 +6,7 @@
   display: flex;
   flex-direction: column;
   align-items: safe center;
-  padding: 10px 0;
+  padding: 10px 0 0 0;
   gap: 10px;
   width: 100%;
   min-height: 50px;


### PR DESCRIPTION
The recent responsiveness-related PRs surfaced a small issue: new notifications were partially overlapping the header (whose height had been slightly increased), and since the header is configured as the drag region, anything that overlaps it is no longer interactable, including parts of the notification dismiss button.
This PR excludes the notification elements from the drag region, making the dismiss button normally interactable.

I've also included a small adjustment for the header size to largely revert it to its previous height, by removing the bottom padding. Button overflow still works as expected.