### PR TITLE
fix: do not show screenshot mode controls when quitting session

### DIFF
--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -178,7 +178,7 @@ const ScreenshotControls = (props) => {
   return (
     <div className={styles.screenshotControls}>
       <Space size="small">
-        {serverDetails.mjpegScreenshotUrl !== null && (
+        {serverDetails.mjpegScreenshotUrl != null && (
           <ScreenshotCaptureModeControls
             setMjpegState={setMjpegState}
             isUsingMjpegMode={isUsingMjpegMode}


### PR DESCRIPTION
Very small but noticeable fix.
Currently, if a user is in a session without MJPEG enabled, and quits it, the screenshot capture mode controls briefly appear on top of the screenshot. This is because the condition for their appearance (`mjpegScreenshotUrl`) was set to `undefined` upon session quit, while the value was being exactly compared to `null`.
With this fix, the value is also compared to `undefined`, resulting in the buttons no longer showing up.