### PR TITLE
fix: enable retrieval of active app for tvOS & watchOS

### DIFF
--- a/app/common/renderer/actions/SessionInspector.js
+++ b/app/common/renderer/actions/SessionInspector.js
@@ -2,6 +2,7 @@ import sanitize from 'sanitize-filename';
 
 import {SAVED_CLIENT_FRAMEWORK, SET_SAVED_GESTURES} from '../../shared/setting-defs.js';
 import {COMMAND_UPDATE_SETTINGS} from '../constants/commands.js';
+import {DRIVERS} from '../constants/common.js';
 import {APP_MODE, NATIVE_APP, UNKNOWN_ERROR} from '../constants/session-inspector.js';
 import i18n from '../i18next.js';
 import InspectorDriver from '../lib/appium/inspector-driver.js';
@@ -728,10 +729,10 @@ export function toggleShowCentroids() {
   };
 }
 
-export function getActiveAppId(isIOS, isAndroid) {
+export function getActiveAppId(automationName) {
   return async (dispatch, getState) => {
     try {
-      if (isIOS) {
+      if (automationName === DRIVERS.XCUITEST) {
         const action = applyClientMethod({
           methodName: 'executeScript',
           args: ['mobile:activeAppInfo', []],
@@ -740,7 +741,7 @@ export function getActiveAppId(isIOS, isAndroid) {
         const {bundleId} = await action(dispatch, getState);
         dispatch({type: SET_APP_ID, appId: bundleId});
       }
-      if (isAndroid) {
+      if ([DRIVERS.UIAUTOMATOR2, DRIVERS.ESPRESSO].includes(automationName)) {
         const action = applyClientMethod({
           methodName: 'executeScript',
           args: ['mobile:getCurrentPackage', []],

--- a/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoTable.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInfoTab/SessionInfoTable.jsx
@@ -62,6 +62,7 @@ const SessionInfoInnerTable = ({tableData}) => (
 const SessionInfoTable = (props) => {
   const {
     driver,
+    featureCaps,
     getActiveAppId,
     getServerStatus,
     getFlatSessionCaps,
@@ -114,11 +115,10 @@ const SessionInfoTable = (props) => {
   };
 
   useEffect(() => {
-    if (!driver) {
+    if (!sessionStartTime) {
       return;
     }
-    const {isIOS, isAndroid} = driver;
-    getActiveAppId(isIOS, isAndroid);
+    getActiveAppId(featureCaps.automationName);
     getServerStatus();
     getFlatSessionCaps();
 
@@ -126,7 +126,7 @@ const SessionInfoTable = (props) => {
       setSessionLength(Date.now() - sessionStartTime);
     }, 1000);
     return () => clearInterval(intervalRef.current);
-  }, [driver, getActiveAppId, getServerStatus, getFlatSessionCaps, sessionStartTime]);
+  }, [featureCaps, getActiveAppId, getServerStatus, getFlatSessionCaps, sessionStartTime]);
 
   return (
     <Table


### PR DESCRIPTION
Small change where the retrieval of the active app in the Session Information tab now depends on `automationName` rather than iOS/Android only.
For most usecases this doesn't change much, but now the field can be populated on tvOS and watchOS sessions as well.