### PR TITLE
chore: move tracking of driver settings to applyClientMethod

### DIFF
--- a/app/common/renderer/actions/SessionInspector.js
+++ b/app/common/renderer/actions/SessionInspector.js
@@ -1,6 +1,7 @@
 import sanitize from 'sanitize-filename';
 
 import {SAVED_CLIENT_FRAMEWORK, SET_SAVED_GESTURES} from '../../shared/setting-defs.js';
+import {COMMAND_UPDATE_SETTINGS} from '../constants/commands.js';
 import {APP_MODE, NATIVE_APP, UNKNOWN_ERROR} from '../constants/session-inspector.js';
 import i18n from '../i18next.js';
 import InspectorDriver from '../lib/appium/inspector-driver.js';
@@ -263,6 +264,11 @@ export function applyClientMethod(params) {
       let args = [variableName, variableIndex];
       args = args.concat(params.args || []);
       dispatch({type: RECORD_ACTION, action: params.methodName, params: args});
+    }
+    // If updating settings, store the updated values
+    if (params.methodName === COMMAND_UPDATE_SETTINGS) {
+      const storeSettingsAction = storeSessionSettings(params.args[0]);
+      await storeSettingsAction(dispatch, getState);
     }
     dispatch({type: METHOD_CALL_DONE});
 

--- a/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from 'react';
 
+import {COMMAND_EXECUTE_SCRIPT} from '../../../constants/commands.js';
 import {adjustParamValueType, transformCommandsMap, transformExecMethodsMap} from '../../../utils/commands-tab.js';
 import {isEmpty, isPlainObject} from '../../../utils/common.js';
 import CommandParametersModal from './CommandParametersModal.jsx';
@@ -10,15 +11,10 @@ import StaticCommandsContent from './StaticCommandsContent.jsx';
 
 import styles from './Commands.module.css';
 
-const COMMAND_EXECUTE_SCRIPT = 'executeScript';
-const COMMAND_UPDATE_SETTINGS = 'updateSettings';
-
 /**
  * Contents of the commands tab.
  */
-const Commands = (props) => {
-  const {applyClientMethod, getSupportedSessionMethods, storeSessionSettings} = props;
-
+const Commands = ({applyClientMethod, getSupportedSessionMethods}) => {
   const [hasMethodsMap, setHasMethodsMap] = useState(null);
   const [driverCommands, setDriverCommands] = useState(null);
   const [driverExecuteMethods, setDriverExecuteMethods] = useState(null);
@@ -82,11 +78,6 @@ const Commands = (props) => {
     const [newCmdName, newCmdParams] = prepareCommand(cmdName, cmdParams, isExecute);
     // Do not await - let the command run in the background without blocking the UI
     runCommand(newCmdName, newCmdParams, !refresh);
-
-    // if updating settings, store the updated values
-    if (newCmdName === COMMAND_UPDATE_SETTINGS) {
-      storeSessionSettings(newCmdParams[0]);
-    }
   };
 
   const clearCurrentCommand = () => {

--- a/app/common/renderer/components/SessionInspector/SessionInspectorTabs.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInspectorTabs.jsx
@@ -15,7 +15,14 @@ import styles from './SessionInspector.module.css';
  * Tabs shown to the right of the screenshot on the Session Inspector screen.
  */
 const SessionInspectorTabs = (props) => {
-  const {selectedInspectorTab, selectInspectorTab, isGestureEditorVisible, showScreenshot} = props;
+  const {
+    selectedInspectorTab,
+    selectInspectorTab,
+    isGestureEditorVisible,
+    showScreenshot,
+    applyClientMethod,
+    getSupportedSessionMethods,
+  } = props;
 
   const {t} = useTranslation();
 
@@ -30,7 +37,9 @@ const SessionInspectorTabs = (props) => {
       label: t('Commands'),
       key: INSPECTOR_TABS.COMMANDS,
       disabled: !showScreenshot,
-      children: <Commands {...props} />,
+      children: (
+        <Commands applyClientMethod={applyClientMethod} getSupportedSessionMethods={getSupportedSessionMethods} />
+      ),
     },
     {
       label: t('Gestures'),

--- a/app/common/renderer/constants/commands.js
+++ b/app/common/renderer/constants/commands.js
@@ -379,3 +379,6 @@ export const COMMAND_DEFINITIONS = {
     },
   },
 };
+
+export const COMMAND_EXECUTE_SCRIPT = 'executeScript';
+export const COMMAND_UPDATE_SETTINGS = 'updateSettings';


### PR DESCRIPTION
This makes it easier to add new functionality that depends on settings.
Also reduced the number of props passed to the Commands tab.