### PR TITLE
fix: hide W3C Action features on unsupported platforms

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -334,5 +334,6 @@
   "refreshDiscoveredSessions": "Refresh Discovered Sessions",
   "toggleMultiDisplayMode": "Toggle Multi-Display Mode",
   "switchToEspressoSubdriver": "Switch to Espresso Subdriver",
-  "switchToComposeSubdriver": "Switch to Compose Subdriver"
+  "switchToComposeSubdriver": "Switch to Compose Subdriver",
+  "w3cActionsUnsupported": "W3C Actions are not supported on this platform"
 }

--- a/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Screenshot/ScreenshotControls.jsx
@@ -11,6 +11,7 @@ import {Button, Space, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
 import {BUTTON} from '../../../constants/antd-types.js';
+import {PLATFORMS_WITHOUT_W3C_ACTIONS} from '../../../constants/common.js';
 import {SCREENSHOT_INTERACTION_MODE} from '../../../constants/screenshot.js';
 import {downloadFile} from '../../../utils/file-handling.js';
 
@@ -92,11 +93,15 @@ const ScreenshotInteractionModeControls = ({
   selectScreenshotInteractionMode,
   clearCoordAction,
   isGestureEditorVisible,
+  platformName,
 }) => {
+  // Disable the tap/swipe interaction mode on unsupported platforms
+  const areW3CActionsUnsupported = PLATFORMS_WITHOUT_W3C_ACTIONS.includes(platformName);
+
   const {t} = useTranslation();
   const selectElemLabel = t('Select Elements');
   const tapElemLabel = t('Tap By Element');
-  const tapCoordsLabel = t('Tap/Swipe By Coordinates');
+  const tapCoordsLabel = areW3CActionsUnsupported ? t('w3cActionsUnsupported') : t('Tap/Swipe By Coordinates');
 
   const screenshotInteractionChange = (mode) => {
     clearCoordAction(); // When the action changes, reset the swipe action
@@ -123,13 +128,13 @@ const ScreenshotInteractionModeControls = ({
           disabled={isGestureEditorVisible}
         />
       </Tooltip>
-      <Tooltip title={tapCoordsLabel}>
+      <Tooltip title={tapCoordsLabel} placement={areW3CActionsUnsupported ? 'bottom' : 'top'}>
         <Button
           aria-label={tapCoordsLabel}
           icon={<IconCrosshair size={18} />}
           onClick={() => screenshotInteractionChange(TAP_SWIPE)}
           type={screenshotInteractionMode === TAP_SWIPE ? BUTTON.PRIMARY : BUTTON.DEFAULT}
-          disabled={isGestureEditorVisible}
+          disabled={areW3CActionsUnsupported || isGestureEditorVisible}
         />
       </Tooltip>
     </Space.Compact>
@@ -173,6 +178,7 @@ const ScreenshotControls = (props) => {
     isGestureEditorVisible,
     clearCoordAction,
     applyClientMethod,
+    featureCaps,
   } = props;
 
   return (
@@ -196,6 +202,7 @@ const ScreenshotControls = (props) => {
           selectScreenshotInteractionMode={selectScreenshotInteractionMode}
           clearCoordAction={clearCoordAction}
           isGestureEditorVisible={isGestureEditorVisible}
+          platformName={featureCaps.platformName}
         />
         <DownloadScreenshotButton
           screenshot={screenshot}

--- a/app/common/renderer/components/SessionInspector/SessionInspectorTabs.jsx
+++ b/app/common/renderer/components/SessionInspector/SessionInspectorTabs.jsx
@@ -1,6 +1,7 @@
-import {Tabs} from 'antd';
+import {Tabs, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
+import {PLATFORMS_WITHOUT_W3C_ACTIONS} from '../../constants/common.js';
 import {INSPECTOR_TABS} from '../../constants/session-inspector.js';
 import Commands from './CommandsTab/Commands.jsx';
 import GestureEditor from './GesturesTab/GestureEditor/GestureEditor.jsx';
@@ -22,9 +23,13 @@ const SessionInspectorTabs = (props) => {
     showScreenshot,
     applyClientMethod,
     getSupportedSessionMethods,
+    featureCaps,
   } = props;
 
   const {t} = useTranslation();
+
+  // Disable the Gestures tab on unsupported platforms
+  const areW3CActionsUnsupported = PLATFORMS_WITHOUT_W3C_ACTIONS.includes(featureCaps.platformName);
 
   const inspectorTabItems = [
     {
@@ -42,9 +47,15 @@ const SessionInspectorTabs = (props) => {
       ),
     },
     {
-      label: t('Gestures'),
+      label: areW3CActionsUnsupported ? (
+        <Tooltip title={t('w3cActionsUnsupported')} placement="bottom">
+          {t('Gestures')}
+        </Tooltip>
+      ) : (
+        t('Gestures')
+      ),
       key: INSPECTOR_TABS.GESTURES,
-      disabled: !showScreenshot,
+      disabled: areW3CActionsUnsupported || !showScreenshot,
       children: isGestureEditorVisible ? <GestureEditor {...props} /> : <SavedGestures {...props} />,
     },
     {

--- a/app/common/renderer/constants/common.js
+++ b/app/common/renderer/constants/common.js
@@ -15,6 +15,7 @@ export const LINKS = {
   UIAUTOMATOR_DOCS: 'https://github.com/appium/appium-uiautomator2-driver/blob/master/docs/uiautomator-uiselector.md',
 };
 
+// Known values of 'automationName'
 export const DRIVERS = {
   UIAUTOMATOR2: 'uiautomator2',
   ESPRESSO: 'espresso',
@@ -27,3 +28,17 @@ export const DRIVERS = {
   SAFARI: 'safari',
   GECKO: 'gecko',
 };
+
+// Known values of 'platformName'
+export const PLATFORMS = {
+  ANDROID: 'android',
+  IOS: 'ios',
+  TVOS: 'tvos',
+  WATCHOS: 'watchos',
+  MACOS: 'mac',
+  WINDOWS: 'windows',
+  LINUX: 'linux',
+};
+
+// Certain platforms do not support W3C Actions - disable tap/swipe features on those
+export const PLATFORMS_WITHOUT_W3C_ACTIONS = [PLATFORMS.TVOS, PLATFORMS.WATCHOS];


### PR DESCRIPTION
Certain platforms do not support W3C Actions-based features, so it makes sense to disable these features while in a session for such a platform. Currently this only applies to tvOS and watchOS, and affects the following features:

* Tap/Swipe By Coordinates mode for interacting with the screenshot
* The Gestures tab

If the feature is disabled, an informative tooltip is shown.