### PR TITLE
feat: reorder actions in the gesture builder

### DIFF
--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -222,8 +222,6 @@
   "showMoveActionCoordsInPercentage": "Show Coordinates of Move Actions in Screen Dimension Percentages",
   "showMoveActionCoordsInPixels": "Show Coordinates of Move Actions in Pixels",
   "toggleMoveActionCoordPicker": "Toggle Setting Coordinates via Clicking on Screenshot",
-  "moveGestureActionEarlier": "Move Action Earlier",
-  "moveGestureActionLater": "Move Action Later",
   "dragGestureAction": "Drag Action {{id}} to Reorder",
   "Action Type": "Action Type",
   "Pointer Up": "Pointer Up",

--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -222,6 +222,8 @@
   "showMoveActionCoordsInPercentage": "Show Coordinates of Move Actions in Screen Dimension Percentages",
   "showMoveActionCoordsInPixels": "Show Coordinates of Move Actions in Pixels",
   "toggleMoveActionCoordPicker": "Toggle Setting Coordinates via Clicking on Screenshot",
+  "moveGestureActionEarlier": "Move Action Earlier",
+  "moveGestureActionLater": "Move Action Later",
   "Action Type": "Action Type",
   "Pointer Up": "Pointer Up",
   "Pointer Down": "Pointer Down",

--- a/app/common/public/locales/en/translation.json
+++ b/app/common/public/locales/en/translation.json
@@ -224,6 +224,7 @@
   "toggleMoveActionCoordPicker": "Toggle Setting Coordinates via Clicking on Screenshot",
   "moveGestureActionEarlier": "Move Action Earlier",
   "moveGestureActionLater": "Move Action Later",
+  "dragGestureAction": "Drag Action {{id}} to Reorder",
   "Action Type": "Action Type",
   "Pointer Up": "Pointer Up",
   "Pointer Down": "Pointer Down",

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditor.module.css
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditor.module.css
@@ -75,6 +75,19 @@
   flex-shrink: 0;
 }
 
+.tickCard[data-drop-target] {
+  outline: 2px solid var(--ant-color-primary);
+}
+
+.tickDragHandle:not(:disabled) {
+  cursor: grab;
+  touch-action: none;
+}
+
+.tickDragHandle:not(:disabled):active {
+  cursor: grabbing;
+}
+
 .tickPlusBtnWrapper {
   height: 100%;
   display: flex;

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditor.module.css
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditor.module.css
@@ -54,6 +54,11 @@
   text-align: center;
 }
 
