### PR TITLE
style: fix grouping of context-related elements

### DIFF
--- a/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
+++ b/app/common/renderer/components/SessionInspector/Header/ContextControlsGroup.jsx
@@ -30,42 +30,46 @@ const NoContextsFoundButton = () => {
 /**
  * Dropdown used to switch contexts.
  */
-const ContextDropdown = ({contexts, currentContext, setContext, applyClientMethod, openLink}) => {
+const ContextsDropdown = ({contexts, currentContext, setContext, applyClientMethod}) => (
+  <Select
+    styles={{root: {width: 350}}}
+    value={currentContext}
+    popupMatchSelectWidth={false}
+    onChange={(value) => {
+      setContext(value);
+      applyClientMethod({methodName: 'switchAppiumContext', args: [value]});
+    }}
+    options={contexts.map(({id, title}) => ({
+      value: id,
+      label: title ? `${title} (${id})` : id,
+    }))}
+  />
+);
+
+/**
+ * Element (disabled button) used to provide extra info regarding additional contexts.
+ */
+const ContextInfoButton = ({openLink}) => {
   const {t} = useTranslation();
   const contextLabel = t('contextDropdownInfo');
 
   return (
-    <>
-      <Select
-        styles={{root: {width: 350}}}
-        value={currentContext}
-        popupMatchSelectWidth={false}
-        onChange={(value) => {
-          setContext(value);
-          applyClientMethod({methodName: 'switchAppiumContext', args: [value]});
-        }}
-        options={contexts.map(({id, title}) => ({
-          value: id,
-          label: title ? `${title} (${id})` : id,
-        }))}
+    <Tooltip
+      title={
+        <>
+          {contextLabel}{' '}
+          <a onClick={(e) => e.preventDefault() || openLink(LINKS.HYBRID_MODE_DOCS)}>{LINKS.HYBRID_MODE_DOCS}</a>
+        </>
+      }
+      classNames={{root: styles.wideTooltip}}
+    >
+      <Button
+        aria-label={`${contextLabel} ${LINKS.HYBRID_MODE_DOCS}`}
+        disabled
+        icon={<IconInfoCircle size={20} />}
+        styles={{root: {backgroundColor: 'var(--ant-color-primary)', color: '#ffffff'}}}
       />
-      <Tooltip
-        title={
-          <>
-            {contextLabel}{' '}
-            <a onClick={(e) => e.preventDefault() || openLink(LINKS.HYBRID_MODE_DOCS)}>{LINKS.HYBRID_MODE_DOCS}</a>
-          </>
-        }
-        classNames={{root: styles.wideTooltip}}
-      >
-        <Button
-          aria-label={`${contextLabel} ${LINKS.HYBRID_MODE_DOCS}`}
-          disabled
-          icon={<IconInfoCircle size={20} />}
-          styles={{root: {backgroundColor: 'var(--ant-color-primary)', color: '#ffffff'}}}
-        />
-      </Tooltip>
-    </>
+    </Tooltip>
   );
 };
 
@@ -105,14 +109,14 @@ const ContextControlsGroup = ({
       </Tooltip>
       {contexts && contexts.length === 1 && <NoContextsFoundButton />}
       {contexts && contexts.length > 1 && (
-        <ContextDropdown
+        <ContextsDropdown
           contexts={contexts}
           currentContext={currentContext}
           setContext={setContext}
           applyClientMethod={applyClientMethod}
-          openLink={openLink}
         />
       )}
+      {contexts && contexts.length > 1 && <ContextInfoButton openLink={openLink} />}
     </Space.Compact>
   );
 };


### PR DESCRIPTION
The opened Contexts dropdown currently doesn't group together with the info button next to it:

<img width="78" height="45" alt="Screenshot 2026-09-09 at 16 11 37" src="https://github.com/user-attachments/assets/f9981303-f688-4fb0-8ec0-46080d1d2ed1" />

This PR fixes the issue.