### PR TITLE
fix: adjust Commands tab responsiveness to work with Splitter

### DIFF
--- a/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/Commands.jsx
@@ -11,10 +11,24 @@ import StaticCommandsContent from './StaticCommandsContent.jsx';
 
 import styles from './Commands.module.css';
 
+const calculateBtnColspan = (breakpoints, curCommandsTabWidth) => {
+  if (!curCommandsTabWidth) {
+    return 1;
+  }
+  for (const entry of breakpoints) {
+    if (curCommandsTabWidth <= entry.maxWidth) {
+      return entry.colspan;
+    }
+  }
+};
+
 /**
  * Contents of the commands tab.
  */
 const Commands = ({applyClientMethod, getSupportedSessionMethods}) => {
+  const tabRef = useRef(null);
+  const [tabWidth, setTabWidth] = useState(null);
+
   const [hasMethodsMap, setHasMethodsMap] = useState(null);
   const [driverCommands, setDriverCommands] = useState(null);
   const [driverExecuteMethods, setDriverExecuteMethods] = useState(null);
@@ -86,6 +100,24 @@ const Commands = ({applyClientMethod, getSupportedSessionMethods}) => {
     curCommandParamValsRef.current = [];
   };
 
+  const getBtnColspan = (bp) => calculateBtnColspan(bp, tabWidth);
+
+  // add an observer for tracking the Commands tab width,
+  // which can be used to set the commands button grid colspan
+  useEffect(() => {
+    const tab = tabRef.current;
+    if (!tab) {
+      return;
+    }
+    const observer = new ResizeObserver(([entry]) => {
+      if (entry.contentRect.width > 0) {
+        setTabWidth(entry.contentRect.width);
+      }
+    });
+    observer.observe(tab);
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     (async () => {
       const {commands, executeMethods} = await getSupportedSessionMethods();
@@ -97,12 +129,13 @@ const Commands = ({applyClientMethod, getSupportedSessionMethods}) => {
 
   return (
     <CommandsTabCard>
-      <div className={styles.commandsContainer}>
+      <div ref={tabRef} className={styles.commandsContainer}>
         {/* do not use ternary operator, as that will show the static list
             while getSupportedSessionMethods is running */}
-        {hasMethodsMap === false && <StaticCommandsContent startCommand={startCommand} />}
+        {hasMethodsMap === false && <StaticCommandsContent getBtnColspan={getBtnColspan} startCommand={startCommand} />}
         {hasMethodsMap && (
           <MethodMapCommandsTabs
+            getBtnColspan={getBtnColspan}
             driverCommands={driverCommands}
             driverExecuteMethods={driverExecuteMethods}
             startCommand={startCommand}

--- a/app/common/renderer/components/SessionInspector/CommandsTab/Commands.module.css
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/Commands.module.css
@@ -34,6 +34,7 @@
   word-break: break-all;
   height: 100%;
   min-height: 30px;
+  padding: 0 4px;
 }
 
 .deprecatedMethod {

--- a/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsContent.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsContent.jsx
@@ -1,6 +1,8 @@
 import {Button, Col, Divider, Row, Tooltip} from 'antd';
 import {useTranslation} from 'react-i18next';
 
+import {COMMANDS_GRID_BREAKPOINTS, EXECUTE_METHODS_GRID_BREAKPOINTS} from '../../../constants/commands.js';
+
 import inspectorStyles from '../SessionInspector.module.css';
 import styles from './Commands.module.css';
 
@@ -72,8 +74,10 @@ const MethodMapCommandButton = ({methodName, methodDetails, isExecute, startComm
  * Unlike StaticCommandsContent, we cannot predict the contents of the method map response,
  * and we also want to be able to filter it, so just render all methods in a single grid.
  */
-const MethodMapCommandsContent = ({driverMethods, isExecute, startCommand}) => {
+const MethodMapCommandsContent = ({getBtnColspan, driverMethods, isExecute, startCommand}) => {
   const {t} = useTranslation();
+
+  const btnColspan = getBtnColspan(isExecute ? EXECUTE_METHODS_GRID_BREAKPOINTS : COMMANDS_GRID_BREAKPOINTS);
 
   return (
     <>
@@ -82,7 +86,7 @@ const MethodMapCommandsContent = ({driverMethods, isExecute, startCommand}) => {
       <div className={styles.methodMapGrid}>
         <Row>
           {driverMethods.map(([methodName, methodDetails]) => (
-            <Col key={methodName} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
+            <Col key={methodName} span={btnColspan}>
               <MethodMapCommandButton
                 methodName={methodName}
                 methodDetails={methodDetails}

--- a/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsTabs.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/MethodMapCommandsTabs.jsx
@@ -12,7 +12,7 @@ import styles from './Commands.module.css';
 /**
  * Tab switcher for the dynamic list of driver commands and execute methods.
  */
-const MethodMapCommandsTabs = ({driverCommands, driverExecuteMethods, startCommand}) => {
+const MethodMapCommandsTabs = ({getBtnColspan, driverCommands, driverExecuteMethods, startCommand}) => {
   const {t} = useTranslation();
 
   const [searchQuery, setSearchQuery] = useState('');
@@ -36,6 +36,7 @@ const MethodMapCommandsTabs = ({driverCommands, driverExecuteMethods, startComma
           className: styles.methodMapTab,
           children: (
             <MethodMapCommandsContent
+              getBtnColspan={getBtnColspan}
               driverMethods={filteredDriverCommands}
               isExecute={false}
               startCommand={startCommand}
@@ -49,6 +50,7 @@ const MethodMapCommandsTabs = ({driverCommands, driverExecuteMethods, startComma
           className: styles.methodMapTab,
           children: (
             <MethodMapCommandsContent
+              getBtnColspan={getBtnColspan}
               driverMethods={filteredDriverExecuteMethods}
               isExecute={true}
               startCommand={startCommand}

--- a/app/common/renderer/components/SessionInspector/CommandsTab/StaticCommandsContent.jsx
+++ b/app/common/renderer/components/SessionInspector/CommandsTab/StaticCommandsContent.jsx
@@ -1,7 +1,7 @@
 import {Button, Col, Collapse, Row, Space} from 'antd';
 import {useTranslation} from 'react-i18next';
 
-import {COMMAND_DEFINITIONS, TOP_LEVEL_COMMANDS} from '../../../constants/commands.js';
+import {COMMAND_DEFINITIONS, COMMANDS_GRID_BREAKPOINTS, TOP_LEVEL_COMMANDS} from '../../../constants/commands.js';
 
 import inspectorStyles from '../SessionInspector.module.css';
 import styles from './Commands.module.css';
@@ -9,10 +9,10 @@ import styles from './Commands.module.css';
 /**
  * Button rows used for the static list of driver commands.
  */
-const StaticCommandsRow = ({startCommand, commands}) => (
+const StaticCommandsRow = ({btnColspan, startCommand, commands}) => (
   <Row>
     {Object.entries(commands).map(([cmdName, cmdDetails]) => (
-      <Col key={cmdName} xs={12} sm={12} md={12} lg={8} xl={6} xxl={4}>
+      <Col key={cmdName} span={btnColspan}>
         <div className={styles.btnContainer}>
           <Button onClick={() => startCommand({name: cmdName, details: cmdDetails})}>
             <span className={inspectorStyles.monoFont}>{cmdName}</span>
@@ -44,13 +44,15 @@ const StaticCommandsCollapseGroups = ({startCommand}) => {
  * Static list of driver commands, shown only for drivers that do not support
  * the listCommands/listExtensions endpoints.
  */
-const StaticCommandsContent = ({startCommand}) => {
+const StaticCommandsContent = ({getBtnColspan, startCommand}) => {
   const {t} = useTranslation();
+
+  const btnColspan = getBtnColspan(COMMANDS_GRID_BREAKPOINTS);
 
   return (
     <Space className={inspectorStyles.spaceContainer} orientation="vertical" size="middle">
       {t('commandsDescription')}
-      <StaticCommandsRow startCommand={startCommand} commands={TOP_LEVEL_COMMANDS} />
+      <StaticCommandsRow btnColspan={btnColspan} startCommand={startCommand} commands={TOP_LEVEL_COMMANDS} />
       <StaticCommandsCollapseGroups startCommand={startCommand} />
     </Space>
   );

--- a/app/common/renderer/constants/commands.js
+++ b/app/common/renderer/constants/commands.js
@@ -382,3 +382,35 @@ export const COMMAND_DEFINITIONS = {
 
 export const COMMAND_EXECUTE_SCRIPT = 'executeScript';
 export const COMMAND_UPDATE_SETTINGS = 'updateSettings';
+
+/**
+ * Breakpoints used for the grid of command buttons.
+ * For each entry, colspan is the colspan to use for each button,
+ * if the width of the Commands tab in pixels is below maxWidth.
+ * The maxWidth values target around 200px minimum width for a button (including padding).
+ */
+export const COMMANDS_GRID_BREAKPOINTS = [
+  {maxWidth: 400, colspan: 24},
+  {maxWidth: 600, colspan: 12},
+  {maxWidth: 800, colspan: 8},
+  {maxWidth: 1200, colspan: 6},
+  {maxWidth: 1600, colspan: 4},
+  {maxWidth: 2400, colspan: 3},
+  {maxWidth: 4800, colspan: 2},
+  {maxWidth: Number.MAX_SAFE_INTEGER, colspan: 1},
+];
+
+/**
+ * Similar to COMMANDS_GRID_BREAKPOINTS, but due to execute methods having longer names,
+ * these maxWidth values target around 250px minimum width for a button (including padding).
+ */
+export const EXECUTE_METHODS_GRID_BREAKPOINTS = [
+  {maxWidth: 500, colspan: 24},
+  {maxWidth: 750, colspan: 12},
+  {maxWidth: 1000, colspan: 8},
+  {maxWidth: 1500, colspan: 6},
+  {maxWidth: 2000, colspan: 4},
+  {maxWidth: 3000, colspan: 3},
+  {maxWidth: 6000, colspan: 2},
+  {maxWidth: Number.MAX_SAFE_INTEGER, colspan: 1},
+];


### PR DESCRIPTION
The Commands tab currently features some responsive design, where the colspan of the buttons grid is adjusted depending on the Inspector window width. However, since #3145, the width of the Commands tab can also be changed without changing the Inspector window, which the current design does not track.

This PR fixes the problem by only tracking the width of the Commands tab (which can still be changed by changing the whole window). Ant design does not provide a convenient way to apply grid breakpoints based on a specific element rather than the whole screen, so a ResizeObserver is used, similarly to the approach used for the Source tab.

Another benefit of this solution is that it allows setting different colspans for the Commands and Execute Methods grids, which is quite useful, since execute method names are generally longer.

The inner left/right padding of each button has also been slightly reduced.

Quick demo:

https://github.com/user-attachments/assets/2265d856-f8d6-4da9-a173-99c842cc75f9