+.tickCard {
+  display: flex;
+  flex-direction: column;
+}
+
 .tickCard :global(.ant-card-head) {
   min-height: unset;
   padding: 0px;
@@ -62,7 +67,12 @@
 
 .tickCard :global(.ant-card-body) {
   padding-top: 6px;
-  height: calc(100% - 25px);
+  height: auto;
+  flex: 1;
+}
+
+.tickCard :global(.ant-card-actions) {
+  flex-shrink: 0;
 }
 
 .tickPlusBtnWrapper {

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabContents.jsx
@@ -1,7 +1,12 @@
+import {Feedback} from '@dnd-kit/dom';
+import {SortableKeyboardPlugin} from '@dnd-kit/dom/sortable';
+import {DragDropProvider} from '@dnd-kit/react';
+import {isSortable, useSortable} from '@dnd-kit/react/sortable';
 import {IconPlus} from '@tabler/icons-react';
 import {Button, Col, Row, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
+import {moveGestureTick} from '../../../../utils/gesture-editing.js';
 import GestureEditorTickCard from './GestureEditorTickCard.jsx';
 import GestureEditorTickCardContents from './GestureEditorTickCardContents.jsx';
 
@@ -40,30 +45,49 @@ const AddNewTickButton = ({id, pointers, setPointers}) => {
  */
 const GestureEditorTick = ({
   tick,
+  index,
+  pointer,
   pointers,
   setPointers,
   selectedTick,
   selectTick,
   unselectTick,
   getDefaultMoveDuration,
-}) => (
-  <GestureEditorTickCard
-    tick={tick}
-    pointers={pointers}
-    setPointers={setPointers}
-    selectedTick={selectedTick}
-    selectTick={selectTick}
-    unselectTick={unselectTick}
-  >
-    <GestureEditorTickCardContents
-      tick={tick}
-      selectTick={selectTick}
-      getDefaultMoveDuration={getDefaultMoveDuration}
-      pointers={pointers}
-      setPointers={setPointers}
-    />
-  </GestureEditorTickCard>
-);
+}) => {
+  const {ref, handleRef, isDropTarget} = useSortable({
+    id: tick.id,
+    index,
+    group: pointer.id,
+    disabled: pointer.ticks.length < 2,
+    // Tick IDs describe positions, not stable identities. Commit the new order on drop
+    // instead of optimistically reordering DOM nodes behind React's positional keys.
+    plugins: [SortableKeyboardPlugin, Feedback.configure({dropAnimation: null})],
+  });
+
+  return (
+    <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3} ref={ref}>
+      <GestureEditorTickCard
+        tick={tick}
+        dragHandleRef={handleRef}
+        dragDisabled={pointer.ticks.length < 2}
+        isDropTarget={isDropTarget}
+        pointers={pointers}
+        setPointers={setPointers}
+        selectedTick={selectedTick}
+        selectTick={selectTick}
+        unselectTick={unselectTick}
+      >
+        <GestureEditorTickCardContents
+          tick={tick}
+          selectTick={selectTick}
+          getDefaultMoveDuration={getDefaultMoveDuration}
+          pointers={pointers}
+          setPointers={setPointers}
+        />
+      </GestureEditorTickCard>
+    </Col>
+  );
+};
 
 /**
  * Contents of a pointer tab in the gesture editor.
@@ -76,25 +100,51 @@ const GestureEditorPointerTabContents = ({
   selectTick,
   unselectTick,
   getDefaultMoveDuration,
-}) => (
-  <Row gutter={[24, 24]}>
-    {pointer.ticks.map((tick) => (
-      <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3} key={tick.id}>
-        <GestureEditorTick
-          tick={tick}
-          pointers={pointers}
-          setPointers={setPointers}
-          selectedTick={selectedTick}
-          selectTick={selectTick}
-          unselectTick={unselectTick}
-          getDefaultMoveDuration={getDefaultMoveDuration}
-        />
-      </Col>
-    ))}
-    <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3}>
-      <AddNewTickButton id={pointer.id} pointers={pointers} setPointers={setPointers} />
-    </Col>
-  </Row>
-);
+}) => {
+  const handleDragEnd = (event) => {
+    const {source, target, activatorEvent} = event.operation;
+    if (!isSortable(source)) {
+      return;
+    }
+    const updatedPointers =
+      !event.canceled && isSortable(target)
+        ? moveGestureTick(pointers, pointer.id, source.id, target.index - source.index)
+        : pointers;
+    if (updatedPointers !== pointers) {
+      unselectTick();
+      setPointers(updatedPointers);
+    }
+    if (activatorEvent instanceof KeyboardEvent) {
+      // The default drop animation restores the old positional ID. Keep keyboard
+      // focus on the moved action instead, or on the source if the drag was canceled.
+      const handle = updatedPointers !== pointers ? target.sortable.draggable.handle : source.handle;
+      requestAnimationFrame(() => handle?.focus());
+    }
+  };
+
+  return (
+    <DragDropProvider onDragEnd={handleDragEnd}>
+      <Row gutter={[24, 24]}>
+        {pointer.ticks.map((tick, index) => (
+          <GestureEditorTick
+            key={tick.id}
+            tick={tick}
+            index={index}
+            pointer={pointer}
+            pointers={pointers}
+            setPointers={setPointers}
+            selectedTick={selectedTick}
+            selectTick={selectTick}
+            unselectTick={unselectTick}
+            getDefaultMoveDuration={getDefaultMoveDuration}
+          />
+        ))}
+        <Col xs={12} sm={12} md={12} lg={8} xl={6} xxl={4} xxxl={3}>
+          <AddNewTickButton id={pointer.id} pointers={pointers} setPointers={setPointers} />
+        </Col>
+      </Row>
+    </DragDropProvider>
+  );
+};
 
 export default GestureEditorPointerTabContents;

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabs.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorPointerTabs.jsx
@@ -133,6 +133,7 @@ const GestureEditorPointerTabs = ({
       onEdit={addOrRemovePointer}
       hideAdd={pointers.length === 5}
       centered={true}
+      destroyOnHidden={true}
       tabBarGutter={10}
       items={pointerTabs}
     />

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
@@ -1,4 +1,4 @@
-import {IconArrowLeft, IconArrowRight, IconFocus2, IconX} from '@tabler/icons-react';
+import {IconArrowLeft, IconArrowRight, IconFocus2, IconGripVertical, IconX} from '@tabler/icons-react';
 import {Button, Card, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
@@ -90,33 +90,63 @@ const GestureEditorTickMoveButton = ({tick, pointers, setPointers, unselectTick,
 /**
  * Wrapper card for a single tick in the gesture editor.
  */
-const GestureEditorTickCard = ({children, tick, pointers, setPointers, selectedTick, selectTick, unselectTick}) => (
-  <Card
-    hoverable={true}
-    className={styles.tickCard}
-    actions={[-1, 1].map((direction) => (
-      <GestureEditorTickMoveButton
-        key={direction}
-        tick={tick}
-        pointers={pointers}
-        setPointers={setPointers}
-        unselectTick={unselectTick}
-        direction={direction}
-      />
-    ))}
-    extra={
-      <GestureEditorTickCardHeaderButtons
-        tick={tick}
-        pointers={pointers}
-        setPointers={setPointers}
-        selectedTick={selectedTick}
-        selectTick={selectTick}
-        unselectTick={unselectTick}
-      />
-    }
-  >
-    {children}
-  </Card>
-);
+const GestureEditorTickCard = ({
+  children,
+  tick,
+  dragHandleRef,
+  dragDisabled,
+  isDropTarget,
+  pointers,
+  setPointers,
+  selectedTick,
+  selectTick,
+  unselectTick,
+}) => {
+  const {t} = useTranslation();
+  const dragLabel = t('dragGestureAction', {id: tick.id});
+
+  return (
+    <Card
+      hoverable={true}
+      className={styles.tickCard}
+      data-drop-target={isDropTarget || undefined}
+      title={
+        <Tooltip title={dragLabel}>
+          <Button
+            ref={dragHandleRef}
+            aria-label={dragLabel}
+            className={styles.tickDragHandle}
+            size="small"
+            type="text"
+            disabled={dragDisabled}
+            icon={<IconGripVertical size={18} />}
+          />
+        </Tooltip>
+      }
+      actions={[-1, 1].map((direction) => (
+        <GestureEditorTickMoveButton
+          key={direction}
+          tick={tick}
+          pointers={pointers}
+          setPointers={setPointers}
+          unselectTick={unselectTick}
+          direction={direction}
+        />
+      ))}
+      extra={
+        <GestureEditorTickCardHeaderButtons
+          tick={tick}
+          pointers={pointers}
+          setPointers={setPointers}
+          selectedTick={selectedTick}
+          selectTick={selectTick}
+          unselectTick={unselectTick}
+        />
+      }
+    >
+      {children}
+    </Card>
+  );
+};
 
 export default GestureEditorTickCard;

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
@@ -1,8 +1,9 @@
-import {IconFocus2, IconX} from '@tabler/icons-react';
+import {IconArrowLeft, IconArrowRight, IconFocus2, IconX} from '@tabler/icons-react';
 import {Button, Card, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
 import {POINTER_TYPES} from '../../../../constants/gestures.js';
+import {moveGestureTick} from '../../../../utils/gesture-editing.js';
 
 import styles from './GestureEditor.module.css';
 
@@ -56,6 +57,36 @@ const GestureEditorTickCardHeaderButtons = ({tick, pointers, setPointers, select
   );
 };
 
+const GestureEditorTickMoveButton = ({tick, pointers, setPointers, unselectTick, direction}) => {
+  const {t} = useTranslation();
+  const pointer = pointers.find(({ticks}) => ticks.includes(tick));
+  const index = pointer?.ticks.indexOf(tick) ?? -1;
+  const targetIndex = index + direction;
+  const label = t(direction < 0 ? 'moveGestureActionEarlier' : 'moveGestureActionLater');
+
+  const moveTick = () => {
+    const updatedPointers = moveGestureTick(pointers, pointer.id, tick.id, direction);
+    if (updatedPointers !== pointers) {
+      // The coordinate picker uses position-based IDs, so clear it before renumbering.
+      unselectTick();
+      setPointers(updatedPointers);
+    }
+  };
+
+  return (
+    <Tooltip title={label}>
+      <Button
+        aria-label={label}
+        size="small"
+        type="text"
+        icon={direction < 0 ? <IconArrowLeft size={18} /> : <IconArrowRight size={18} />}
+        disabled={index < 0 || targetIndex < 0 || targetIndex >= pointer.ticks.length}
+        onClick={moveTick}
+      />
+    </Tooltip>
+  );
+};
+
 /**
  * Wrapper card for a single tick in the gesture editor.
  */
@@ -63,6 +94,16 @@ const GestureEditorTickCard = ({children, tick, pointers, setPointers, selectedT
   <Card
     hoverable={true}
     className={styles.tickCard}
+    actions={[-1, 1].map((direction) => (
+      <GestureEditorTickMoveButton
+        key={direction}
+        tick={tick}
+        pointers={pointers}
+        setPointers={setPointers}
+        unselectTick={unselectTick}
+        direction={direction}
+      />
+    ))}
     extra={
       <GestureEditorTickCardHeaderButtons
         tick={tick}

--- a/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
+++ b/app/common/renderer/components/SessionInspector/GesturesTab/GestureEditor/GestureEditorTickCard.jsx
@@ -1,9 +1,8 @@
-import {IconArrowLeft, IconArrowRight, IconFocus2, IconGripVertical, IconX} from '@tabler/icons-react';
+import {IconFocus2, IconGripVertical, IconX} from '@tabler/icons-react';
 import {Button, Card, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
 import {POINTER_TYPES} from '../../../../constants/gestures.js';
-import {moveGestureTick} from '../../../../utils/gesture-editing.js';
 
 import styles from './GestureEditor.module.css';
 
@@ -57,36 +56,6 @@ const GestureEditorTickCardHeaderButtons = ({tick, pointers, setPointers, select
   );
 };
 
-const GestureEditorTickMoveButton = ({tick, pointers, setPointers, unselectTick, direction}) => {
-  const {t} = useTranslation();
-  const pointer = pointers.find(({ticks}) => ticks.includes(tick));
-  const index = pointer?.ticks.indexOf(tick) ?? -1;
-  const targetIndex = index + direction;
-  const label = t(direction < 0 ? 'moveGestureActionEarlier' : 'moveGestureActionLater');
-
-  const moveTick = () => {
-    const updatedPointers = moveGestureTick(pointers, pointer.id, tick.id, direction);
-    if (updatedPointers !== pointers) {
-      // The coordinate picker uses position-based IDs, so clear it before renumbering.
-      unselectTick();
-      setPointers(updatedPointers);
-    }
-  };
-
-  return (
-    <Tooltip title={label}>
-      <Button
-        aria-label={label}
-        size="small"
-        type="text"
-        icon={direction < 0 ? <IconArrowLeft size={18} /> : <IconArrowRight size={18} />}
-        disabled={index < 0 || targetIndex < 0 || targetIndex >= pointer.ticks.length}
-        onClick={moveTick}
-      />
-    </Tooltip>
-  );
-};
-
 /**
  * Wrapper card for a single tick in the gesture editor.
  */
@@ -123,16 +92,6 @@ const GestureEditorTickCard = ({
           />
         </Tooltip>
       }
-      actions={[-1, 1].map((direction) => (
-        <GestureEditorTickMoveButton
-          key={direction}
-          tick={tick}
-          pointers={pointers}
-          setPointers={setPointers}
-          unselectTick={unselectTick}
-          direction={direction}
-        />
-      ))}
       extra={
         <GestureEditorTickCardHeaderButtons
           tick={tick}

--- a/app/common/renderer/utils/gesture-editing.js
+++ b/app/common/renderer/utils/gesture-editing.js
@@ -1,9 +1,15 @@
 /** Move one action within its pointer and keep the position-based tick IDs consistent. */
-export function moveGestureTick(pointers, pointerId, tickId, direction) {
+export function moveGestureTick(pointers, pointerId, tickId, offset) {
   const pointer = pointers.find(({id}) => id === pointerId);
   const index = pointer?.ticks.findIndex(({id}) => id === tickId) ?? -1;
-  const targetIndex = index + direction;
-  if (index < 0 || ![-1, 1].includes(direction) || targetIndex < 0 || targetIndex >= pointer.ticks.length) {
+  const targetIndex = index + offset;
+  if (
+    index < 0 ||
+    !Number.isInteger(offset) ||
+    offset === 0 ||
+    targetIndex < 0 ||
+    targetIndex >= pointer.ticks.length
+  ) {
     return pointers;
   }
 

--- a/app/common/renderer/utils/gesture-editing.js
+++ b/app/common/renderer/utils/gesture-editing.js
@@ -1,0 +1,25 @@
+/** Move one action within its pointer and keep the position-based tick IDs consistent. */
+export function moveGestureTick(pointers, pointerId, tickId, direction) {
+  const pointer = pointers.find(({id}) => id === pointerId);
+  const index = pointer?.ticks.findIndex(({id}) => id === tickId) ?? -1;
+  const targetIndex = index + direction;
+  if (index < 0 || ![-1, 1].includes(direction) || targetIndex < 0 || targetIndex >= pointer.ticks.length) {
+    return pointers;
+  }
+
+  const ticks = [...pointer.ticks];
+  const [tick] = ticks.splice(index, 1);
+  ticks.splice(targetIndex, 0, tick);
+
+  return pointers.map((currentPointer) =>
+    currentPointer.id === pointerId
+      ? {
+          ...currentPointer,
+          ticks: ticks.map((currentTick, position) => ({
+            ...currentTick,
+            id: `${pointerId}.${position + 1}`,
+          })),
+        }
+      : currentPointer,
+  );
+}

--- a/docs/session-inspector/gestures.md
+++ b/docs/session-inspector/gestures.md
@@ -100,10 +100,8 @@ position within its pointer. The destination card is highlighted until the actio
 To reorder with the keyboard, focus the grip, press Space or Enter to pick it up, use the arrow
 keys to choose a destination, then press Space or Enter to drop it. Press Escape to cancel.
 
-The left and right arrow buttons at the bottom of each card also move the action one position
-earlier or later. The gesture timeline updates when an action moves, and the action keeps its
-coordinates, duration, and other parameters. The first action cannot move earlier, and the last
-cannot move later. Moving an action turns off the screenshot coordinate picker.
+The gesture timeline updates when an action moves, and the action keeps its coordinates, duration,
+and other parameters. Moving an action turns off the screenshot coordinate picker.
 
 ![Pointer Actions](./assets/images/gestures/gesture-editor-actions.png)
 

--- a/docs/session-inspector/gestures.md
+++ b/docs/session-inspector/gestures.md
@@ -95,10 +95,15 @@ The title of each pointer can also be clicked and edited.
 Pointer actions are used to define the behavior of each pointer. Each individual action is presented
 as a rectangular card, and new cards can be freely added and removed.
 
-The left and right arrow buttons at the bottom of each card move the action earlier or later within
-its pointer. The gesture timeline updates immediately, and the action keeps its coordinates,
-duration, and other parameters. The first action cannot move earlier, and the last cannot move
-later. Moving an action turns off the screenshot coordinate picker.
+Drag a card by the grip in its upper-left corner onto another card to move the action to that
+position within its pointer. The destination card is highlighted until the action is dropped.
+To reorder with the keyboard, focus the grip, press Space or Enter to pick it up, use the arrow
+keys to choose a destination, then press Space or Enter to drop it. Press Escape to cancel.
+
+The left and right arrow buttons at the bottom of each card also move the action one position
+earlier or later. The gesture timeline updates when an action moves, and the action keeps its
+coordinates, duration, and other parameters. The first action cannot move earlier, and the last
+cannot move later. Moving an action turns off the screenshot coordinate picker.
 
 ![Pointer Actions](./assets/images/gestures/gesture-editor-actions.png)
 

--- a/docs/session-inspector/gestures.md
+++ b/docs/session-inspector/gestures.md
@@ -95,6 +95,11 @@ The title of each pointer can also be clicked and edited.
 Pointer actions are used to define the behavior of each pointer. Each individual action is presented
 as a rectangular card, and new cards can be freely added and removed.
 
+The left and right arrow buttons at the bottom of each card move the action earlier or later within
+its pointer. The gesture timeline updates immediately, and the action keeps its coordinates,
+duration, and other parameters. The first action cannot move earlier, and the last cannot move
+later. Moving an action turns off the screenshot coordinate picker.
+
 ![Pointer Actions](./assets/images/gestures/gesture-editor-actions.png)
 
 The _Action Type_ dropdown is used to select any of the supported actions: move, pointer down,

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@ant-design/icons": "6.3.4",
+        "@dnd-kit/dom": "0.5.0",
+        "@dnd-kit/react": "0.5.0",
         "@reduxjs/toolkit": "2.12.0",
         "@tabler/icons-react": "3.46.0",
         "@wdio/protocols": "9.31.5",
@@ -785,6 +787,77 @@
         "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/abstract": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/abstract/-/abstract-0.5.0.tgz",
+      "integrity": "sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/collision": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/collision/-/collision-0.5.0.tgz",
+      "integrity": "sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/dom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/dom/-/dom-0.5.0.tgz",
+      "integrity": "sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/collision": "^0.5.0",
+        "@dnd-kit/geometry": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/geometry": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/geometry/-/geometry-0.5.0.tgz",
+      "integrity": "sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@dnd-kit/react": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/react/-/react-0.5.0.tgz",
+      "integrity": "sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/abstract": "^0.5.0",
+        "@dnd-kit/dom": "^0.5.0",
+        "@dnd-kit/state": "^0.5.0",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/state": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/state/-/state-0.5.0.tgz",
+      "integrity": "sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@preact/signals-core": "^1.10.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -3242,6 +3315,16 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@preact/signals-core": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.14.4.tgz",
+      "integrity": "sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/@promptbook/utils": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
   },
   "dependencies": {
     "@ant-design/icons": "6.3.4",
+    "@dnd-kit/dom": "0.5.0",
+    "@dnd-kit/react": "0.5.0",
     "@reduxjs/toolkit": "2.12.0",
     "@tabler/icons-react": "3.46.0",
     "@wdio/protocols": "9.31.5",

--- a/test/unit/utils-gesture-editing.spec.js
+++ b/test/unit/utils-gesture-editing.spec.js
@@ -1,0 +1,60 @@
+import {describe, expect, it} from 'vitest';
+
+import {moveGestureTick} from '../../app/common/renderer/utils/gesture-editing.js';
+
+const pointers = [
+  {
+    id: '1',
+    name: 'First pointer',
+    color: '#FF3333',
+    ticks: [
+      {id: '1.1', type: 'pointerMove', x: 12, y: 34, duration: 500},
+      {id: '1.2', type: 'pointerDown', button: 0},
+      {id: '1.3', type: 'pause', duration: 750},
+    ],
+  },
+  {id: '2', name: 'Second pointer', ticks: [{id: '2.1', type: 'pointerUp', button: 0}]},
+];
+
+describe('moveGestureTick', () => {
+  it('moves an action earlier, retaining its parameters and renumbering every position', () => {
+    const original = structuredClone(pointers);
+    const result = moveGestureTick(pointers, '1', '1.3', -1);
+    expect(result[0]).toEqual({
+      ...pointers[0],
+      ticks: [pointers[0].ticks[0], {...pointers[0].ticks[2], id: '1.2'}, {...pointers[0].ticks[1], id: '1.3'}],
+    });
+    expect(result[1]).toBe(pointers[1]);
+    expect(pointers).toEqual(original);
+  });
+
+  it('moves an action later and allows a subsequent move using its new ID', () => {
+    const result = moveGestureTick(pointers, '1', '1.1', 1);
+    expect(result[0].ticks).toEqual([
+      {...pointers[0].ticks[1], id: '1.1'},
+      {...pointers[0].ticks[0], id: '1.2'},
+      pointers[0].ticks[2],
+    ]);
+    expect(moveGestureTick(result, '1', '1.2', -1)).toEqual(pointers);
+  });
+
+  it.each([
+    ['1', '1.1', -1],
+    ['1', '1.3', 1],
+    ['2', '2.1', 1],
+    ['missing', '1.1', 1],
+    ['1', 'missing', 1],
+    ['1', '1.1', 0],
+    ['1', '1.1', 2],
+  ])('ignores unavailable moves for pointer %s, action %s, direction %s', (pointerId, tickId, direction) => {
+    expect(moveGestureTick(pointers, pointerId, tickId, direction)).toBe(pointers);
+  });
+
+  it('keeps an unfinished action and multi-character pointer IDs intact', () => {
+    const original = [{id: '12', ticks: [{id: '12.1'}, {id: '12.2', type: 'pause', duration: 50}]}];
+    expect(moveGestureTick(original, '12', '12.1', 1)[0].ticks).toEqual([
+      {id: '12.1', type: 'pause', duration: 50},
+      {id: '12.2'},
+    ]);
+  });
+});

--- a/test/unit/utils-gesture-editing.spec.js
+++ b/test/unit/utils-gesture-editing.spec.js
@@ -38,6 +38,19 @@ describe('moveGestureTick', () => {
     expect(moveGestureTick(result, '1', '1.2', -1)).toEqual(pointers);
   });
 
+  it('moves directly to a non-adjacent position and back without changing the other pointer', () => {
+    const original = structuredClone(pointers);
+    const result = moveGestureTick(pointers, '1', '1.1', 2);
+    expect(result[0].ticks).toEqual([
+      {...pointers[0].ticks[1], id: '1.1'},
+      {...pointers[0].ticks[2], id: '1.2'},
+      {...pointers[0].ticks[0], id: '1.3'},
+    ]);
+    expect(result[1]).toBe(pointers[1]);
+    expect(moveGestureTick(result, '1', '1.3', -2)).toEqual(pointers);
+    expect(pointers).toEqual(original);
+  });
+
   it.each([
     ['1', '1.1', -1],
     ['1', '1.3', 1],
@@ -45,7 +58,11 @@ describe('moveGestureTick', () => {
     ['missing', '1.1', 1],
     ['1', 'missing', 1],
     ['1', '1.1', 0],
-    ['1', '1.1', 2],
+    ['1', '1.1', 3],
+    ['1', '1.3', -3],
+    ['1', '1.1', 0.5],
+    ['1', '1.1', NaN],
+    ['1', '1.1', Infinity],
   ])('ignores unavailable moves for pointer %s, action %s, direction %s', (pointerId, tickId, direction) => {
     expect(moveGestureTick(pointers, pointerId, tickId, direction)).toBe(pointers);
   });


### PR DESCRIPTION
Gesture actions can be reordered by dragging an SVG grip onto another card within the same pointer. The drop target is highlighted. Keyboard pickup/drop with Space or Enter, arrow navigation, and Escape cancellation are supported. The grip is hidden for a single action, while the action fields and delete/coordinate-picker controls remain usable.

Moves retain coordinates, duration and other parameters, refresh the timeline, renumber position-based IDs and clear the coordinate picker. Each pointer has its own drag context. Optimistic sorting and drop animation are disabled to keep DOM ordering consistent with positional IDs; focus is restored to the destination after keyboard moves. The saved gesture format is unchanged.

Closes #1968.

Validation:
- Clean `npm ci` passed; `@dnd-kit/dom` 0.5.0 resolves through `@dnd-kit/react`. The lockfile change only removes the direct declaration.
- 207 unit tests, 7 integration tests, lint and formatting passed.
- Browser, Electron and plugin builds passed.
- The production Chromium browser build with FakeDriver verified mouse/keyboard sorting, destination focus, Escape, pointer switching, one/two-action transitions, deletion during drag, editable single-action fields, and saving/reopening with parameters preserved.
- All nine published files were fetched back and match the tested revision.

Native touch, screen-reader speech and the native Electron UI were not exercised; Electron compiled successfully. OpenAI Codex performed the implementation and local validation for this GitHub account.