### PR TITLE
chore: wrap local automationName var into featureCaps object

### DIFF
--- a/app/common/renderer/actions/SessionInspector.js
+++ b/app/common/renderer/actions/SessionInspector.js
@@ -119,7 +119,7 @@ const NO_NEW_COMMAND_LIMIT = 24 * 60 * 60 * 1000; // Set timeout to 24 hours
 // Shared by selectElement and tapElement.
 // Returns the computed strategy map.
 function prepareElementSelection(path, dispatch, getState) {
-  const {sourceJSON, sourceXML, expandedPaths, currentContext, automationName} = getState().inspector;
+  const {sourceJSON, sourceXML, expandedPaths, currentContext, featureCaps} = getState().inspector;
   const isNative = currentContext === NATIVE_APP;
   // Set the selected element in the source tree
   const selectedElement = findJSONElementByPath(path, sourceJSON);
@@ -139,7 +139,7 @@ function prepareElementSelection(path, dispatch, getState) {
   dispatch({type: SET_EXPANDED_PATHS, paths: copiedExpandedPaths});
 
   // Calculate the recommended locator strategies
-  const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative, automationName);
+  const strategyMap = getSuggestedLocators(selectedElement, sourceXML, isNative, featureCaps.automationName);
   dispatch({type: SET_OPTIMAL_LOCATORS, strategyMap});
 
   return strategyMap;
@@ -404,11 +404,22 @@ export function toggleShowBoilerplate() {
 
 export function setSessionDetails({serverDetails, driver, sessionCaps, appMode, isUsingMjpegMode}) {
   return (dispatch) => {
+    // Extract several capabilities from the finalised set of caps
+    // that may be relevant for enabling specific Inspector features
+    const featureCaps = {};
+    for (const stringCapName of ['automationName', 'browserName', 'platformName']) {
+      featureCaps[stringCapName] = driver.capabilities[stringCapName]?.toLowerCase();
+    }
+    // Convert platformVersion to a float - even if it is in a semver-style format, where conversion
+    // will only retain the first major & minor versions, this is sufficient for feature-gating
+    featureCaps.platformVersion = parseFloat(driver.capabilities.platformVersion, 10) || undefined;
+
     dispatch({
       type: SET_SESSION_DETAILS,
       serverDetails,
       driver,
       sessionCaps,
+      featureCaps,
       appMode,
       isUsingMjpegMode,
     });

--- a/app/common/renderer/components/SessionInspector/Header/DriverControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DriverControlsGroup.jsx
@@ -136,12 +136,12 @@ const EspressoControlsGroup = ({sessionSettings, applyClientMethod}) => {
 /**
  * Controls specific to the driver (automationName)
  */
-const DriverControlsGroup = ({automationName, sessionSettings, applyClientMethod}) => (
+const DriverControlsGroup = ({featureCaps, sessionSettings, applyClientMethod}) => (
   <>
-    {automationName === DRIVERS.UIAUTOMATOR2 && (
+    {featureCaps.automationName === DRIVERS.UIAUTOMATOR2 && (
       <UiA2ControlsGroup sessionSettings={sessionSettings} applyClientMethod={applyClientMethod} />
     )}
-    {automationName === DRIVERS.ESPRESSO && (
+    {featureCaps.automationName === DRIVERS.ESPRESSO && (
       <EspressoControlsGroup sessionSettings={sessionSettings} applyClientMethod={applyClientMethod} />
     )}
   </>

--- a/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/HeaderButtons.jsx
@@ -26,7 +26,7 @@ const HeaderButtons = (props) => {
     setContext,
     autoSessionRestart,
     toggleAutoSessionRestart,
-    automationName,
+    featureCaps,
     sessionSettings,
     siriCommandValue,
     setSiriCommandValue,
@@ -47,7 +47,7 @@ const HeaderButtons = (props) => {
           hideSiriCommandModal={hideSiriCommandModal}
         />
         <DriverControlsGroup
-          automationName={automationName}
+          featureCaps={featureCaps}
           sessionSettings={sessionSettings}
           applyClientMethod={applyClientMethod}
         />

--- a/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchModal.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/LocatorSearch/LocatorSearchModal.jsx
@@ -18,7 +18,7 @@ const LocatorSearchModal = (props) => {
     locatedElements,
     locatorSearchStrategy,
     locatorSearchValue,
-    automationName,
+    featureCaps,
     sessionSettings,
     currentContext,
   } = props;
@@ -59,7 +59,7 @@ const LocatorSearchModal = (props) => {
           locatorSearchValue={locatorSearchValue}
           setLocatorSearchStrategy={setLocatorSearchStrategy}
           locatorSearchStrategy={locatorSearchStrategy}
-          automationName={automationName}
+          automationName={featureCaps.automationName}
           currentContext={currentContext}
         />
       )}
@@ -69,7 +69,7 @@ const LocatorSearchModal = (props) => {
             <LocatorSearchEmptyResults
               locatorSearchStrategy={locatorSearchStrategy}
               locatorSearchValue={locatorSearchValue}
-              automationName={automationName}
+              automationName={featureCaps.automationName}
               sessionSettings={sessionSettings}
             />
           )}

--- a/app/common/renderer/reducers/SessionInspector.js
+++ b/app/common/renderer/reducers/SessionInspector.js
@@ -86,7 +86,6 @@ import {omit} from '../utils/common.js';
 const INITIAL_STATE = {
   savedGestures: [],
   driver: null,
-  automationName: null,
   keepAliveInterval: null,
   showKeepAlivePrompt: false,
   userWaitTimeout: null,
@@ -99,6 +98,7 @@ const INITIAL_STATE = {
   clientFramework: CLIENT_FRAMEWORKS.JAVA_JUNIT4,
   serverDetails: {},
   sessionCaps: {},
+  featureCaps: {},
   sessionSettings: {},
   isGestureEditorVisible: false,
   isLocatorSearchModalVisible: false,
@@ -283,13 +283,12 @@ export default function inspector(state = INITIAL_STATE, action) {
       return {...state, showBoilerplate: action.show};
 
     case SET_SESSION_DETAILS: {
-      const automationName = action.driver.capabilities.automationName;
       return {
         ...state,
         serverDetails: action.serverDetails,
         driver: action.driver,
         sessionCaps: action.sessionCaps,
-        automationName: automationName && automationName.toLowerCase(),
+        featureCaps: action.featureCaps,
         appMode: action.appMode,
         isUsingMjpegMode: action.isUsingMjpegMode,
       };


### PR DESCRIPTION
Some Inspector features (like the recently added display selector and subdriver buttons) are gated behind specific drivers, which are identified from the locally-saved `automationName` variable, itself retrieved from the driver's finalised capability of the same name.
While this works fine, there is currently no way to gate features behind other session properties like `platformName` or `platformVersion`. WDIO's inherited `isIOS`/`isAndroid` do help, but they don't work for something like tvOS or watchOS.

This PR drops the local standalone `automationName` variable and instead packages it as one of the fields in the new `featureCaps` object variable. This variable now also stores `platformName`, `platformVersion` and `browserName`, enabling future PRs that lock features behind any of these properties.