### PR TITLE
chore: split iDevice controls file into multiple files

### DIFF
--- a/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDeviceControls.jsx
@@ -1,26 +1,12 @@
-import {
-  IconChevronDown,
-  IconDeviceMobile,
-  IconDeviceRemote,
-  IconDeviceWatch,
-  IconHandStop,
-  IconMessageChatbot,
-} from '@tabler/icons-react';
-import {Button, Dropdown, Space, Tooltip} from 'antd';
+import {IconMessageChatbot} from '@tabler/icons-react';
+import {Button, Space, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
 import {COMMAND_EXECUTE_SCRIPT} from '../../../../constants/commands.js';
 import {PLATFORMS} from '../../../../constants/common.js';
-import {
-  XCUITEST_IOS_BUTTONS,
-  XCUITEST_TVOS_BUTTONS,
-  XCUITEST_WATCHOS_BUTTONS,
-  XCUITEST_WATCHOS_GESTURES as WATCHOS_GESTURES,
-  XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION,
-  XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION,
-  XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION,
-} from '../../../../constants/driver-specific.js';
+import IDevicePressButtonControls from './IDevicePressButtonControls.jsx';
 import SiriCommandModal from './SiriCommandModal.jsx';
+import WatchOSGestureControls from './WatchOSGestureControls.jsx';
 
 import inspectorStyles from '../../SessionInspector.module.css';
 
@@ -28,59 +14,6 @@ const toDropdownItem = (item) => ({
   key: item,
   label: <span className={inspectorStyles.monoFont}>{item}</span>,
 });
-
-// Per-platform behavior lives here, so callers never need to branch on platformName themselves.
-const PLATFORM_CONFIGS = {
-  [PLATFORMS.IOS]: {
-    icon: <IconDeviceMobile size={18} />,
-    buttons: (platformVersion) => {
-      const buttons = [XCUITEST_IOS_BUTTONS.HOME, XCUITEST_IOS_BUTTONS.VOLUME_UP, XCUITEST_IOS_BUTTONS.VOLUME_DOWN];
-      if (platformVersion >= XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION) {
-        buttons.push(XCUITEST_IOS_BUTTONS.ACTION, XCUITEST_IOS_BUTTONS.CAMERA);
-      }
-      return buttons;
-    },
-  },
-
-  [PLATFORMS.TVOS]: {
-    icon: <IconDeviceRemote size={18} />,
-    buttons: (platformVersion) => {
-      const buttons = [
-        XCUITEST_TVOS_BUTTONS.HOME,
-        XCUITEST_TVOS_BUTTONS.UP,
-        XCUITEST_TVOS_BUTTONS.DOWN,
-        XCUITEST_TVOS_BUTTONS.LEFT,
-        XCUITEST_TVOS_BUTTONS.RIGHT,
-        XCUITEST_TVOS_BUTTONS.MENU,
-        XCUITEST_TVOS_BUTTONS.PLAY_PAUSE,
-        XCUITEST_TVOS_BUTTONS.SELECT,
-        XCUITEST_TVOS_BUTTONS.PAGE_UP,
-        XCUITEST_TVOS_BUTTONS.PAGE_DOWN,
-        XCUITEST_TVOS_BUTTONS.GUIDE,
-      ];
-      if (platformVersion >= XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION) {
-        buttons.push(
-          XCUITEST_TVOS_BUTTONS.FOUR_COLORS,
-          XCUITEST_TVOS_BUTTONS.ONE_TWO_THREE,
-          XCUITEST_TVOS_BUTTONS.TV_PROVIDER,
-        );
-      }
-      return buttons;
-    },
-  },
-
-  [PLATFORMS.WATCHOS]: {
-    icon: <IconDeviceWatch size={18} />,
-    buttons: () => Object.values(XCUITEST_WATCHOS_BUTTONS),
-    gestures: (platformVersion) => {
-      const gestures = [WATCHOS_GESTURES.DOUBLE_TAP];
-      if (platformVersion >= XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION) {
-        gestures.push(WATCHOS_GESTURES.FLICK);
-      }
-      return gestures;
-    },
-  },
-};
 
 /**
  * Device controls used for iOS/iPadOS/tvOS/watchOS sessions.
@@ -95,56 +28,29 @@ const IDeviceControls = ({
   hideSiriCommandModal,
 }) => {
   const {t} = useTranslation();
-  const pressButtonLabel = t('pressDeviceButton');
-  const performGestureLabel = t('performHandGesture');
   const siriLabel = t('Execute Siri Command');
 
-  const platformName = featureCaps.platformName;
-  const platformVersion = featureCaps.platformVersion;
-  const platformConfig = PLATFORM_CONFIGS[platformName];
-
-  const executeInteraction = (methodName, itemName) => {
+  const executeInteraction = (methodName, params) => {
     applyClientMethod({
       methodName: COMMAND_EXECUTE_SCRIPT,
-      args: [methodName, [{name: itemName}]],
+      args: [methodName, [params]],
     });
   };
-
-  const onBtnDropdownItemClick = ({key}) => executeInteraction('mobile:pressButton', key);
-  const onGestureDropdownItemClick = ({key}) => executeInteraction('mobile:performHandGesture', key);
 
   return (
     <>
       <Space.Compact>
-        <Tooltip title={pressButtonLabel} placement="left">
-          <Dropdown
-            menu={{
-              items: platformConfig.buttons(platformVersion).map(toDropdownItem),
-              onClick: onBtnDropdownItemClick,
-            }}
-            trigger={['click']}
-          >
-            <Button aria-label={pressButtonLabel} style={{padding: 4, columnGap: 0}}>
-              {platformConfig.icon}
-              <IconChevronDown size={14} />
-            </Button>
-          </Dropdown>
-        </Tooltip>
-        {platformName === PLATFORMS.WATCHOS && (
-          <Tooltip title={performGestureLabel} placement="left">
-            <Dropdown
-              menu={{
-                items: platformConfig.gestures(platformVersion).map(toDropdownItem),
-                onClick: onGestureDropdownItemClick,
-              }}
-              trigger={['click']}
-            >
-              <Button aria-label={performGestureLabel} style={{padding: 4, columnGap: 0}}>
-                <IconHandStop size={18} />
-                <IconChevronDown size={14} />
-              </Button>
-            </Dropdown>
-          </Tooltip>
+        <IDevicePressButtonControls
+          featureCaps={featureCaps}
+          toDropdownItem={toDropdownItem}
+          executeInteraction={executeInteraction}
+        />
+        {featureCaps.platformName === PLATFORMS.WATCHOS && (
+          <WatchOSGestureControls
+            featureCaps={featureCaps}
+            toDropdownItem={toDropdownItem}
+            executeInteraction={executeInteraction}
+          />
         )}
         <Tooltip title={siriLabel}>
           <Button

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDevicePressButtonControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControls/IDevicePressButtonControls.jsx
@@ -1,0 +1,91 @@
+import {IconChevronDown, IconDeviceMobile, IconDeviceRemote, IconDeviceWatch} from '@tabler/icons-react';
+import {Button, Dropdown, Tooltip} from 'antd';
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+import {PLATFORMS} from '../../../../constants/common.js';
+import {
+  XCUITEST_IOS_BUTTONS,
+  XCUITEST_TVOS_BUTTONS,
+  XCUITEST_WATCHOS_BUTTONS,
+  XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION,
+  XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION,
+} from '../../../../constants/driver-specific.js';
+
+const PLATFORM_CONFIGS = {
+  [PLATFORMS.IOS]: {
+    icon: <IconDeviceMobile size={18} />,
+    buttons: (platformVersion) => {
+      const buttons = [XCUITEST_IOS_BUTTONS.HOME, XCUITEST_IOS_BUTTONS.VOLUME_UP, XCUITEST_IOS_BUTTONS.VOLUME_DOWN];
+      if (platformVersion >= XCUITEST_IOS_MIN_EXTRA_BUTTONS_VERSION) {
+        buttons.push(XCUITEST_IOS_BUTTONS.ACTION, XCUITEST_IOS_BUTTONS.CAMERA);
+      }
+      return buttons;
+    },
+  },
+
+  [PLATFORMS.TVOS]: {
+    icon: <IconDeviceRemote size={18} />,
+    buttons: (platformVersion) => {
+      const buttons = [
+        XCUITEST_TVOS_BUTTONS.HOME,
+        XCUITEST_TVOS_BUTTONS.UP,
+        XCUITEST_TVOS_BUTTONS.DOWN,
+        XCUITEST_TVOS_BUTTONS.LEFT,
+        XCUITEST_TVOS_BUTTONS.RIGHT,
+        XCUITEST_TVOS_BUTTONS.MENU,
+        XCUITEST_TVOS_BUTTONS.PLAY_PAUSE,
+        XCUITEST_TVOS_BUTTONS.SELECT,
+        XCUITEST_TVOS_BUTTONS.PAGE_UP,
+        XCUITEST_TVOS_BUTTONS.PAGE_DOWN,
+        XCUITEST_TVOS_BUTTONS.GUIDE,
+      ];
+      if (platformVersion >= XCUITEST_TVOS_MIN_EXTRA_BUTTONS_VERSION) {
+        buttons.push(
+          XCUITEST_TVOS_BUTTONS.FOUR_COLORS,
+          XCUITEST_TVOS_BUTTONS.ONE_TWO_THREE,
+          XCUITEST_TVOS_BUTTONS.TV_PROVIDER,
+        );
+      }
+      return buttons;
+    },
+  },
+
+  [PLATFORMS.WATCHOS]: {
+    icon: <IconDeviceWatch size={18} />,
+    buttons: () => Object.values(XCUITEST_WATCHOS_BUTTONS),
+  },
+};
+
+/**
+ * Button + dropdown to execute 'mobile: pressButton' in iOS/iPadOS/tvOS/watchOS sessions.
+ */
+const IDevicePressButtonControls = ({featureCaps, toDropdownItem, executeInteraction}) => {
+  const {t} = useTranslation();
+  const pressButtonLabel = t('pressDeviceButton');
+
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  const platformConfig = PLATFORM_CONFIGS[featureCaps.platformName];
+
+  return (
+    <Tooltip title={pressButtonLabel} open={showTooltip} onOpenChange={setShowTooltip}>
+      <Dropdown
+        menu={{
+          items: platformConfig.buttons(featureCaps.platformVersion).map(toDropdownItem),
+          onClick: ({key}) => executeInteraction('mobile:pressButton', {name: key}),
+        }}
+        placement="bottom"
+        trigger="click"
+        onOpenChange={() => setShowTooltip(false)}
+      >
+        <Button aria-label={pressButtonLabel} style={{padding: 4, columnGap: 0}}>
+          {platformConfig.icon}
+          <IconChevronDown size={14} />
+        </Button>
+      </Dropdown>
+    </Tooltip>
+  );
+};
+
+export default IDevicePressButtonControls;

--- a/app/common/renderer/components/SessionInspector/Header/DeviceControls/WatchOSGestureControls.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/DeviceControls/WatchOSGestureControls.jsx
@@ -1,0 +1,48 @@
+import {IconChevronDown, IconHandStop} from '@tabler/icons-react';
+import {Button, Dropdown, Tooltip} from 'antd';
+import {useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+import {
+  XCUITEST_WATCHOS_GESTURES,
+  XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION,
+} from '../../../../constants/driver-specific.js';
+
+const getSupportedGestures = (platformVersion) => {
+  const gestures = [XCUITEST_WATCHOS_GESTURES.DOUBLE_TAP];
+  if (platformVersion >= XCUITEST_WATCHOS_MIN_EXTRA_GESTURES_VERSION) {
+    gestures.push(XCUITEST_WATCHOS_GESTURES.FLICK);
+  }
+  return gestures;
+};
+
+/**
+ * Button + dropdown to execute 'mobile: performHandGesture' in watchOS sessions.
+ */
+const WatchOSGestureControls = ({featureCaps, toDropdownItem, executeInteraction}) => {
+  const {t} = useTranslation();
+  const performGestureLabel = t('performHandGesture');
+
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <Tooltip title={performGestureLabel} open={showTooltip} onOpenChange={setShowTooltip}>
+      <Dropdown
+        menu={{
+          items: getSupportedGestures(featureCaps.platformVersion).map(toDropdownItem),
+          onClick: ({key}) => executeInteraction('mobile:performHandGesture', {name: key}),
+        }}
+        placement="bottom"
+        trigger="click"
+        onOpenChange={() => setShowTooltip(false)}
+      >
+        <Button aria-label={performGestureLabel} style={{padding: 4, columnGap: 0}}>
+          <IconHandStop size={18} />
+          <IconChevronDown size={14} />
+        </Button>
+      </Dropdown>
+    </Tooltip>
+  );
+};
+
+export default WatchOSGestureControls;


### PR DESCRIPTION
The `IDeviceControls` file was getting a bit large, so this PR separates the pressButton/performHandGesture functionalities into their own files.

I have also adjusted the popup behavior for both. It now appears on the bottom for consistency with the Siri button, but is hidden upon clicking the button and opening the dropdown.