### PR TITLE
feat: add dropdown for watchOS gestures in the app header

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -73,6 +73,7 @@
   "couldNotObtainScreenshot": "Could not obtain screenshot: {{screenshotError}}",
   "pressDeviceButton": "Press Device Button",
   "Execute Siri Command": "Execute Siri Command",
+  "performHandGesture": "Perform Hand Gesture",
   "Press Home Button": "Press Home Button",
   "Press Back Button": "Press Back Button",
   "Press App Switch Button": "Press App Switch Button",

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
@@ -3,6 +3,7 @@ import {
   IconDeviceMobile,
   IconDeviceRemote,
   IconDeviceWatch,
+  IconHandStop,
   IconMessageChatbot,
 } from '@tabler/icons-react';
 import {Button, Dropdown, Space, Tooltip} from 'antd';
@@ -10,46 +11,25 @@ import {useTranslation} from 'react-i18next';
 
 import {COMMAND_EXECUTE_SCRIPT} from '../../../../constants/commands.js';
 import {PLATFORMS} from '../../../../constants/common.js';
+import {
+  XCUITEST_BUTTONS as BTNS,
+  XCUITEST_WATCHOS_GESTURES as WATCHOS_GESTURES,
+  XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION,
+  XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION,
+  XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION,
+} from '../../../../constants/driver-specific.js';
 import SiriCommandModal from './SiriCommandModal.jsx';
 
 import inspectorStyles from '../../SessionInspector.module.css';
 
-/**
- * All supported values for the 'mobile: pressButton' extension.
- * The Inspector only applies constraints for the device category and OS version:
- * limitations for Xcode, device model and simulator/real device currently cannot be implemented
- * @see https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-pressbutton
- */
-const BTNS = {
-  // All devices
-  HOME: 'home',
-  // iOS 16+ and watchOS 9+ supported devices only
-  ACTION: 'action',
-  // iOS real devices only
-  VOLUME_UP: 'volumeup',
-  VOLUME_DOWN: 'volumedown',
-  // iOS 16+ supported real devices only
-  CAMERA: 'camera',
-  // tvOS only
-  UP: 'up',
-  DOWN: 'down',
-  LEFT: 'left',
-  RIGHT: 'right',
-  MENU: 'menu',
-  PLAY_PAUSE: 'playpause',
-  SELECT: 'select',
-  PAGE_UP: 'pageup',
-  PAGE_DOWN: 'pagedown',
-  GUIDE: 'guide',
-  // tvOS 18.1+ only
-  FOUR_COLORS: 'fourcolors',
-  ONE_TWO_THREE: 'onetwothree',
-  TV_PROVIDER: 'tvprovider',
-};
+const toDropdownItem = (item) => ({
+  key: item,
+  label: <span className={inspectorStyles.monoFont}>{item}</span>,
+});
 
 const getIOSButtons = (platformVersion) => {
   const iosButtons = [BTNS.HOME, BTNS.VOLUME_UP, BTNS.VOLUME_DOWN];
-  if (platformVersion >= 16) {
+  if (platformVersion >= XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION) {
     iosButtons.push(BTNS.ACTION, BTNS.CAMERA);
   }
   return iosButtons;
@@ -69,7 +49,7 @@ const getTvOSButtons = (platformVersion) => {
     BTNS.PAGE_DOWN,
     BTNS.GUIDE,
   ];
-  if (platformVersion >= 18.1) {
+  if (platformVersion >= XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION) {
     tvOSButtons.push(BTNS.FOUR_COLORS, BTNS.ONE_TWO_THREE, BTNS.TV_PROVIDER);
   }
   return tvOSButtons;
@@ -77,22 +57,28 @@ const getTvOSButtons = (platformVersion) => {
 
 const getWatchOSButtons = () => [BTNS.HOME, BTNS.ACTION];
 
-const getButtonNames = (platformName, platformVersion) => {
+const getBtnDropdownItems = (platformName, platformVersion) => {
+  let platformButtons = [];
   switch (platformName) {
     case PLATFORMS.IOS:
-      return getIOSButtons(platformVersion);
+      platformButtons = getIOSButtons(platformVersion);
+      break;
     case PLATFORMS.TVOS:
-      return getTvOSButtons(platformVersion);
+      platformButtons = getTvOSButtons(platformVersion);
+      break;
     case PLATFORMS.WATCHOS:
-      return getWatchOSButtons();
+      platformButtons = getWatchOSButtons();
   }
+  return platformButtons.map(toDropdownItem);
 };
 
-const getDropdownItems = (platformName, platformVersion) =>
-  getButtonNames(platformName, platformVersion).map((btn) => ({
-    key: btn,
-    label: <span className={inspectorStyles.monoFont}>{btn}</span>,
-  }));
+const getGestureDropdownItems = (platformVersion) => {
+  const supportedGestures = [WATCHOS_GESTURES.DOUBLE_TAP];
+  if (platformVersion >= XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION) {
+    supportedGestures.push(WATCHOS_GESTURES.FLICK);
+  }
+  return supportedGestures.map(toDropdownItem);
+};
 
 const PressButtonIcon = ({platformName}) => {
   switch (platformName) {
@@ -119,24 +105,28 @@ const IDeviceControls = ({
 }) => {
   const {t} = useTranslation();
   const pressButtonLabel = t('pressDeviceButton');
+  const performGestureLabel = t('performHandGesture');
   const siriLabel = t('Execute Siri Command');
 
   const platformName = featureCaps.platformName;
   const platformVersion = featureCaps.platformVersion;
 
-  const onDropdownItemClick = ({key}) => {
+  const executeInteraction = (methodName, itemName) => {
     applyClientMethod({
       methodName: COMMAND_EXECUTE_SCRIPT,
-      args: ['mobile:pressButton', [{name: key}]],
+      args: [methodName, [{name: itemName}]],
     });
   };
+
+  const onBtnDropdownItemClick = ({key}) => executeInteraction('mobile:pressButton', key);
+  const onGestureDropdownItemClick = ({key}) => executeInteraction('mobile:performHandGesture', key);
 
   return (
     <>
       <Space.Compact>
         <Tooltip title={pressButtonLabel} placement="left">
           <Dropdown
-            menu={{items: getDropdownItems(platformName, platformVersion), onClick: onDropdownItemClick}}
+            menu={{items: getBtnDropdownItems(platformName, platformVersion), onClick: onBtnDropdownItemClick}}
             trigger={['click']}
           >
             <Button aria-label={pressButtonLabel} style={{padding: 4, columnGap: 0}}>
@@ -145,6 +135,19 @@ const IDeviceControls = ({
             </Button>
           </Dropdown>
         </Tooltip>
+        {platformName === PLATFORMS.WATCHOS && (
+          <Tooltip title={performGestureLabel} placement="left">
+            <Dropdown
+              menu={{items: getGestureDropdownItems(platformVersion), onClick: onGestureDropdownItemClick}}
+              trigger={['click']}
+            >
+              <Button aria-label={performGestureLabel} style={{padding: 4, columnGap: 0}}>
+                <IconHandStop size={18} />
+                <IconChevronDown size={14} />
+              </Button>
+            </Dropdown>
+          </Tooltip>
+        )}
         <Tooltip title={siriLabel}>
           <Button
             aria-label={siriLabel}

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
@@ -12,7 +12,9 @@ import {useTranslation} from 'react-i18next';
 import {COMMAND_EXECUTE_SCRIPT} from '../../../../constants/commands.js';
 import {PLATFORMS} from '../../../../constants/common.js';
 import {
-  XCUITEST_BUTTONS as BTNS,
+  XCUITEST_IOS_BUTTONS,
+  XCUITEST_TVOS_BUTTONS,
+  XCUITEST_WATCHOS_BUTTONS,
   XCUITEST_WATCHOS_GESTURES as WATCHOS_GESTURES,
   XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION,
   XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION,
@@ -27,68 +29,57 @@ const toDropdownItem = (item) => ({
   label: <span className={inspectorStyles.monoFont}>{item}</span>,
 });
 
-const getIOSButtons = (platformVersion) => {
-  const iosButtons = [BTNS.HOME, BTNS.VOLUME_UP, BTNS.VOLUME_DOWN];
-  if (platformVersion >= XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION) {
-    iosButtons.push(BTNS.ACTION, BTNS.CAMERA);
-  }
-  return iosButtons;
-};
+// Per-platform behavior lives here, so callers never need to branch on platformName themselves.
+const PLATFORM_CONFIGS = {
+  [PLATFORMS.IOS]: {
+    icon: <IconDeviceMobile size={18} />,
+    buttons: (platformVersion) => {
+      const buttons = [XCUITEST_IOS_BUTTONS.HOME, XCUITEST_IOS_BUTTONS.VOLUME_UP, XCUITEST_IOS_BUTTONS.VOLUME_DOWN];
+      if (platformVersion >= XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION) {
+        buttons.push(XCUITEST_IOS_BUTTONS.ACTION, XCUITEST_IOS_BUTTONS.CAMERA);
+      }
+      return buttons;
+    },
+  },
 
-const getTvOSButtons = (platformVersion) => {
-  const tvOSButtons = [
-    BTNS.HOME,
-    BTNS.UP,
-    BTNS.DOWN,
-    BTNS.LEFT,
-    BTNS.RIGHT,
-    BTNS.MENU,
-    BTNS.PLAY_PAUSE,
-    BTNS.SELECT,
-    BTNS.PAGE_UP,
-    BTNS.PAGE_DOWN,
-    BTNS.GUIDE,
-  ];
-  if (platformVersion >= XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION) {
-    tvOSButtons.push(BTNS.FOUR_COLORS, BTNS.ONE_TWO_THREE, BTNS.TV_PROVIDER);
-  }
-  return tvOSButtons;
-};
+  [PLATFORMS.TVOS]: {
+    icon: <IconDeviceRemote size={18} />,
+    buttons: (platformVersion) => {
+      const buttons = [
+        XCUITEST_TVOS_BUTTONS.HOME,
+        XCUITEST_TVOS_BUTTONS.UP,
+        XCUITEST_TVOS_BUTTONS.DOWN,
+        XCUITEST_TVOS_BUTTONS.LEFT,
+        XCUITEST_TVOS_BUTTONS.RIGHT,
+        XCUITEST_TVOS_BUTTONS.MENU,
+        XCUITEST_TVOS_BUTTONS.PLAY_PAUSE,
+        XCUITEST_TVOS_BUTTONS.SELECT,
+        XCUITEST_TVOS_BUTTONS.PAGE_UP,
+        XCUITEST_TVOS_BUTTONS.PAGE_DOWN,
+        XCUITEST_TVOS_BUTTONS.GUIDE,
+      ];
+      if (platformVersion >= XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION) {
+        buttons.push(
+          XCUITEST_TVOS_BUTTONS.FOUR_COLORS,
+          XCUITEST_TVOS_BUTTONS.ONE_TWO_THREE,
+          XCUITEST_TVOS_BUTTONS.TV_PROVIDER,
+        );
+      }
+      return buttons;
+    },
+  },
 
-const getWatchOSButtons = () => [BTNS.HOME, BTNS.ACTION];
-
-const getBtnDropdownItems = (platformName, platformVersion) => {
-  let platformButtons = [];
-  switch (platformName) {
-    case PLATFORMS.IOS:
-      platformButtons = getIOSButtons(platformVersion);
-      break;
-    case PLATFORMS.TVOS:
-      platformButtons = getTvOSButtons(platformVersion);
-      break;
-    case PLATFORMS.WATCHOS:
-      platformButtons = getWatchOSButtons();
-  }
-  return platformButtons.map(toDropdownItem);
-};
-
-const getGestureDropdownItems = (platformVersion) => {
-  const supportedGestures = [WATCHOS_GESTURES.DOUBLE_TAP];
-  if (platformVersion >= XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION) {
-    supportedGestures.push(WATCHOS_GESTURES.FLICK);
-  }
-  return supportedGestures.map(toDropdownItem);
-};
-
-const PressButtonIcon = ({platformName}) => {
-  switch (platformName) {
-    case PLATFORMS.IOS:
-      return <IconDeviceMobile size={18} />;
-    case PLATFORMS.TVOS:
-      return <IconDeviceRemote size={18} />;
-    case PLATFORMS.WATCHOS:
-      return <IconDeviceWatch size={18} />;
-  }
+  [PLATFORMS.WATCHOS]: {
+    icon: <IconDeviceWatch size={18} />,
+    buttons: () => Object.values(XCUITEST_WATCHOS_BUTTONS),
+    gestures: (platformVersion) => {
+      const gestures = [WATCHOS_GESTURES.DOUBLE_TAP];
+      if (platformVersion >= XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION) {
+        gestures.push(WATCHOS_GESTURES.FLICK);
+      }
+      return gestures;
+    },
+  },
 };
 
 /**
@@ -110,6 +101,7 @@ const IDeviceControls = ({
 
   const platformName = featureCaps.platformName;
   const platformVersion = featureCaps.platformVersion;
+  const platformConfig = PLATFORM_CONFIGS[platformName];
 
   const executeInteraction = (methodName, itemName) => {
     applyClientMethod({
@@ -126,11 +118,14 @@ const IDeviceControls = ({
       <Space.Compact>
         <Tooltip title={pressButtonLabel} placement="left">
           <Dropdown
-            menu={{items: getBtnDropdownItems(platformName, platformVersion), onClick: onBtnDropdownItemClick}}
+            menu={{
+              items: platformConfig.buttons(platformVersion).map(toDropdownItem),
+              onClick: onBtnDropdownItemClick,
+            }}
             trigger={['click']}
           >
             <Button aria-label={pressButtonLabel} style={{padding: 4, columnGap: 0}}>
-              <PressButtonIcon platformName={platformName} />
+              {platformConfig.icon}
               <IconChevronDown size={14} />
             </Button>
           </Dropdown>
@@ -138,7 +133,10 @@ const IDeviceControls = ({
         {platformName === PLATFORMS.WATCHOS && (
           <Tooltip title={performGestureLabel} placement="left">
             <Dropdown
-              menu={{items: getGestureDropdownItems(platformVersion), onClick: onGestureDropdownItemClick}}
+              menu={{
+                items: platformConfig.gestures(platformVersion).map(toDropdownItem),
+                onClick: onGestureDropdownItemClick,
+              }}
               trigger={['click']}
             >
               <Button aria-label={performGestureLabel} style={{padding: 4, columnGap: 0}}>

--- a/app/common/renderer/constants/driver-specific.js
+++ b/app/common/renderer/constants/driver-specific.js
@@ -1,0 +1,59 @@
+// Constants for driver-specific values
+
+/**
+ * All supported values for the XCUITest driver's 'mobile: pressButton' extension.
+ * The Inspector only applies constraints for the device category and OS version:
+ * limitations for Xcode, device model and simulator/real device currently cannot be implemented
+ * @see https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-pressbutton
+ */
+export const XCUITEST_BUTTONS = {
+  // All devices
+  HOME: 'home',
+  // iOS 16+ and watchOS 9+ supported devices only
+  ACTION: 'action',
+  // iOS real devices only
+  VOLUME_UP: 'volumeup',
+  VOLUME_DOWN: 'volumedown',
+  // iOS 16+ supported real devices only
+  CAMERA: 'camera',
+  // tvOS only
+  UP: 'up',
+  DOWN: 'down',
+  LEFT: 'left',
+  RIGHT: 'right',
+  MENU: 'menu',
+  PLAY_PAUSE: 'playpause',
+  SELECT: 'select',
+  PAGE_UP: 'pageup',
+  PAGE_DOWN: 'pagedown',
+  GUIDE: 'guide',
+  // tvOS 18.1+ only
+  FOUR_COLORS: 'fourcolors',
+  ONE_TWO_THREE: 'onetwothree',
+  TV_PROVIDER: 'tvprovider',
+};
+
+/**
+ * All supported values for the XCUITest driver's 'mobile: performHandGesture' extension.
+ * @see https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-performhandgesture
+ */
+export const XCUITEST_WATCHOS_GESTURES = {
+  DOUBLE_TAP: 'doubleTap',
+  // watchOS 26+ only
+  FLICK: 'flick',
+};
+
+/**
+ * Minimum iOS version that supports the action and camera buttons
+ */
+export const XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION = 16;
+
+/**
+ * Minimum tvOS version that supports the fourcolors, onetwothree and tvprovider buttons
+ */
+export const XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION = 18.1;
+
+/**
+ * Minimum watchOS version that supports the flick gesture
+ */
+export const XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION = 26;

--- a/app/common/renderer/constants/driver-specific.js
+++ b/app/common/renderer/constants/driver-specific.js
@@ -1,22 +1,27 @@
 // Constants for driver-specific values
 
 /**
- * All supported values for the XCUITest driver's 'mobile: pressButton' extension.
+ * Supported values for the XCUITest driver's 'mobile: pressButton' extension on iOS.
  * The Inspector only applies constraints for the device category and OS version:
  * limitations for Xcode, device model and simulator/real device currently cannot be implemented
  * @see https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-pressbutton
  */
-export const XCUITEST_BUTTONS = {
-  // All devices
+export const XCUITEST_IOS_BUTTONS = {
   HOME: 'home',
-  // iOS 16+ and watchOS 9+ supported devices only
-  ACTION: 'action',
-  // iOS real devices only
+  // Real devices only
   VOLUME_UP: 'volumeup',
   VOLUME_DOWN: 'volumedown',
+  // iOS 16+ supported devices only
+  ACTION: 'action',
   // iOS 16+ supported real devices only
   CAMERA: 'camera',
-  // tvOS only
+};
+
+/**
+ * Supported values for the XCUITest driver's 'mobile: pressButton' extension on tvOS.
+ */
+export const XCUITEST_TVOS_BUTTONS = {
+  HOME: 'home',
   UP: 'up',
   DOWN: 'down',
   LEFT: 'left',
@@ -34,7 +39,16 @@ export const XCUITEST_BUTTONS = {
 };
 
 /**
- * All supported values for the XCUITest driver's 'mobile: performHandGesture' extension.
+ * Supported values for the XCUITest driver's 'mobile: pressButton' extension on watchOS.
+ */
+export const XCUITEST_WATCHOS_BUTTONS = {
+  HOME: 'home',
+  // Supported devices only
+  ACTION: 'action',
+};
+
+/**
+ * Supported values for the XCUITest driver's 'mobile: performHandGesture' extension.
  * @see https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-performhandgesture
  */
 export const XCUITEST_WATCHOS_GESTURES = {

--- a/docs/session-inspector/header.md
+++ b/docs/session-inspector/header.md
@@ -16,12 +16,15 @@ generally correspond to a hardware button on an Android, iOS, iPadOS, tvOS or wa
 ![Android Buttons](./assets/images/header/system-buttons-android.png) ![XCUITest Buttons](./assets/images/header/system-buttons-xcuitest.png)
 
 - Android: back / home / app switcher
-- iOS/iPadOS/tvOS/watchOS: buttons dropdown / Siri
-    - The buttons listed in the dropdown correspond to the names supported by the XCUITest driver's
+- iOS/iPadOS/tvOS: buttons dropdown / Siri
+    - The buttons listed in the dropdown correspond to values supported by the XCUITest driver's
       [`mobile: pressButton`](https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-pressbutton)
       execute method. The Inspector filters these only by the device category and OS version.
     - The Siri button will open a prompt for input text, which will be used as the Siri command.
       Please note that the command will not work if Siri is disabled.
+- watchOS: buttons dropdown / gestures dropdown / Siri
+    - Gestures listed in the dropdown correspond to values supported by the XCUITest driver's
+      [`mobile: performHandGesture`](https://appium.github.io/appium-xcuitest-driver/latest/reference/execute-methods/#mobile-performhandgesture) execute method
 
 ## Driver-Specific Controls
 


### PR DESCRIPTION
With a similar implementation to #3141, this PR adds a second dropdown exclusive to watchOS sessions, with a list of available gestures.
I've also extracted various constants to a new separate file.

Quick demo:

https://github.com/user-attachments/assets/67b7ebe8-e9bd-438f-a677-32a34e9dbc45